### PR TITLE
Add all available error codes as constant

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,9 +2,7 @@
 
 ## master
 
-* Add available error codes:  `ErrorCodeForbidden`, `ErrorJSONError`, `ErrorLocked`, 
-  `ErrorResourceLimitExceeded`, `ErrorResourceUnavailable`, `ErrorUniquenessError`,
-  `ErrorProtected` and `ErrorMaintenance`
+* Add missing constants for all [documented error codes](https://docs.hetzner.cloud/#overview-errors)
 
 ## v1.11.0
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # Changes
 
+## master
+
+* Add available error codes:  `ErrorCodeForbidden`, `ErrorJSONError`, `ErrorLocked`, 
+  `ErrorResourceLimitExceeded`, `ErrorResourceUnavailable`, `ErrorUniquenessError`,
+  `ErrorProtected` and `ErrorMaintenance`
+
 ## v1.11.0
 
 * Add `NextActions` to `ServerCreateResult` and `VolumeCreateResult`

--- a/hcloud/error.go
+++ b/hcloud/error.go
@@ -17,7 +17,7 @@ const (
 	ErrorCodeLocked                ErrorCode = "locked"                  // Item is locked (Another action is running)
 	ErrorCodeResourceLimitExceeded ErrorCode = "resource_limit_exceeded" // Resource limit exceeded
 	ErrorCodeResourceUnavailable   ErrorCode = "resource_unavailable"    // Resource currently unavailable
-	ErrorCodeUniqueness            ErrorCode = "uniqueness_error"        // One or more fields must be unique
+	ErrorCodeUniquenessError       ErrorCode = "uniqueness_error"        // One or more fields must be unique
 	ErrorCodeProtected             ErrorCode = "protected"               // The actions you are trying is protected
 	ErrorCodeMaintenance           ErrorCode = "maintenance"             // Cannot perform operation due to maintenance
 

--- a/hcloud/error.go
+++ b/hcloud/error.go
@@ -7,19 +7,19 @@ type ErrorCode string
 
 // Error codes returned from the API.
 const (
-	ErrorCodeServiceError      ErrorCode = "service_error"           // Generic service error
-	ErrorCodeRateLimitExceeded ErrorCode = "rate_limit_exceeded"     // Rate limit exceeded
-	ErrorCodeUnknownError      ErrorCode = "unknown_error"           // Unknown error
-	ErrorCodeNotFound          ErrorCode = "not_found"               // Resource not found
-	ErrorCodeInvalidInput      ErrorCode = "invalid_input"           // Validation error
-	ErrorCodeForbidden         ErrorCode = "forbidden"               // Insufficient permissions
-	ErrorJSONError             ErrorCode = "json_error"              // Invalid JSON in request
-	ErrorLocked                ErrorCode = "locked"                  // Item is locked (Another action is running)
-	ErrorResourceLimitExceeded ErrorCode = "resource_limit_exceeded" // Resource limit exceeded
-	ErrorResourceUnavailable   ErrorCode = "resource_unavailable"    // Resource currently unavailable
-	ErrorUniquenessError       ErrorCode = "uniqueness_error"        // One or more fields must be unique
-	ErrorProtected             ErrorCode = "protected"               // The actions you are trying is protected
-	ErrorMaintenance           ErrorCode = "maintenance"             // Cannot perform operation due to maintenance
+	ErrorCodeServiceError          ErrorCode = "service_error"           // Generic service error
+	ErrorCodeRateLimitExceeded     ErrorCode = "rate_limit_exceeded"     // Rate limit exceeded
+	ErrorCodeUnknownError          ErrorCode = "unknown_error"           // Unknown error
+	ErrorCodeNotFound              ErrorCode = "not_found"               // Resource not found
+	ErrorCodeInvalidInput          ErrorCode = "invalid_input"           // Validation error
+	ErrorCodeForbidden             ErrorCode = "forbidden"               // Insufficient permissions
+	ErrorCodeJSONError             ErrorCode = "json_error"              // Invalid JSON in request
+	ErrorCodeLocked                ErrorCode = "locked"                  // Item is locked (Another action is running)
+	ErrorCodeResourceLimitExceeded ErrorCode = "resource_limit_exceeded" // Resource limit exceeded
+	ErrorCodeResourceUnavailable   ErrorCode = "resource_unavailable"    // Resource currently unavailable
+	ErrorCodeUniqueness            ErrorCode = "uniqueness_error"        // One or more fields must be unique
+	ErrorCodeProtected             ErrorCode = "protected"               // The actions you are trying is protected
+	ErrorCodeMaintenance           ErrorCode = "maintenance"             // Cannot perform operation due to maintenance
 
 	// Deprecated error codes
 

--- a/hcloud/error.go
+++ b/hcloud/error.go
@@ -7,11 +7,19 @@ type ErrorCode string
 
 // Error codes returned from the API.
 const (
-	ErrorCodeServiceError      ErrorCode = "service_error"       // Generic server error
-	ErrorCodeRateLimitExceeded ErrorCode = "rate_limit_exceeded" // Rate limit exceeded
-	ErrorCodeUnknownError      ErrorCode = "unknown_error"       // Unknown error
-	ErrorCodeNotFound          ErrorCode = "not_found"           // Resource not found
-	ErrorCodeInvalidInput      ErrorCode = "invalid_input"       // Validation error
+	ErrorCodeServiceError      ErrorCode = "service_error"           // Generic service error
+	ErrorCodeRateLimitExceeded ErrorCode = "rate_limit_exceeded"     // Rate limit exceeded
+	ErrorCodeUnknownError      ErrorCode = "unknown_error"           // Unknown error
+	ErrorCodeNotFound          ErrorCode = "not_found"               // Resource not found
+	ErrorCodeInvalidInput      ErrorCode = "invalid_input"           // Validation error
+	ErrorCodeForbidden         ErrorCode = "forbidden"               // Insufficient permissions
+	ErrorJSONError             ErrorCode = "json_error"              // Invalid JSON in request
+	ErrorLocked                ErrorCode = "locked"                  // Item is locked (Another action is running)
+	ErrorResourceLimitExceeded ErrorCode = "resource_limit_exceeded" // Resource limit exceeded
+	ErrorResourceUnavailable   ErrorCode = "resource_unavailable"    // Resource currently unavailable
+	ErrorUniquenessError       ErrorCode = "uniqueness_error"        // One or more fields must be unique
+	ErrorProtected             ErrorCode = "protected"               // The actions you are trying is protected
+	ErrorMaintenance           ErrorCode = "maintenance"             // Cannot perform operation due to maintenance
 
 	// Deprecated error codes
 


### PR DESCRIPTION
This PR aims to fix #103. 

At the moment we have 12 error codes, but only five are available in the hcloud-go as constant.

When this PR is merged, it allows developers to do something like:
```go
action, _, err := client.Volume.Detach(ctx, volume)
if err != nil {
	if hcloud.IsError(err, hcloud.ErrorLocked) {
		// retry
	}
}

``` 	
instead of

```go
action, _, err := client.Volume.Detach(ctx, volume)
if err != nil {
	if hcloud.IsError(err, "locked") {
		// retry
	}
}

``` 	