### PR TITLE
Set UsePrivateIP for targets when creating a LoadBalancer

### DIFF
--- a/hcloud/schema.go
+++ b/hcloud/schema.go
@@ -842,7 +842,9 @@ func loadBalancerCreateOptsToSchema(opts LoadBalancerCreateOpts) schema.LoadBala
 		req.Network = Int(opts.Network.ID)
 	}
 	for _, target := range opts.Targets {
-		schemaTarget := schema.LoadBalancerCreateRequestTarget{}
+		schemaTarget := schema.LoadBalancerCreateRequestTarget{
+			UsePrivateIP: target.UsePrivateIP,
+		}
 		switch target.Type {
 		case LoadBalancerTargetTypeServer:
 			schemaTarget.Type = string(LoadBalancerTargetTypeServer)


### PR DESCRIPTION
Setting `UsePrivateIP` for targets when creating a LoadBalancer should be allowed, same as when creating the targets separately:
https://github.com/hetznercloud/hcloud-go/blob/cf8f35d1f96cc8d74d1706f9e834ed25a851300f/hcloud/load_balancer.go#L567-L573
https://github.com/hetznercloud/hcloud-go/blob/cf8f35d1f96cc8d74d1706f9e834ed25a851300f/hcloud/load_balancer.go#L597-L603
