### PR TITLE
refactor: Return consistent empty slice from .All() methods

### DIFF
--- a/hcloud/action.go
+++ b/hcloud/action.go
@@ -145,7 +145,7 @@ func (c *ActionClient) All(ctx context.Context) ([]*Action, error) {
 
 // AllWithOpts returns all actions for the given options.
 func (c *ActionClient) AllWithOpts(ctx context.Context, opts ActionListOpts) ([]*Action, error) {
-	var allActions []*Action
+	allActions := []*Action{}
 
 	err := c.client.all(func(page int) (*Response, error) {
 		opts.Page = page

--- a/hcloud/certificate.go
+++ b/hcloud/certificate.go
@@ -182,7 +182,7 @@ func (c *CertificateClient) All(ctx context.Context) ([]*Certificate, error) {
 
 // AllWithOpts returns all Certificates for the given options.
 func (c *CertificateClient) AllWithOpts(ctx context.Context, opts CertificateListOpts) ([]*Certificate, error) {
-	var allCertificates []*Certificate
+	allCertificates := []*Certificate{}
 
 	err := c.client.all(func(page int) (*Response, error) {
 		opts.Page = page

--- a/hcloud/datacenter.go
+++ b/hcloud/datacenter.go
@@ -116,7 +116,7 @@ func (c *DatacenterClient) All(ctx context.Context) ([]*Datacenter, error) {
 
 // AllWithOpts returns all datacenters for the given options.
 func (c *DatacenterClient) AllWithOpts(ctx context.Context, opts DatacenterListOpts) ([]*Datacenter, error) {
-	var allDatacenters []*Datacenter
+	allDatacenters := []*Datacenter{}
 
 	err := c.client.all(func(page int) (*Response, error) {
 		opts.Page = page

--- a/hcloud/firewall.go
+++ b/hcloud/firewall.go
@@ -180,7 +180,7 @@ func (c *FirewallClient) All(ctx context.Context) ([]*Firewall, error) {
 
 // AllWithOpts returns all Firewalls for the given options.
 func (c *FirewallClient) AllWithOpts(ctx context.Context, opts FirewallListOpts) ([]*Firewall, error) {
-	var allFirewalls []*Firewall
+	allFirewalls := []*Firewall{}
 
 	err := c.client.all(func(page int) (*Response, error) {
 		opts.Page = page

--- a/hcloud/floating_ip.go
+++ b/hcloud/floating_ip.go
@@ -181,7 +181,7 @@ func (c *FloatingIPClient) All(ctx context.Context) ([]*FloatingIP, error) {
 
 // AllWithOpts returns all Floating IPs for the given options.
 func (c *FloatingIPClient) AllWithOpts(ctx context.Context, opts FloatingIPListOpts) ([]*FloatingIP, error) {
-	var allFloatingIPs []*FloatingIP
+	allFloatingIPs := []*FloatingIP{}
 
 	err := c.client.all(func(page int) (*Response, error) {
 		opts.Page = page

--- a/hcloud/iso.go
+++ b/hcloud/iso.go
@@ -143,7 +143,7 @@ func (c *ISOClient) All(ctx context.Context) ([]*ISO, error) {
 
 // AllWithOpts returns all ISOs for the given options.
 func (c *ISOClient) AllWithOpts(ctx context.Context, opts ISOListOpts) ([]*ISO, error) {
-	allISOs := make([]*ISO, 0)
+	allISOs := []*ISO{}
 
 	err := c.client.all(func(page int) (*Response, error) {
 		opts.Page = page

--- a/hcloud/load_balancer.go
+++ b/hcloud/load_balancer.go
@@ -327,7 +327,7 @@ func (c *LoadBalancerClient) All(ctx context.Context) ([]*LoadBalancer, error) {
 
 // AllWithOpts returns all Load Balancers for the given options.
 func (c *LoadBalancerClient) AllWithOpts(ctx context.Context, opts LoadBalancerListOpts) ([]*LoadBalancer, error) {
-	var allLoadBalancers []*LoadBalancer
+	allLoadBalancers := []*LoadBalancer{}
 
 	err := c.client.all(func(page int) (*Response, error) {
 		opts.Page = page

--- a/hcloud/load_balancer_type.go
+++ b/hcloud/load_balancer_type.go
@@ -113,7 +113,7 @@ func (c *LoadBalancerTypeClient) All(ctx context.Context) ([]*LoadBalancerType, 
 
 // AllWithOpts returns all Load Balancer types for the given options.
 func (c *LoadBalancerTypeClient) AllWithOpts(ctx context.Context, opts LoadBalancerTypeListOpts) ([]*LoadBalancerType, error) {
-	var allLoadBalancerTypes []*LoadBalancerType
+	allLoadBalancerTypes := []*LoadBalancerType{}
 
 	err := c.client.all(func(page int) (*Response, error) {
 		opts.Page = page

--- a/hcloud/location.go
+++ b/hcloud/location.go
@@ -113,7 +113,7 @@ func (c *LocationClient) All(ctx context.Context) ([]*Location, error) {
 
 // AllWithOpts returns all locations for the given options.
 func (c *LocationClient) AllWithOpts(ctx context.Context, opts LocationListOpts) ([]*Location, error) {
-	var allLocations []*Location
+	allLocations := []*Location{}
 
 	err := c.client.all(func(page int) (*Response, error) {
 		opts.Page = page

--- a/hcloud/network.go
+++ b/hcloud/network.go
@@ -162,7 +162,7 @@ func (c *NetworkClient) All(ctx context.Context) ([]*Network, error) {
 
 // AllWithOpts returns all networks for the given options.
 func (c *NetworkClient) AllWithOpts(ctx context.Context, opts NetworkListOpts) ([]*Network, error) {
-	var allNetworks []*Network
+	allNetworks := []*Network{}
 
 	err := c.client.all(func(page int) (*Response, error) {
 		opts.Page = page

--- a/hcloud/placement_group.go
+++ b/hcloud/placement_group.go
@@ -133,7 +133,7 @@ func (c *PlacementGroupClient) All(ctx context.Context) ([]*PlacementGroup, erro
 
 // AllWithOpts returns all PlacementGroups for the given options.
 func (c *PlacementGroupClient) AllWithOpts(ctx context.Context, opts PlacementGroupListOpts) ([]*PlacementGroup, error) {
-	var allPlacementGroups []*PlacementGroup
+	allPlacementGroups := []*PlacementGroup{}
 
 	err := c.client.all(func(page int) (*Response, error) {
 		opts.Page = page

--- a/hcloud/primary_ip.go
+++ b/hcloud/primary_ip.go
@@ -265,7 +265,7 @@ func (c *PrimaryIPClient) All(ctx context.Context) ([]*PrimaryIP, error) {
 
 // AllWithOpts returns all Primary IPs for the given options.
 func (c *PrimaryIPClient) AllWithOpts(ctx context.Context, opts PrimaryIPListOpts) ([]*PrimaryIP, error) {
-	var allPrimaryIPs []*PrimaryIP
+	allPrimaryIPs := []*PrimaryIP{}
 
 	err := c.client.all(func(page int) (*Response, error) {
 		opts.Page = page

--- a/hcloud/server_type.go
+++ b/hcloud/server_type.go
@@ -140,7 +140,7 @@ func (c *ServerTypeClient) All(ctx context.Context) ([]*ServerType, error) {
 
 // AllWithOpts returns all server types for the given options.
 func (c *ServerTypeClient) AllWithOpts(ctx context.Context, opts ServerTypeListOpts) ([]*ServerType, error) {
-	var allServerTypes []*ServerType
+	allServerTypes := []*ServerType{}
 
 	err := c.client.all(func(page int) (*Response, error) {
 		opts.Page = page


### PR DESCRIPTION
The clients `.All()` & `.AllWithOpts()` methods returned an inconsistent slice value when no resources were found. Some clients returned a `nil` slice while others returned an empty slice with 0 entries.

This makes sure that all methods return empty slices except if an actual error occured.