### PR TITLE
added ability to use sshkey, volume, networks names during instance creation

### DIFF
--- a/hcloud/schema/server.go
+++ b/hcloud/schema/server.go
@@ -98,15 +98,15 @@ type ServerCreateRequest struct {
 	Name             string                  `json:"name"`
 	ServerType       interface{}             `json:"server_type"` // int or string
 	Image            interface{}             `json:"image"`       // int or string
-	SSHKeys          []int                   `json:"ssh_keys,omitempty"`
+	SSHKeys          []interface{}           `json:"ssh_keys,omitempty"`
 	Location         string                  `json:"location,omitempty"`
 	Datacenter       string                  `json:"datacenter,omitempty"`
 	UserData         string                  `json:"user_data,omitempty"`
 	StartAfterCreate *bool                   `json:"start_after_create,omitempty"`
 	Labels           *map[string]string      `json:"labels,omitempty"`
 	Automount        *bool                   `json:"automount,omitempty"`
-	Volumes          []int                   `json:"volumes,omitempty"`
-	Networks         []int                   `json:"networks,omitempty"`
+	Volumes          []interface{}           `json:"volumes,omitempty"`
+	Networks         []interface{}           `json:"networks,omitempty"`
 	Firewalls        []ServerCreateFirewalls `json:"firewalls,omitempty"`
 	PlacementGroup   int                     `json:"placement_group,omitempty"`
 }

--- a/hcloud/server.go
+++ b/hcloud/server.go
@@ -362,13 +362,31 @@ func (c *ServerClient) Create(ctx context.Context, opts ServerCreateOpts) (Serve
 		reqBody.Labels = &opts.Labels
 	}
 	for _, sshKey := range opts.SSHKeys {
-		reqBody.SSHKeys = append(reqBody.SSHKeys, sshKey.ID)
+		var value interface{}
+		if sshKey.ID != 0 {
+			value = strconv.Itoa(sshKey.ID)
+		} else if sshKey.Name != "" {
+			value = sshKey.Name
+		}
+		reqBody.SSHKeys = append(reqBody.SSHKeys, value)
 	}
 	for _, volume := range opts.Volumes {
-		reqBody.Volumes = append(reqBody.Volumes, volume.ID)
+		var value interface{}
+		if volume.ID != 0 {
+			value = strconv.Itoa(volume.ID)
+		} else if volume.Name != "" {
+			value = volume.Name
+		}
+		reqBody.Volumes = append(reqBody.Volumes, value)
 	}
 	for _, network := range opts.Networks {
-		reqBody.Networks = append(reqBody.Networks, network.ID)
+		var value interface{}
+		if network.ID != 0 {
+			value = strconv.Itoa(network.ID)
+		} else if network.Name != "" {
+			value = network.Name
+		}
+		reqBody.Networks = append(reqBody.Networks, value)
 	}
 	for _, firewall := range opts.Firewalls {
 		reqBody.Firewalls = append(reqBody.Firewalls, schema.ServerCreateFirewalls{


### PR DESCRIPTION
Hi all!
I'm working on plugin for Nomad scaler and added input validation according to [documentation](https://docs.hetzner.cloud/#servers-create-a-server). Now I met a problem: at least create server function in hcloud-go library doesn't follow this documentation cause doesn't allow to use both names and ids for volumes, networks and ssh keys. Added PR to fill this gap. Could you please review it?