### PR TITLE
fix(servertype): use int64 to fit TB sizes on 32-bit platforms

### DIFF
--- a/hcloud/schema/server_type.go
+++ b/hcloud/schema/server_type.go
@@ -11,7 +11,7 @@ type ServerType struct {
 	StorageType     string                   `json:"storage_type"`
 	CPUType         string                   `json:"cpu_type"`
 	Architecture    string                   `json:"architecture"`
-	IncludedTraffic int                      `json:"included_traffic"`
+	IncludedTraffic int64                    `json:"included_traffic"`
 	Prices          []PricingServerTypePrice `json:"prices"`
 }
 

--- a/hcloud/server_type.go
+++ b/hcloud/server_type.go
@@ -21,7 +21,7 @@ type ServerType struct {
 	CPUType      CPUType
 	Architecture Architecture
 	// IncludedTraffic is the free traffic per month in bytes
-	IncludedTraffic int
+	IncludedTraffic int64
 	Pricings        []ServerTypeLocationPricing
 }
 


### PR DESCRIPTION
This is theoretically a breaking change, but the version that introduced the type was released 20 minutes ago.

Failed here while trying to build the clie preview: https://github.com/hetznercloud/cli/actions/runs/4947310060