### PR TITLE
ci: fix linting issues

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -16,8 +16,8 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
-          # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
-          version: latest
+          # Required: the version of golangci-lint is required and must be specified without patch version
+          version: v1.53.2
 
           # Optional: working directory, useful for monorepos
           # working-directory: somedir

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -6,7 +6,7 @@ variables:
 
 test:golangci-lint:
   stage: test
-  image: golangci/golangci-lint:latest
+  image: golangci/golangci-lint:v1.53.2
   script:
     - golangci-lint run -v
   except:

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -32,7 +32,6 @@ linters:
   disable-all: true
   enable:
     - bodyclose
-    - depguard
     - errcheck
     - errname
     - exhaustive


### PR DESCRIPTION
A new version of golangci-lint updated depguard, which in turn started erroring because it was missing a config. Previously depguard did not do anything as we never configured a list of allowed/denied imports.

In general, we already have gomodguard for linting imports.

To avoid sudden breakages of our CI in the future, I pinned the exact version of golangci-lint to the current release. Upgrading this should hppen through a PR process (e.g. by renovate) so we can notice new linting failures and fix them before merging to main.