### PR TITLE
use DumpRequestOut for debugging

### DIFF
--- a/hcloud/client.go
+++ b/hcloud/client.go
@@ -189,7 +189,7 @@ func (c *Client) Do(r *http.Request, v interface{}) (*Response, error) {
 	for {
 		if c.debugWriter != nil {
 			// To get the response body we need to read it before the request was actually send. https://github.com/golang/go/issues/29792
-			dumpReq, err := httputil.DumpRequest(r, true)
+			dumpReq, err := httputil.DumpRequestOut(r, true)
 			if err != nil {
 				return nil, err
 			}


### PR DESCRIPTION
httputil.DumpRequest was used before, which should only be used by
servers. Clients should use httputil.DumpRequestOut, which may produce
subtly different (and more accurate) output.

> DumpRequestOut is like DumpRequest but for outgoing client requests. It includes any headers that the standard http.Transport adds, such as User-Agent.
-- https://golang.org/pkg/net/http/httputil/#DumpRequestOut

I don't think it's worth mentioning this in the changelog. If you disagree let me know and I'll update it.