### PR TITLE
Update ServerCreateOpts to use pointers

### DIFF
--- a/hcloud/server.go
+++ b/hcloud/server.go
@@ -185,8 +185,8 @@ func (c *ServerClient) All(ctx context.Context) ([]*Server, error) {
 // ServerCreateOpts specifies options for creating a new server.
 type ServerCreateOpts struct {
 	Name       string
-	ServerType ServerType
-	Image      Image
+	ServerType *ServerType
+	Image      *Image
 	SSHKeys    []*SSHKey
 	Location   *Location
 	Datacenter *Datacenter
@@ -197,10 +197,10 @@ func (o ServerCreateOpts) Validate() error {
 	if o.Name == "" {
 		return errors.New("missing name")
 	}
-	if o.ServerType.ID == 0 && o.ServerType.Name == "" {
+	if o.ServerType == nil || (o.ServerType.ID == 0 && o.ServerType.Name == "") {
 		return errors.New("missing server type")
 	}
-	if o.Image.ID == 0 && o.Image.Name == "" {
+	if o.Image == nil || (o.Image.ID == 0 && o.Image.Name == "") {
 		return errors.New("missing image")
 	}
 	if o.Location != nil && o.Datacenter != nil {

--- a/hcloud/server_test.go
+++ b/hcloud/server_test.go
@@ -232,8 +232,8 @@ func TestServersCreateWithSSHKeys(t *testing.T) {
 	ctx := context.Background()
 	result, _, err := env.Client.Server.Create(ctx, ServerCreateOpts{
 		Name:       "test",
-		ServerType: ServerType{ID: 1},
-		Image:      Image{ID: 2},
+		ServerType: &ServerType{ID: 1},
+		Image:      &Image{ID: 2},
 		SSHKeys: []*SSHKey{
 			{ID: 1},
 			{ID: 2},
@@ -276,8 +276,8 @@ func TestServersCreateWithoutSSHKeys(t *testing.T) {
 	ctx := context.Background()
 	result, _, err := env.Client.Server.Create(ctx, ServerCreateOpts{
 		Name:       "test",
-		ServerType: ServerType{ID: 1},
-		Image:      Image{ID: 2},
+		ServerType: &ServerType{ID: 1},
+		Image:      &Image{ID: 2},
 	})
 	if err != nil {
 		t.Fatalf("Server.Create failed: %s", err)
@@ -315,8 +315,8 @@ func TestServersCreateWithDatacenterID(t *testing.T) {
 	ctx := context.Background()
 	result, _, err := env.Client.Server.Create(ctx, ServerCreateOpts{
 		Name:       "test",
-		ServerType: ServerType{ID: 1},
-		Image:      Image{ID: 2},
+		ServerType: &ServerType{ID: 1},
+		Image:      &Image{ID: 2},
 		Datacenter: &Datacenter{ID: 1},
 	})
 	if err != nil {
@@ -349,8 +349,8 @@ func TestServersCreateWithDatacenterName(t *testing.T) {
 	ctx := context.Background()
 	result, _, err := env.Client.Server.Create(ctx, ServerCreateOpts{
 		Name:       "test",
-		ServerType: ServerType{ID: 1},
-		Image:      Image{ID: 2},
+		ServerType: &ServerType{ID: 1},
+		Image:      &Image{ID: 2},
 		Datacenter: &Datacenter{Name: "dc1"},
 	})
 	if err != nil {
@@ -383,8 +383,8 @@ func TestServersCreateWithLocationID(t *testing.T) {
 	ctx := context.Background()
 	result, _, err := env.Client.Server.Create(ctx, ServerCreateOpts{
 		Name:       "test",
-		ServerType: ServerType{ID: 1},
-		Image:      Image{ID: 2},
+		ServerType: &ServerType{ID: 1},
+		Image:      &Image{ID: 2},
 		Location:   &Location{ID: 1},
 	})
 	if err != nil {
@@ -417,8 +417,8 @@ func TestServersCreateWithLocationName(t *testing.T) {
 	ctx := context.Background()
 	result, _, err := env.Client.Server.Create(ctx, ServerCreateOpts{
 		Name:       "test",
-		ServerType: ServerType{ID: 1},
-		Image:      Image{ID: 2},
+		ServerType: &ServerType{ID: 1},
+		Image:      &Image{ID: 2},
 		Location:   &Location{Name: "loc1"},
 	})
 	if err != nil {


### PR DESCRIPTION
v1.0.0 is already tagged, but only used by our CLI, so it’s save to change it and re-tag v1.0.0.