### PR TITLE
fix(images): Fix inabiltiy to find depreacted images by name

### DIFF
--- a/hcloud/image.go
+++ b/hcloud/image.go
@@ -102,7 +102,7 @@ func (c *ImageClient) GetByName(ctx context.Context, name string) (*Image, *Resp
 	if name == "" {
 		return nil, nil, nil
 	}
-	images, response, err := c.List(ctx, ImageListOpts{Name: name})
+	images, response, err := c.List(ctx, ImageListOpts{Name: name, IncludeDeprecated: true})
 	if len(images) == 0 {
 		return nil, response, err
 	}

--- a/hcloud/image_test.go
+++ b/hcloud/image_test.go
@@ -96,7 +96,7 @@ func TestImageClient(t *testing.T) {
 		defer env.Teardown()
 
 		env.Mux.HandleFunc("/images", func(w http.ResponseWriter, r *http.Request) {
-			if r.URL.RawQuery != "name=my+image" {
+			if r.URL.RawQuery != "include_deprecated=true&name=my+image" {
 				t.Fatal("missing name query")
 			}
 			json.NewEncoder(w).Encode(schema.ImageListResponse{
@@ -139,7 +139,7 @@ func TestImageClient(t *testing.T) {
 		defer env.Teardown()
 
 		env.Mux.HandleFunc("/images", func(w http.ResponseWriter, r *http.Request) {
-			if r.URL.RawQuery != "name=my+image" {
+			if r.URL.RawQuery != "include_deprecated=true&name=my+image" {
 				t.Fatal("missing name query")
 			}
 			json.NewEncoder(w).Encode(schema.ImageListResponse{


### PR DESCRIPTION
Currently it's not possible to query e.g. the `fedora-35` image by name,
after it was marked as deprecated due to the release of the `fedora-36`
image. Instead the library will treat this request as if the image
doesn't exist anymore.

This patch enables the `IncludeDeprecated` switch in the `GetByName`
function to allow images that were marked as deprecated to be found by
name.

This is necessary to allow e.g. the Terraform module, build on top of
this library, to continue to provide old OS versions for a transition
time without breaking.

References:
https://github.com/hetznercloud/terraform-provider-hcloud/blob/1dbb289398f19ca52b6b772501630381fc601fa0/internal/server/resource.go#L230
https://github.com/hetznercloud/terraform-provider-hcloud/issues/527