### PR TITLE
Fix schema for primary IP pricing to reflect the current API response

### DIFF
--- a/hcloud/pricing.go
+++ b/hcloud/pricing.go
@@ -56,7 +56,8 @@ type FloatingIPTypePricing struct {
 // PrimaryIPTypePricing defines the schema of pricing information for a primary IP
 // type at a datacenter.
 type PrimaryIPTypePricing struct {
-	Datacenter string
+	Datacenter string // Deprecated: the API does not return pricing for the individual DCs anymore
+	Location   string
 	Hourly     PrimaryIPPrice
 	Monthly    PrimaryIPPrice
 }

--- a/hcloud/schema.go
+++ b/hcloud/schema.go
@@ -721,7 +721,7 @@ func PricingFromSchema(s schema.Pricing) Pricing {
 		var pricings []PrimaryIPTypePricing
 		for _, price := range primaryIPType.Prices {
 			p := PrimaryIPTypePricing{
-				Datacenter: price.Datacenter,
+				Location: price.Location,
 				Monthly: PrimaryIPPrice{
 					Net:   price.PriceMonthly.Net,
 					Gross: price.PriceMonthly.Gross,

--- a/hcloud/schema/pricing.go
+++ b/hcloud/schema/pricing.go
@@ -97,7 +97,8 @@ type PricingGetResponse struct {
 // PricingPrimaryIPTypePrice defines the schema of pricing information for a primary IP
 // type at a datacenter.
 type PricingPrimaryIPTypePrice struct {
-	Datacenter   string `json:"datacenter"`
+	Datacenter   string `json:"datacenter"` // Deprecated: the API does not return pricing for the individual DCs anymore
+	Location     string `json:"location"`
 	PriceHourly  Price  `json:"price_hourly"`
 	PriceMonthly Price  `json:"price_monthly"`
 }

--- a/hcloud/schema_test.go
+++ b/hcloud/schema_test.go
@@ -2044,7 +2044,7 @@ func TestPricingFromSchema(t *testing.T) {
 			{
 				"prices": [
 				{
-					"datacenter": "fsn1-dc8",
+					"location": "fsn1",
 					"price_hourly": {
 					"gross": "1.1900000000000000",
 					"net": "1.0000000000"
@@ -2185,8 +2185,8 @@ func TestPricingFromSchema(t *testing.T) {
 		if len(ip.Pricings) != 1 {
 			t.Errorf("unexpected number of prices: %d", len(ip.Pricings))
 		} else {
-			if ip.Pricings[0].Datacenter != "fsn1-dc8" {
-				t.Errorf("unexpected Datacenter: %v", ip.Pricings[0].Datacenter)
+			if ip.Pricings[0].Location != "fsn1" {
+				t.Errorf("unexpected Location: %v", ip.Pricings[0].Location)
 			}
 			if ip.Pricings[0].Monthly.Net != "1.0000000000" {
 				t.Errorf("unexpected Monthly.Net: %v", ip.Pricings[0].Monthly.Net)


### PR DESCRIPTION
The /pricing API endpoint for primary IPs does not return individual DCs anymore but just regions ("fsn1", "nbg1", ...). I have changed the key name in the schema and updated the test for the new format.