### PR TITLE
Add delete server response

### DIFF
--- a/hcloud/schema/server.go
+++ b/hcloud/schema/server.go
@@ -136,6 +136,11 @@ type ServerCreateResponse struct {
 	NextActions  []Action `json:"next_actions"`
 }
 
+// ServerDeleteResponse defines the schema of the response when deleting a server.
+type ServerDeleteResponse struct {
+	Action Action `json:"action"`
+}
+
 // ServerUpdateRequest defines the schema of the request to update a server.
 type ServerUpdateRequest struct {
 	Name   string             `json:"name,omitempty"`

--- a/hcloud/server.go
+++ b/hcloud/server.go
@@ -459,12 +459,18 @@ func (c *ServerClient) Create(ctx context.Context, opts ServerCreateOpts) (Serve
 }
 
 // Delete deletes a server.
-func (c *ServerClient) Delete(ctx context.Context, server *Server) (*Response, error) {
+func (c *ServerClient) Delete(ctx context.Context, server *Server) (*Action, *Response, error) {
 	req, err := c.client.NewRequest(ctx, "DELETE", fmt.Sprintf("/servers/%d", server.ID), nil)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
-	return c.client.Do(req, nil)
+
+	respBody := schema.ServerDeleteResponse{}
+	resp, err := c.client.Do(req, &respBody)
+	if err != nil {
+		return nil, resp, err
+	}
+	return ActionFromSchema(respBody.Action), resp, nil
 }
 
 // ServerUpdateOpts specifies options for updating a server.

--- a/hcloud/server_test.go
+++ b/hcloud/server_test.go
@@ -1022,15 +1022,24 @@ func TestServersDelete(t *testing.T) {
 	env := newTestEnv()
 	defer env.Teardown()
 
-	env.Mux.HandleFunc("/servers/1", func(w http.ResponseWriter, r *http.Request) {})
+	env.Mux.HandleFunc("/servers/1", func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(schema.ServerDeleteResponse{
+			Action: schema.Action{
+				ID: 1,
+			},
+		})
+	})
 
 	var (
 		ctx    = context.Background()
 		server = &Server{ID: 1}
 	)
-	_, err := env.Client.Server.Delete(ctx, server)
+	action, _, err := env.Client.Server.Delete(ctx, server)
 	if err != nil {
 		t.Fatalf("Server.Delete failed: %s", err)
+	}
+	if action.ID != 1 {
+		t.Errorf("unexpected action ID: %d", action.ID)
 	}
 }
 


### PR DESCRIPTION
Hello 👋,

I'm trying to find a way to wait until a server is deleted (i.e. unreachable).

The API documentation states that an action object is returned when deleting a server (https://docs.hetzner.cloud/#servers-delete-a-server) but this object is absent from the response of the server's delete method.

It's a breaking change given that the number of values returned needs to be changed.