### PR TITLE
HTTP debug logs: Redact Authorization header

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Changes
 
+## Unreleased
+
+* Fix Authorization header being included in debug output
+
 ## v1.23.1
 * Add removed `ErrorCodeServerAlreadyAttached` again
 

--- a/hcloud/client_test.go
+++ b/hcloud/client_test.go
@@ -272,9 +272,16 @@ func TestClientDoPost(t *testing.T) {
 	env := newTestEnv()
 	defer env.Teardown()
 
-	env.Client.debugWriter = new(bytes.Buffer)
+	debugLog := new(bytes.Buffer)
+
+	env.Client.debugWriter = debugLog
 	callCount := 0
 	env.Mux.HandleFunc("/test", func(w http.ResponseWriter, r *http.Request) {
+		auth := r.Header.Get("Authorization")
+		if auth != "Bearer token" {
+			t.Errorf("unexpected auth header: %q, expected %q", auth, "Bearer token")
+		}
+
 		callCount++
 		w.Header().Set("Content-Type", "application/json")
 		var dat map[string]interface{}
@@ -316,6 +323,10 @@ func TestClientDoPost(t *testing.T) {
 	}
 	if callCount != 2 {
 		t.Fatalf("unexpected callCount: %v", callCount)
+	}
+
+	if strings.Contains(debugLog.String(), "token") {
+		t.Errorf("debug log did contain token, although it shouldn't")
 	}
 }
 


### PR DESCRIPTION
When using `hcloud.WithDebugWriter`, we currently output full HTTP requests and responses, including the `Authorization` header.

As we sometimes have to ask customers to provide debug logs, it's not ideal if they need to manually remove the header and may do so incompletely.

Redact the header in the output.
