### PR TITLE
ci: test against actually supported Go versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: [1.17, 1.18, 1.19]
+        go-version: [1.18, 1.19]
     steps:
     - name: Set up Go ${{ matrix.go-version }}
       uses: actions/setup-go@v2

--- a/README.md
+++ b/README.md
@@ -36,6 +36,14 @@ func main() {
 }
 ```
 
+## Go Version Support
+
+The library supports the latest two Go minor versions, e.g. at the time Go 1.19 is released, it supports Go 1.18 and 1.19.
+
+This matches the official [Go Release Policy](https://go.dev/doc/devel/release#policy).
+
+When the minimum required Go version is changed, it is announced in the release notes for that version.
+
 ## License
 
 MIT license


### PR DESCRIPTION
We require Go 1.18 according to `go.mod`, but still test against 1.17.

This removes the testing and codifies our supported Go versions.