### PR TITLE
fix(action): show accurate progress in WatchOverallProgress

### DIFF
--- a/hcloud/action.go
+++ b/hcloud/action.go
@@ -223,7 +223,7 @@ func (c *ActionClient) WatchOverallProgress(ctx context.Context, actions []*Acti
 					continue
 				case ActionStatusSuccess:
 					delete(watchIDs, a.ID)
-					successIDs := append(successIDs, a.ID)
+					successIDs = append(successIDs, a.ID)
 					sendProgress(progressCh, int(float64(len(actions)-len(successIDs))/float64(len(actions))*100))
 				case ActionStatusError:
 					delete(watchIDs, a.ID)


### PR DESCRIPTION
The progress was updated incorrectly and only over showed `0` or `1/len(actions)`.