### PR TITLE
Fix WatchProgress() error handling

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@
 ## master
 
 * Add missing fields to `*ListOpts` structs
+* Fix error handling in `WatchProgress()`
 
 ## v1.12.0
 

--- a/hcloud/action.go
+++ b/hcloud/action.go
@@ -184,7 +184,7 @@ func (c *ActionClient) WatchProgress(ctx context.Context, action *Action) (<-cha
 
 			a, _, err := c.GetByID(ctx, action.ID)
 			if err != nil {
-				errCh <- ctx.Err()
+				errCh <- err
 				return
 			}
 


### PR DESCRIPTION
Return the error from GetByID(), not ctx.Err() (which is nil).

Closes #108.