### PR TITLE
Stop automatic retrying on RateLimitExceeded

### DIFF
--- a/hcloud/action_test.go
+++ b/hcloud/action_test.go
@@ -183,11 +183,11 @@ func TestActionClientWatchProgress(t *testing.T) {
 				},
 			})
 		case 2:
-			w.WriteHeader(http.StatusTooManyRequests)
+			w.WriteHeader(http.StatusConflict)
 			_ = json.NewEncoder(w).Encode(schema.ErrorResponse{
 				Error: schema.Error{
-					Code:    string(ErrorCodeRateLimitExceeded),
-					Message: "ratelimited",
+					Code:    string(ErrorCodeConflict),
+					Message: "conflict",
 				},
 			})
 			return

--- a/hcloud/client.go
+++ b/hcloud/client.go
@@ -270,7 +270,7 @@ func (c *Client) Do(r *http.Request, v interface{}) (*Response, error) {
 			err = errorFromResponse(resp, body)
 			if err == nil {
 				err = fmt.Errorf("hcloud: server responded with status code %d", resp.StatusCode)
-			} else if isRetryable(err) {
+			} else if isConflict(err) {
 				c.backoff(retries)
 				retries++
 				continue
@@ -289,12 +289,12 @@ func (c *Client) Do(r *http.Request, v interface{}) (*Response, error) {
 	}
 }
 
-func isRetryable(error error) bool {
+func isConflict(error error) bool {
 	err, ok := error.(Error)
 	if !ok {
 		return false
 	}
-	return err.Code == ErrorCodeRateLimitExceeded || err.Code == ErrorCodeConflict
+	return err.Code == ErrorCodeConflict
 }
 
 func (c *Client) backoff(retries int) {

--- a/hcloud/client_test.go
+++ b/hcloud/client_test.go
@@ -183,7 +183,7 @@ func TestClientAll(t *testing.T) {
 
 	var (
 		ctx          = context.Background()
-		ratelimited  bool
+		conflicting  bool
 		expectedPage = 1
 	)
 
@@ -205,13 +205,13 @@ func TestClientAll(t *testing.T) {
 			respBody.Meta.Pagination.Page = 1
 			respBody.Meta.Pagination.NextPage = 2
 		case "2":
-			if !ratelimited {
-				ratelimited = true
-				w.WriteHeader(http.StatusTooManyRequests)
+			if !conflicting {
+				conflicting = true
+				w.WriteHeader(http.StatusConflict)
 				json.NewEncoder(w).Encode(schema.ErrorResponse{
 					Error: schema.Error{
-						Code:    string(ErrorCodeRateLimitExceeded),
-						Message: "ratelimited",
+						Code:    string(ErrorCodeConflict),
+						Message: "conflict",
 					},
 				})
 				return
@@ -262,11 +262,11 @@ func TestClientDo(t *testing.T) {
 		w.Header().Set("Content-Type", "application/json")
 		switch callCount {
 		case 1:
-			w.WriteHeader(http.StatusTooManyRequests)
+			w.WriteHeader(http.StatusConflict)
 			json.NewEncoder(w).Encode(schema.ErrorResponse{
 				Error: schema.Error{
-					Code:    string(ErrorCodeRateLimitExceeded),
-					Message: "ratelimited",
+					Code:    string(ErrorCodeConflict),
+					Message: "conflict",
 				},
 			})
 		case 2:


### PR DESCRIPTION
It does not make sense to retry when the rate limit is already exceeded. However, it makes sense to retry on Conflict. In the best case this would happen on the Caller/User side, but removing the retry completely would be a breaking change.

Signed-off-by: Lukas Kämmerling <lukas.kaemmerling@hetzner-cloud.de>