### PR TITLE
refactor: re-use implementation of `.AllWithOpts` for `.All`

### DIFF
--- a/hcloud/action.go
+++ b/hcloud/action.go
@@ -140,30 +140,12 @@ func (c *ActionClient) List(ctx context.Context, opts ActionListOpts) ([]*Action
 
 // All returns all actions.
 func (c *ActionClient) All(ctx context.Context) ([]*Action, error) {
-	allActions := []*Action{}
-
-	opts := ActionListOpts{}
-	opts.PerPage = 50
-
-	err := c.client.all(func(page int) (*Response, error) {
-		opts.Page = page
-		actions, resp, err := c.List(ctx, opts)
-		if err != nil {
-			return resp, err
-		}
-		allActions = append(allActions, actions...)
-		return resp, nil
-	})
-	if err != nil {
-		return nil, err
-	}
-
-	return allActions, nil
+	return c.AllWithOpts(ctx, ActionListOpts{ListOpts: ListOpts{PerPage: 50}})
 }
 
 // AllWithOpts returns all actions for the given options.
 func (c *ActionClient) AllWithOpts(ctx context.Context, opts ActionListOpts) ([]*Action, error) {
-	allActions := []*Action{}
+	var allActions []*Action
 
 	err := c.client.all(func(page int) (*Response, error) {
 		opts.Page = page
@@ -192,7 +174,7 @@ func (c *ActionClient) AllWithOpts(ctx context.Context, opts ActionListOpts) ([]
 //     complete successfully, as well as any errors that happened while
 //     querying the API.
 //
-// By default the method keeps watching until all actions have finished
+// By default, the method keeps watching until all actions have finished
 // processing. If you want to be able to cancel the method or configure a
 // timeout, use the [context.Context]. Once the method has stopped watching,
 // both returned channels are closed.
@@ -269,7 +251,7 @@ func (c *ActionClient) WatchOverallProgress(ctx context.Context, actions []*Acti
 //     API, as well as the error of the action if it did not complete
 //     successfully, or nil if it did.
 //
-// By default the method keeps watching until the action has finished
+// By default, the method keeps watching until the action has finished
 // processing. If you want to be able to cancel the method or configure a
 // timeout, use the [context.Context]. Once the method has stopped watching,
 // both returned channels are closed.

--- a/hcloud/certificate.go
+++ b/hcloud/certificate.go
@@ -68,7 +68,7 @@ func (st *CertificateStatus) IsFailed() bool {
 	return st.Issuance == CertificateStatusTypeFailed || st.Renewal == CertificateStatusTypeFailed
 }
 
-// Certificate represents an certificate in the Hetzner Cloud.
+// Certificate represents a certificate in the Hetzner Cloud.
 type Certificate struct {
 	ID             int
 	Name           string
@@ -129,7 +129,7 @@ func (c *CertificateClient) GetByName(ctx context.Context, name string) (*Certif
 // retrieves a Certificate by its name. If the Certificate does not exist, nil is returned.
 func (c *CertificateClient) Get(ctx context.Context, idOrName string) (*Certificate, *Response, error) {
 	if id, err := strconv.Atoi(idOrName); err == nil {
-		return c.GetByID(ctx, int(id))
+		return c.GetByID(ctx, id)
 	}
 	return c.GetByName(ctx, idOrName)
 }
@@ -177,25 +177,7 @@ func (c *CertificateClient) List(ctx context.Context, opts CertificateListOpts) 
 
 // All returns all Certificates.
 func (c *CertificateClient) All(ctx context.Context) ([]*Certificate, error) {
-	allCertificates := []*Certificate{}
-
-	opts := CertificateListOpts{}
-	opts.PerPage = 50
-
-	err := c.client.all(func(page int) (*Response, error) {
-		opts.Page = page
-		Certificate, resp, err := c.List(ctx, opts)
-		if err != nil {
-			return resp, err
-		}
-		allCertificates = append(allCertificates, Certificate...)
-		return resp, nil
-	})
-	if err != nil {
-		return nil, err
-	}
-
-	return allCertificates, nil
+	return c.AllWithOpts(ctx, CertificateListOpts{ListOpts: ListOpts{PerPage: 50}})
 }
 
 // AllWithOpts returns all Certificates for the given options.

--- a/hcloud/firewall.go
+++ b/hcloud/firewall.go
@@ -127,7 +127,7 @@ func (c *FirewallClient) GetByName(ctx context.Context, name string) (*Firewall,
 // retrieves a Firewall by its name. If the Firewall does not exist, nil is returned.
 func (c *FirewallClient) Get(ctx context.Context, idOrName string) (*Firewall, *Response, error) {
 	if id, err := strconv.Atoi(idOrName); err == nil {
-		return c.GetByID(ctx, int(id))
+		return c.GetByID(ctx, id)
 	}
 	return c.GetByName(ctx, idOrName)
 }
@@ -175,25 +175,7 @@ func (c *FirewallClient) List(ctx context.Context, opts FirewallListOpts) ([]*Fi
 
 // All returns all Firewalls.
 func (c *FirewallClient) All(ctx context.Context) ([]*Firewall, error) {
-	allFirewalls := []*Firewall{}
-
-	opts := FirewallListOpts{}
-	opts.PerPage = 50
-
-	err := c.client.all(func(page int) (*Response, error) {
-		opts.Page = page
-		firewalls, resp, err := c.List(ctx, opts)
-		if err != nil {
-			return resp, err
-		}
-		allFirewalls = append(allFirewalls, firewalls...)
-		return resp, nil
-	})
-	if err != nil {
-		return nil, err
-	}
-
-	return allFirewalls, nil
+	return c.AllWithOpts(ctx, FirewallListOpts{ListOpts: ListOpts{PerPage: 50}})
 }
 
 // AllWithOpts returns all Firewalls for the given options.

--- a/hcloud/floating_ip.go
+++ b/hcloud/floating_ip.go
@@ -42,7 +42,7 @@ type FloatingIPProtection struct {
 	Delete bool
 }
 
-// FloatingIPType represents the type of a Floating IP.
+// FloatingIPType represents the type of Floating IP.
 type FloatingIPType string
 
 // Floating IP types.
@@ -51,7 +51,7 @@ const (
 	FloatingIPTypeIPv6 FloatingIPType = "ipv6"
 )
 
-// changeDNSPtr changes or resets the reverse DNS pointer for a IP address.
+// changeDNSPtr changes or resets the reverse DNS pointer for an IP address.
 // Pass a nil ptr to reset the reverse DNS pointer to its default value.
 func (f *FloatingIP) changeDNSPtr(ctx context.Context, client *Client, ip net.IP, ptr *string) (*Action, *Response, error) {
 	reqBody := schema.FloatingIPActionChangeDNSPtrRequest{
@@ -128,7 +128,7 @@ func (c *FloatingIPClient) GetByName(ctx context.Context, name string) (*Floatin
 // retrieves a Floating IP by its name. If the Floating IP does not exist, nil is returned.
 func (c *FloatingIPClient) Get(ctx context.Context, idOrName string) (*FloatingIP, *Response, error) {
 	if id, err := strconv.Atoi(idOrName); err == nil {
-		return c.GetByID(ctx, int(id))
+		return c.GetByID(ctx, id)
 	}
 	return c.GetByName(ctx, idOrName)
 }
@@ -181,7 +181,7 @@ func (c *FloatingIPClient) All(ctx context.Context) ([]*FloatingIP, error) {
 
 // AllWithOpts returns all Floating IPs for the given options.
 func (c *FloatingIPClient) AllWithOpts(ctx context.Context, opts FloatingIPListOpts) ([]*FloatingIP, error) {
-	allFloatingIPs := []*FloatingIP{}
+	var allFloatingIPs []*FloatingIP
 
 	err := c.client.all(func(page int) (*Response, error) {
 		opts.Page = page

--- a/hcloud/load_balancer.go
+++ b/hcloud/load_balancer.go
@@ -103,7 +103,7 @@ type LoadBalancerAlgorithmType string
 
 const (
 	// LoadBalancerAlgorithmTypeRoundRobin is an algorithm which distributes
-	// requests to targets in a round robin fashion.
+	// requests to targets in a round-robin fashion.
 	LoadBalancerAlgorithmTypeRoundRobin LoadBalancerAlgorithmType = "round_robin"
 	// LoadBalancerAlgorithmTypeLeastConnections is an algorithm which distributes
 	// requests to targets with the least number of connections.
@@ -116,7 +116,7 @@ type LoadBalancerAlgorithm struct {
 	Type LoadBalancerAlgorithmType
 }
 
-// LoadBalancerTargetType specifies the type of a Load Balancer target.
+// LoadBalancerTargetType specifies the type of Load Balancer target.
 type LoadBalancerTargetType string
 
 const (
@@ -197,7 +197,7 @@ type LoadBalancerProtection struct {
 	Delete bool
 }
 
-// changeDNSPtr changes or resets the reverse DNS pointer for a IP address.
+// changeDNSPtr changes or resets the reverse DNS pointer for an IP address.
 // Pass a nil ptr to reset the reverse DNS pointer to its default value.
 func (lb *LoadBalancer) changeDNSPtr(ctx context.Context, client *Client, ip net.IP, ptr *string) (*Action, *Response, error) {
 	reqBody := schema.LoadBalancerActionChangeDNSPtrRequest{
@@ -274,7 +274,7 @@ func (c *LoadBalancerClient) GetByName(ctx context.Context, name string) (*LoadB
 // retrieves a Load Balancer by its name. If the Load Balancer does not exist, nil is returned.
 func (c *LoadBalancerClient) Get(ctx context.Context, idOrName string) (*LoadBalancer, *Response, error) {
 	if id, err := strconv.Atoi(idOrName); err == nil {
-		return c.GetByID(ctx, int(id))
+		return c.GetByID(ctx, id)
 	}
 	return c.GetByName(ctx, idOrName)
 }
@@ -322,25 +322,7 @@ func (c *LoadBalancerClient) List(ctx context.Context, opts LoadBalancerListOpts
 
 // All returns all Load Balancers.
 func (c *LoadBalancerClient) All(ctx context.Context) ([]*LoadBalancer, error) {
-	allLoadBalancer := []*LoadBalancer{}
-
-	opts := LoadBalancerListOpts{}
-	opts.PerPage = 50
-
-	err := c.client.all(func(page int) (*Response, error) {
-		opts.Page = page
-		LoadBalancer, resp, err := c.List(ctx, opts)
-		if err != nil {
-			return resp, err
-		}
-		allLoadBalancer = append(allLoadBalancer, LoadBalancer...)
-		return resp, nil
-	})
-	if err != nil {
-		return nil, err
-	}
-
-	return allLoadBalancer, nil
+	return c.AllWithOpts(ctx, LoadBalancerListOpts{ListOpts: ListOpts{PerPage: 50}})
 }
 
 // AllWithOpts returns all Load Balancers for the given options.
@@ -665,7 +647,7 @@ type LoadBalancerAddServiceOptsHTTP struct {
 	StickySessions *bool
 }
 
-// LoadBalancerAddServiceOptsHealthCheck holds options for specifying an health check
+// LoadBalancerAddServiceOptsHealthCheck holds options for specifying a health check
 // when adding a service to a Load Balancer.
 type LoadBalancerAddServiceOptsHealthCheck struct {
 	Protocol LoadBalancerServiceProtocol


### PR DESCRIPTION
This PR simplifies some client implementations of `.All` by calling `.AllWithOpts` with the according default options.

Fixes #257 