### PR TITLE
Use http.DefaultClient by default

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@
 
 * Add `Status` field to `Volume`
 * Add subnet type `cloud`
+* Use `http.DefaultClient` by default to take advantage of cached TCP connections
 
 ## v1.17.0
 

--- a/hcloud/client.go
+++ b/hcloud/client.go
@@ -126,7 +126,7 @@ func WithDebugWriter(debugWriter io.Writer) ClientOption {
 func NewClient(options ...ClientOption) *Client {
 	client := &Client{
 		endpoint:     Endpoint,
-		httpClient:   &http.Client{},
+		httpClient:   http.DefaultClient,
 		backoffFunc:  ExponentialBackoff(2, 500*time.Millisecond),
 		pollInterval: 500 * time.Millisecond,
 	}


### PR DESCRIPTION
As stated in the net/http docs, a http.Client should be reused in order
to take advantage of cached TCP connections. http.DefaultClient is safe
for concurrent use.

This will improve performance when you create a lot of clients with
different tokens, for example.