### PR TITLE
Fixed PublicNet IPv6 extraction from returned network

### DIFF
--- a/hcloud/schema.go
+++ b/hcloud/schema.go
@@ -186,6 +186,9 @@ func ServerPublicNetIPv6FromSchema(s schema.ServerPublicNetIPv6) ServerPublicNet
 		DNSPtr:  map[string]string{},
 	}
 	ipv6.IP, ipv6.Network, _ = net.ParseCIDR(s.IP)
+	// Workaround to extract the first IP from IPv6 range.
+	// ParseCIDR only returns 2001:db8:: for 2001:db8::/64 as IP.
+	ipv6.IP = net.ParseIP(ipv6.IP.String() + "1")
 
 	for _, dnsPtr := range s.DNSPtr {
 		ipv6.DNSPtr[dnsPtr.IP] = dnsPtr.DNSPtr


### PR DESCRIPTION
I experienced some problems setting up IPv6 DNS entries using Terraform due to invalid `${hcloud_server.gitlab.ipv6_address}` variable. Hetzner Cloud returns the following according to the API documentation(see https://docs.hetzner.cloud/#servers-get-all-servers) for IPv6 on server requests:
```
"ipv6": {
          "ip": "2001:db8::/64",
          "blocked": false,
          "dns_ptr": [
            {
              "ip": "2001:db8::1",
              "dns_ptr": "server.example.com"
            }
          ]
        }
```
Using go's net.ParseCIDR returns `2001:db8::` for the IP part resulting `${hcloud_server.gitlab.ipv6_address}` in Terraform being not a valid first IPv6 address.

I'm not sure if this workaround is an appropriate fix.