### PR TITLE
Add debug mode to the client

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,7 +3,7 @@
 ## master
 
 * Add `MacAddress` field to `ServerPrivateNet`
-* Add `WithDebugWriter()` client option to provide easier debugging of requests and responses
+* Add `WithDebugWriter()` client option to provide an `io.Writer` to write debug output to
 
 ## v1.14.0
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@
 ## master
 
 * Add `MacAddress` field to `ServerPrivateNet`
+* Add `WithDebugWriter()` client option to provide easier debugging of requests and responses
 
 ## v1.14.0
 

--- a/hcloud/client.go
+++ b/hcloud/client.go
@@ -116,9 +116,9 @@ func WithApplication(name, version string) ClientOption {
 
 // WithDebugWriter configures a Client to print debug information to the given
 // writer. To, for example, print debug information on stderr, set it to os.Stderr.
-func WithDebugWriter(debugFile io.Writer) ClientOption {
+func WithDebugWriter(debugWriter io.Writer) ClientOption {
 	return func(client *Client) {
-		client.debugWriter = debugFile
+		client.debugWriter = debugWriter
 	}
 }
 

--- a/hcloud/client.go
+++ b/hcloud/client.go
@@ -189,11 +189,17 @@ func (c *Client) Do(r *http.Request, v interface{}) (*Response, error) {
 		if c.debugWriter != nil {
 			fmt.Fprintln(c.debugWriter, "------- HCLOUD_GO_DEBUG -------")
 			// Print Request Details
-			dumpReq, _ := httputil.DumpRequest(r, true)
+			dumpReq, err := httputil.DumpRequest(r, true)
+			if err != nil {
+				return nil, err
+			}
 			fmt.Fprintf(c.debugWriter, "Request:\n%s", dumpReq)
 
 			// Print Response Details
-			dumpResp, _ := httputil.DumpResponse(resp, true)
+			dumpResp, err := httputil.DumpResponse(resp, true)
+			if err != nil {
+				return nil, err
+			}
 			fmt.Fprintf(c.debugWriter, "Response:\n%s", dumpResp)
 			fmt.Fprintf(c.debugWriter, "-------------------------------")
 		}

--- a/hcloud/client.go
+++ b/hcloud/client.go
@@ -186,23 +186,21 @@ func (c *Client) Do(r *http.Request, v interface{}) (*Response, error) {
 		}
 		resp.Body.Close()
 		resp.Body = ioutil.NopCloser(bytes.NewReader(body))
+
 		if c.debugWriter != nil {
-			fmt.Fprintln(c.debugWriter, "------- HCLOUD_GO_DEBUG -------")
-			// Print Request Details
 			dumpReq, err := httputil.DumpRequest(r, true)
 			if err != nil {
 				return nil, err
 			}
-			fmt.Fprintf(c.debugWriter, "Request:\n%s", dumpReq)
+			fmt.Fprintf(c.debugWriter, "--- Request:\n%s\n\n", dumpReq)
 
-			// Print Response Details
 			dumpResp, err := httputil.DumpResponse(resp, true)
 			if err != nil {
 				return nil, err
 			}
-			fmt.Fprintf(c.debugWriter, "Response:\n%s", dumpResp)
-			fmt.Fprintf(c.debugWriter, "-------------------------------")
+			fmt.Fprintf(c.debugWriter, "--- Response:\n%s\n\n", dumpResp)
 		}
+
 		if err = response.readMeta(body); err != nil {
 			return response, fmt.Errorf("hcloud: error reading response meta data: %s", err)
 		}


### PR DESCRIPTION
This adds a basic debug mode to the client which allows users to debug the whole request and the response. We simply "print" everything including the Headers of Request and Response.

The format was just a draft, we can of course change it.

Sample:
```
------- HCLOUD_GO_DEBUG -------
Request: GET - https://api.hetzner.cloud/v1/locations?page=1&per_page=50
Request Headers: http.Header{"Authorization":[]string{"Bearer THIS_IS_THE_TOKEN"}, "User-Agent":[]string{"hcloud-cli/was not built properly hcloud-go/1.14.0"}}
Request Body: %!s(<nil>)

Response Status Code: 200
Response Headers: http.Header{"Content-Type":[]string{"application/json"}, "Date":[]string{"Thu, 18 Jul 2019 08:47:12 GMT"}, "Link":[]string{"<https://api.hetzner.cloud/v1/locations?page=1&per_page=50>; rel=last"}, "Ratelimit-Limit":[]string{"3600"}, "Ratelimit-Remaining":[]string{"3599"}, "Ratelimit-Reset":[]string{"1563439633"}, "Server":[]string{"nginx"}, "Strict-Transport-Security":[]string{"max-age=3600; preload"}, "X-Correlation-Id":[]string{"5a931672-9464-4892-8a84-626984b3df19"}}
Response Body: {
  "locations": [
    {
      "id": 1,
      "name": "fsn1",
      "description": "Falkenstein DC Park 1",
      "country": "DE",
      "city": "Falkenstein",
      "latitude": 50.47612,
      "longitude": 12.370071,
      "network_zone": "eu-central"
    },
    {
      "id": 2,
      "name": "nbg1",
      "description": "Nuremberg DC Park 1",
      "country": "DE",
      "city": "Nuremberg",
      "latitude": 49.452102,
      "longitude": 11.076665,
      "network_zone": "eu-central"
    },
    {
      "id": 3,
      "name": "hel1",
      "description": "Helsinki DC Park 1",
      "country": "FI",
      "city": "Helsinki",
      "latitude": 60.169855,
      "longitude": 24.938379,
      "network_zone": "eu-central"
    }
  ],
  "meta": {
    "pagination": {
      "page": 1,
      "per_page": 50,
      "previous_page": null,
      "next_page": null,
      "last_page": 1,
      "total_entries": 3
    }
  }
}

-------------------------------
```
