### PR TITLE
chore: do not include renovate PRs in changelog

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,0 @@
-{
-  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "config:base"
-  ]
-}

--- a/renovate.json5
+++ b/renovate.json5
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:base"
+
+    // Generate commits compatible with release-please changelog
+    // => "deps: update module github.com/prometheus/client_golang to v1.15.1"
+    ":semanticCommitTypeAll(deps)",
+    ":semanticCommitScopeDisabled"
+  ]
+}


### PR DESCRIPTION
Changelogs should contain user-relevant stuff, updating dependencies is mostly not. Full list of commits is also linked in the changelog.