### PR TITLE
Catch invalid token values and error out without value exposure

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/google/go-cmp v0.5.5
 	github.com/prometheus/client_golang v1.11.0
 	github.com/stretchr/testify v1.7.0
+	golang.org/x/net v0.0.0-20200625001655-4c5254603344
 )
 
 require (
@@ -19,6 +20,7 @@ require (
 	github.com/prometheus/common v0.26.0 // indirect
 	github.com/prometheus/procfs v0.6.0 // indirect
 	golang.org/x/sys v0.0.0-20210603081109-ebe580a85c40 // indirect
+	golang.org/x/text v0.3.2 // indirect
 	google.golang.org/protobuf v1.26.0-rc.1 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -102,6 +102,7 @@ golang.org/x/net v0.0.0-20181114220301-adae6a3d119a/go.mod h1:mL1N/T3taQHkDXs73r
 golang.org/x/net v0.0.0-20190108225652-1e06a53dbb7e/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190613194153-d28f0bde5980/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
+golang.org/x/net v0.0.0-20200625001655-4c5254603344 h1:vGXIOMxbNfDTk/aXCmfdLgkrSV+Z2tcbze+pEc3v5W4=
 golang.org/x/net v0.0.0-20200625001655-4c5254603344/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
@@ -121,6 +122,7 @@ golang.org/x/sys v0.0.0-20210124154548-22da62e12c0c/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210603081109-ebe580a85c40 h1:JWgyZ1qgdTaF3N3oxC+MdTV7qvEEgHo3otj+HB5CM7Q=
 golang.org/x/sys v0.0.0-20210603081109-ebe580a85c40/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+golang.org/x/text v0.3.2 h1:tW2bmiBqwgJj/UpqtC8EpXEZVYOwU0yG4iWbprSVAcs=
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=

--- a/hcloud/client.go
+++ b/hcloud/client.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -16,9 +17,9 @@ import (
 	"time"
 
 	"github.com/hetznercloud/hcloud-go/hcloud/internal/instrumentation"
-
 	"github.com/hetznercloud/hcloud-go/hcloud/schema"
 	"github.com/prometheus/client_golang/prometheus"
+	"golang.org/x/net/http/httpguts"
 )
 
 // Endpoint is the base URL of the API.
@@ -53,6 +54,7 @@ func ExponentialBackoff(b float64, d time.Duration) BackoffFunc {
 type Client struct {
 	endpoint                string
 	token                   string
+	tokenValid              bool
 	pollInterval            time.Duration
 	backoffFunc             BackoffFunc
 	httpClient              *http.Client
@@ -96,6 +98,7 @@ func WithEndpoint(endpoint string) ClientOption {
 func WithToken(token string) ClientOption {
 	return func(client *Client) {
 		client.token = token
+		client.tokenValid = httpguts.ValidHeaderFieldValue(token)
 	}
 }
 
@@ -150,6 +153,7 @@ func WithInstrumentation(registry *prometheus.Registry) ClientOption {
 func NewClient(options ...ClientOption) *Client {
 	client := &Client{
 		endpoint:     Endpoint,
+		tokenValid:   true,
 		httpClient:   &http.Client{},
 		backoffFunc:  ExponentialBackoff(2, 500*time.Millisecond),
 		pollInterval: 500 * time.Millisecond,
@@ -196,9 +200,13 @@ func (c *Client) NewRequest(ctx context.Context, method, path string, body io.Re
 		return nil, err
 	}
 	req.Header.Set("User-Agent", c.userAgent)
-	if c.token != "" {
+
+	if !c.tokenValid {
+		return nil, errors.New("Authorization token contains invalid characters")
+	} else if c.token != "" {
 		req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", c.token))
 	}
+
 	if body != nil {
 		req.Header.Set("Content-Type", "application/json")
 	}

--- a/hcloud/client_test.go
+++ b/hcloud/client_test.go
@@ -86,6 +86,25 @@ func TestClientError(t *testing.T) {
 	}
 }
 
+func TestClientInvalidToken(t *testing.T) {
+	env := newTestEnv()
+	defer env.Teardown()
+
+	env.Client = NewClient(
+		WithEndpoint(env.Server.URL),
+		WithToken("invalid token\n"),
+	)
+
+	ctx := context.Background()
+	_, err := env.Client.NewRequest(ctx, "GET", "/", nil)
+
+	if nil == err {
+		t.Error("Failed to trigger expected error")
+	} else if err.Error() != "Authorization token contains invalid characters" {
+		t.Fatalf("Invalid encoded authorization token triggered unexpected error message: %s", err)
+	}
+}
+
 func TestClientMeta(t *testing.T) {
 	env := newTestEnv()
 	defer env.Teardown()


### PR DESCRIPTION
This PR handles tokens that have been previously for example encoded in base64 for Kubernetes in an erroneous way containing newline characters.

Currently the error returned return the token value. This may be an unexpected value exposure not intended by an operator.

Example:
`net/http: invalid header field value "Bearer broken\n" for key Authorization`

Applying this change changes the error to not contain any sensitive data anymore:
`Authorization token contains invalid characters`