### PR TITLE
feat(primary-ip): implement RDNSSupporter

### DIFF
--- a/hcloud/primary_ip.go
+++ b/hcloud/primary_ip.go
@@ -43,6 +43,32 @@ type PrimaryIPDNSPTR struct {
 	IP     string
 }
 
+// changeDNSPtr changes or resets the reverse DNS pointer for a IP address.
+// Pass a nil ptr to reset the reverse DNS pointer to its default value.
+func (p *PrimaryIP) changeDNSPtr(ctx context.Context, client *Client, ip net.IP, ptr *string) (*Action, *Response, error) {
+	reqBody := schema.PrimaryIPActionChangeDNSPtrRequest{
+		IP:     ip.String(),
+		DNSPtr: ptr,
+	}
+	reqBodyData, err := json.Marshal(reqBody)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	path := fmt.Sprintf("/primary_ips/%d/actions/change_dns_ptr", p.ID)
+	req, err := client.NewRequest(ctx, "POST", path, bytes.NewReader(reqBodyData))
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var respBody PrimaryIPChangeDNSPtrResult
+	resp, err := client.Do(req, &respBody)
+	if err != nil {
+		return nil, resp, err
+	}
+	return ActionFromSchema(respBody.Action), resp, nil
+}
+
 // GetDNSPtrForIP searches for the dns assigned to the given IP address.
 // It returns an error if there is no dns set for the given IP address.
 func (p *PrimaryIP) GetDNSPtrForIP(ip net.IP) (string, error) {

--- a/hcloud/schema/primary_ip.go
+++ b/hcloud/schema/primary_ip.go
@@ -53,3 +53,10 @@ type PrimaryIPListResult struct {
 type PrimaryIPUpdateResult struct {
 	PrimaryIP PrimaryIP `json:"primary_ip"`
 }
+
+// PrimaryIPActionChangeDNSPtrRequest defines the schema for the request to
+// change a Primary IP's reverse DNS pointer.
+type PrimaryIPActionChangeDNSPtrRequest struct {
+	IP     string  `json:"ip"`
+	DNSPtr *string `json:"dns_ptr"`
+}


### PR DESCRIPTION
Implement the [RDNSSupporter](https://github.com/hetznercloud/hcloud-go/blob/f10e8042ac12e6195824b80a791700ce857111bc/hcloud/rdns.go#L11-L18) interface so the reverse dns for primary ips can be set the same way as for other resources (Server, Floating IP, Load Balancer).

This is required for [terraform-provider-hcloud#668](https://github.com/hetznercloud/terraform-provider-hcloud/issues/668).

The existing struct `hcloud.PrimaryIPChangeDNSPtrOpts` has a bug, where the DNSPtr field should be a `*string` to allow removing the entry, but changing it is not possible without breaking backwards compatibility. To work around this limitation, I added a new `schema.PrimaryIPActionChangeDNSPtrRequest` that has the string pointer field instead.