### PR TITLE
Make GetByName() return nil for empty names

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Changes
 
+## master
+
+* Make all `GetByName` methods return `nil` when an empty name is provided
+
 ## v1.18.0
 
 * Add `Status` field to `Volume`

--- a/hcloud/certificate.go
+++ b/hcloud/certificate.go
@@ -51,6 +51,9 @@ func (c *CertificateClient) GetByID(ctx context.Context, id int) (*Certificate, 
 
 // GetByName retrieves a Certificate by its name. If the Certificate does not exist, nil is returned.
 func (c *CertificateClient) GetByName(ctx context.Context, name string) (*Certificate, *Response, error) {
+	if name == "" {
+		return nil, nil, nil
+	}
 	Certificate, response, err := c.List(ctx, CertificateListOpts{Name: name})
 	if len(Certificate) == 0 {
 		return nil, response, err

--- a/hcloud/certificate_test.go
+++ b/hcloud/certificate_test.go
@@ -197,6 +197,21 @@ func TestCertificateClientGetByNameNotFound(t *testing.T) {
 	}
 }
 
+func TestCertificateClientGetByNameEmpty(t *testing.T) {
+	env := newTestEnv()
+	defer env.Teardown()
+
+	ctx := context.Background()
+
+	certficate, _, err := env.Client.Certificate.GetByName(ctx, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if certficate != nil {
+		t.Fatal("unexpected certficate")
+	}
+}
+
 func TestCertificateCreate(t *testing.T) {
 	env := newTestEnv()
 	defer env.Teardown()

--- a/hcloud/datacenter.go
+++ b/hcloud/datacenter.go
@@ -49,6 +49,9 @@ func (c *DatacenterClient) GetByID(ctx context.Context, id int) (*Datacenter, *R
 
 // GetByName retrieves an datacenter by its name. If the datacenter does not exist, nil is returned.
 func (c *DatacenterClient) GetByName(ctx context.Context, name string) (*Datacenter, *Response, error) {
+	if name == "" {
+		return nil, nil, nil
+	}
 	datacenters, response, err := c.List(ctx, DatacenterListOpts{Name: name})
 	if len(datacenters) == 0 {
 		return nil, response, err

--- a/hcloud/datacenter_test.go
+++ b/hcloud/datacenter_test.go
@@ -138,6 +138,20 @@ func TestDatacenterClient(t *testing.T) {
 		}
 	})
 
+	t.Run("GetByName (empty)", func(t *testing.T) {
+		env := newTestEnv()
+		defer env.Teardown()
+
+		ctx := context.Background()
+		datacenter, _, err := env.Client.Datacenter.GetByName(ctx, "")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if datacenter != nil {
+			t.Fatal("unexpected datacenter")
+		}
+	})
+
 	t.Run("List", func(t *testing.T) {
 		env := newTestEnv()
 		defer env.Teardown()

--- a/hcloud/floating_ip.go
+++ b/hcloud/floating_ip.go
@@ -76,6 +76,9 @@ func (c *FloatingIPClient) GetByID(ctx context.Context, id int) (*FloatingIP, *R
 
 // GetByName retrieves a Floating IP by its name. If the Floating IP does not exist, nil is returned.
 func (c *FloatingIPClient) GetByName(ctx context.Context, name string) (*FloatingIP, *Response, error) {
+	if name == "" {
+		return nil, nil, nil
+	}
 	floatingIPs, response, err := c.List(ctx, FloatingIPListOpts{Name: name})
 	if len(floatingIPs) == 0 {
 		return nil, response, err

--- a/hcloud/floating_ip_test.go
+++ b/hcloud/floating_ip_test.go
@@ -149,6 +149,19 @@ func TestFloatingIPClientGetByNameNotFound(t *testing.T) {
 	})
 }
 
+func TestFloatingIPClientGetByNameEmpty(t *testing.T) {
+	env := newTestEnv()
+	defer env.Teardown()
+
+	floatingIP, _, err := env.Client.FloatingIP.GetByName(context.Background(), "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if floatingIP != nil {
+		t.Fatal("unexpected Floating IP")
+	}
+}
+
 func TestFloatingIPClientList(t *testing.T) {
 	env := newTestEnv()
 	defer env.Teardown()

--- a/hcloud/image.go
+++ b/hcloud/image.go
@@ -91,6 +91,9 @@ func (c *ImageClient) GetByID(ctx context.Context, id int) (*Image, *Response, e
 
 // GetByName retrieves an image by its name. If the image does not exist, nil is returned.
 func (c *ImageClient) GetByName(ctx context.Context, name string) (*Image, *Response, error) {
+	if name == "" {
+		return nil, nil, nil
+	}
 	images, response, err := c.List(ctx, ImageListOpts{Name: name})
 	if len(images) == 0 {
 		return nil, response, err

--- a/hcloud/image_test.go
+++ b/hcloud/image_test.go
@@ -157,6 +157,20 @@ func TestImageClient(t *testing.T) {
 		}
 	})
 
+	t.Run("GetByName (empty)", func(t *testing.T) {
+		env := newTestEnv()
+		defer env.Teardown()
+
+		ctx := context.Background()
+		image, _, err := env.Client.Image.GetByName(ctx, "")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if image != nil {
+			t.Fatal("unexpected image")
+		}
+	})
+
 	t.Run("List", func(t *testing.T) {
 		env := newTestEnv()
 		defer env.Teardown()

--- a/hcloud/iso.go
+++ b/hcloud/iso.go
@@ -60,6 +60,9 @@ func (c *ISOClient) GetByID(ctx context.Context, id int) (*ISO, *Response, error
 
 // GetByName retrieves an ISO by its name.
 func (c *ISOClient) GetByName(ctx context.Context, name string) (*ISO, *Response, error) {
+	if name == "" {
+		return nil, nil, nil
+	}
 	isos, response, err := c.List(ctx, ISOListOpts{Name: name})
 	if len(isos) == 0 {
 		return nil, response, err

--- a/hcloud/iso_test.go
+++ b/hcloud/iso_test.go
@@ -157,6 +157,20 @@ func TestISOClient(t *testing.T) {
 		}
 	})
 
+	t.Run("GetByName (empty)", func(t *testing.T) {
+		env := newTestEnv()
+		defer env.Teardown()
+
+		ctx := context.Background()
+		iso, _, err := env.Client.ISO.GetByName(ctx, "")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if iso != nil {
+			t.Fatal("unexpected iso")
+		}
+	})
+
 	t.Run("List", func(t *testing.T) {
 		env := newTestEnv()
 		defer env.Teardown()

--- a/hcloud/load_balancer.go
+++ b/hcloud/load_balancer.go
@@ -193,6 +193,9 @@ func (c *LoadBalancerClient) GetByID(ctx context.Context, id int) (*LoadBalancer
 
 // GetByName retrieves a Load Balancer by its name. If the Load Balancer does not exist, nil is returned.
 func (c *LoadBalancerClient) GetByName(ctx context.Context, name string) (*LoadBalancer, *Response, error) {
+	if name == "" {
+		return nil, nil, nil
+	}
 	LoadBalancer, response, err := c.List(ctx, LoadBalancerListOpts{Name: name})
 	if len(LoadBalancer) == 0 {
 		return nil, response, err

--- a/hcloud/load_balancer_test.go
+++ b/hcloud/load_balancer_test.go
@@ -146,6 +146,21 @@ func TestLoadBalancerClientGetByNameNotFound(t *testing.T) {
 	}
 }
 
+func TestLoadBalancerClientGetByNameEmpty(t *testing.T) {
+	env := newTestEnv()
+	defer env.Teardown()
+
+	ctx := context.Background()
+
+	loadBalancer, _, err := env.Client.LoadBalancer.GetByName(ctx, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if loadBalancer != nil {
+		t.Fatal("unexpected load balancer")
+	}
+}
+
 func TestLoadBalancerCreate(t *testing.T) {
 	env := newTestEnv()
 	defer env.Teardown()

--- a/hcloud/load_balancer_type.go
+++ b/hcloud/load_balancer_type.go
@@ -46,6 +46,9 @@ func (c *LoadBalancerTypeClient) GetByID(ctx context.Context, id int) (*LoadBala
 
 // GetByName retrieves a Load Balancer type by its name. If the Load Balancer type does not exist, nil is returned.
 func (c *LoadBalancerTypeClient) GetByName(ctx context.Context, name string) (*LoadBalancerType, *Response, error) {
+	if name == "" {
+		return nil, nil, nil
+	}
 	LoadBalancerTypes, response, err := c.List(ctx, LoadBalancerTypeListOpts{Name: name})
 	if len(LoadBalancerTypes) == 0 {
 		return nil, response, err

--- a/hcloud/load_balancer_type_test.go
+++ b/hcloud/load_balancer_type_test.go
@@ -138,6 +138,20 @@ func TestLoadBalancerTypeClient(t *testing.T) {
 		}
 	})
 
+	t.Run("GetByName (empty)", func(t *testing.T) {
+		env := newTestEnv()
+		defer env.Teardown()
+
+		ctx := context.Background()
+		loadBalancerType, _, err := env.Client.LoadBalancerType.GetByName(ctx, "")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if loadBalancerType != nil {
+			t.Fatal("unexpected load balancer type")
+		}
+	})
+
 	t.Run("List", func(t *testing.T) {
 		env := newTestEnv()
 		defer env.Teardown()

--- a/hcloud/location.go
+++ b/hcloud/location.go
@@ -46,6 +46,9 @@ func (c *LocationClient) GetByID(ctx context.Context, id int) (*Location, *Respo
 
 // GetByName retrieves an location by its name. If the location does not exist, nil is returned.
 func (c *LocationClient) GetByName(ctx context.Context, name string) (*Location, *Response, error) {
+	if name == "" {
+		return nil, nil, nil
+	}
 	locations, response, err := c.List(ctx, LocationListOpts{Name: name})
 	if len(locations) == 0 {
 		return nil, response, err

--- a/hcloud/location_test.go
+++ b/hcloud/location_test.go
@@ -138,6 +138,20 @@ func TestLocationClient(t *testing.T) {
 		}
 	})
 
+	t.Run("GetByName (empty)", func(t *testing.T) {
+		env := newTestEnv()
+		defer env.Teardown()
+
+		ctx := context.Background()
+		location, _, err := env.Client.Location.GetByName(ctx, "")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if location != nil {
+			t.Fatal("unexpected location")
+		}
+	})
+
 	t.Run("List", func(t *testing.T) {
 		env := newTestEnv()
 		defer env.Teardown()

--- a/hcloud/network.go
+++ b/hcloud/network.go
@@ -88,6 +88,9 @@ func (c *NetworkClient) GetByID(ctx context.Context, id int) (*Network, *Respons
 
 // GetByName retrieves a network by its name. If the network does not exist, nil is returned.
 func (c *NetworkClient) GetByName(ctx context.Context, name string) (*Network, *Response, error) {
+	if name == "" {
+		return nil, nil, nil
+	}
 	Networks, response, err := c.List(ctx, NetworkListOpts{Name: name})
 	if len(Networks) == 0 {
 		return nil, response, err

--- a/hcloud/network_test.go
+++ b/hcloud/network_test.go
@@ -139,6 +139,20 @@ func TestNetworkClientGetByNameNotFound(t *testing.T) {
 	}
 }
 
+func TestNetworkClientGetByNameEmpty(t *testing.T) {
+	env := newTestEnv()
+	defer env.Teardown()
+
+	ctx := context.Background()
+	network, _, err := env.Client.Network.GetByName(ctx, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if network != nil {
+		t.Fatal("unexpected network")
+	}
+}
+
 func TestNetworkCreate(t *testing.T) {
 	var (
 		ctx           = context.Background()

--- a/hcloud/server.go
+++ b/hcloud/server.go
@@ -144,6 +144,9 @@ func (c *ServerClient) GetByID(ctx context.Context, id int) (*Server, *Response,
 
 // GetByName retrieves a server by its name. If the server does not exist, nil is returned.
 func (c *ServerClient) GetByName(ctx context.Context, name string) (*Server, *Response, error) {
+	if name == "" {
+		return nil, nil, nil
+	}
 	servers, response, err := c.List(ctx, ServerListOpts{Name: name})
 	if len(servers) == 0 {
 		return nil, response, err

--- a/hcloud/server_test.go
+++ b/hcloud/server_test.go
@@ -139,6 +139,20 @@ func TestServerClientGetByNameNotFound(t *testing.T) {
 	}
 }
 
+func TestServerClientGetByNameEmpty(t *testing.T) {
+	env := newTestEnv()
+	defer env.Teardown()
+
+	ctx := context.Background()
+	server, _, err := env.Client.Server.GetByName(ctx, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if server != nil {
+		t.Fatal("unexpected server")
+	}
+}
+
 func TestServersList(t *testing.T) {
 	env := newTestEnv()
 	defer env.Teardown()

--- a/hcloud/server_type.go
+++ b/hcloud/server_type.go
@@ -69,6 +69,9 @@ func (c *ServerTypeClient) GetByID(ctx context.Context, id int) (*ServerType, *R
 
 // GetByName retrieves a server type by its name. If the server type does not exist, nil is returned.
 func (c *ServerTypeClient) GetByName(ctx context.Context, name string) (*ServerType, *Response, error) {
+	if name == "" {
+		return nil, nil, nil
+	}
 	serverTypes, response, err := c.List(ctx, ServerTypeListOpts{Name: name})
 	if len(serverTypes) == 0 {
 		return nil, response, err

--- a/hcloud/server_type_test.go
+++ b/hcloud/server_type_test.go
@@ -138,6 +138,20 @@ func TestServerTypeClient(t *testing.T) {
 		}
 	})
 
+	t.Run("GetByName (empty)", func(t *testing.T) {
+		env := newTestEnv()
+		defer env.Teardown()
+
+		ctx := context.Background()
+		serverType, _, err := env.Client.ServerType.GetByName(ctx, "")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if serverType != nil {
+			t.Fatal("unexpected server type")
+		}
+	})
+
 	t.Run("List", func(t *testing.T) {
 		env := newTestEnv()
 		defer env.Teardown()

--- a/hcloud/ssh_key.go
+++ b/hcloud/ssh_key.go
@@ -48,6 +48,9 @@ func (c *SSHKeyClient) GetByID(ctx context.Context, id int) (*SSHKey, *Response,
 
 // GetByName retrieves a SSH key by its name. If the SSH key does not exist, nil is returned.
 func (c *SSHKeyClient) GetByName(ctx context.Context, name string) (*SSHKey, *Response, error) {
+	if name == "" {
+		return nil, nil, nil
+	}
 	sshKeys, response, err := c.List(ctx, SSHKeyListOpts{Name: name})
 	if len(sshKeys) == 0 {
 		return nil, response, err

--- a/hcloud/ssh_key_test.go
+++ b/hcloud/ssh_key_test.go
@@ -143,6 +143,20 @@ func TestSSHKeyClientGetByNameNotFound(t *testing.T) {
 	}
 }
 
+func TestSSHKeyClientGetByNameEmpty(t *testing.T) {
+	env := newTestEnv()
+	defer env.Teardown()
+
+	ctx := context.Background()
+	sshKey, _, err := env.Client.SSHKey.GetByName(ctx, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if sshKey != nil {
+		t.Fatal("unexpected SSH key")
+	}
+}
+
 func TestSSHKeyClientGetByFingerprint(t *testing.T) {
 	env := newTestEnv()
 	defer env.Teardown()

--- a/hcloud/volume.go
+++ b/hcloud/volume.go
@@ -68,6 +68,9 @@ func (c *VolumeClient) GetByID(ctx context.Context, id int) (*Volume, *Response,
 
 // GetByName retrieves a volume by its name. If the volume does not exist, nil is returned.
 func (c *VolumeClient) GetByName(ctx context.Context, name string) (*Volume, *Response, error) {
+	if name == "" {
+		return nil, nil, nil
+	}
 	volumes, response, err := c.List(ctx, VolumeListOpts{Name: name})
 	if len(volumes) == 0 {
 		return nil, response, err

--- a/hcloud/volume_test.go
+++ b/hcloud/volume_test.go
@@ -180,6 +180,20 @@ func TestVolumeClientGetByNameNotFound(t *testing.T) {
 	}
 }
 
+func TestVolumeClientGetByNameEmpty(t *testing.T) {
+	env := newTestEnv()
+	defer env.Teardown()
+
+	ctx := context.Background()
+	volume, _, err := env.Client.Volume.GetByName(ctx, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if volume != nil {
+		t.Fatal("unexpected volume")
+	}
+}
+
 func TestVolumeClientDelete(t *testing.T) {
 	env := newTestEnv()
 	defer env.Teardown()


### PR DESCRIPTION
In CertificateListOpts, Name is a string, thus we cannot differentiate
between Name unset and Name set to empty string. Making it a *string
would be a breaking change. So the only thing we can do is to
explicitly catch empty name in all those GetByName() methods.

Fixes #136.