### PR TITLE
chore: add codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @hetznercloud/integrations

--- a/.gitlab/CODEOWNERS
+++ b/.gitlab/CODEOWNERS
@@ -1,0 +1,1 @@
+* @cloud/integrations


### PR DESCRIPTION
Add CODEOWNERS files for GitHub and (internal) GitLab referencing the Integrations team.