### PR TITLE
fix: adjust label validation for max length of 63 characters

### DIFF
--- a/hcloud/labels.go
+++ b/hcloud/labels.go
@@ -6,8 +6,8 @@ import (
 )
 
 var keyRegexp = regexp.MustCompile(
-	`^([a-z0-9A-Z]((?:[\-_.]|[a-z0-9A-Z]){0,253}[a-z0-9A-Z])?/)?[a-z0-9A-Z]((?:[\-_.]|[a-z0-9A-Z]|){0,62}[a-z0-9A-Z])?$`)
-var valueRegexp = regexp.MustCompile(`^(([a-z0-9A-Z](?:[\-_.]|[a-z0-9A-Z]){0,62})?[a-z0-9A-Z]$|$)`)
+	`^([a-z0-9A-Z]((?:[\-_.]|[a-z0-9A-Z]){0,253}[a-z0-9A-Z])?/)?[a-z0-9A-Z]((?:[\-_.]|[a-z0-9A-Z]|){0,61}[a-z0-9A-Z])?$`)
+var valueRegexp = regexp.MustCompile(`^(([a-z0-9A-Z](?:[\-_.]|[a-z0-9A-Z]){0,61})?[a-z0-9A-Z]$|$)`)
 
 func ValidateResourceLabels(labels map[string]interface{}) (bool, error) {
 	for k, v := range labels {

--- a/hcloud/labels_test.go
+++ b/hcloud/labels_test.go
@@ -29,6 +29,7 @@ func TestCheckLabels(t *testing.T) {
 			"incorrect.com-",
 			"incorr,ect.com-",
 			"incorrect-111111111111111111111111111111111111111111111111111111111111.com",
+			"63-characters-are-allowed-in-a-label__this-is-one-character-more",
 		}
 
 		for _, label := range incorrectLabels {


### PR DESCRIPTION
According to the api documentation, the length of a label value must be a string of 63 characters or fewer.
The currently used regex for the validation allows 64 char long values.