### PR TITLE
fix: include running action progress in WatchOverallProgress

### DIFF
--- a/hcloud/action_test.go
+++ b/hcloud/action_test.go
@@ -281,7 +281,7 @@ func TestActionClientWatchOverallProgress(t *testing.T) {
 		t.Fatalf("expected hcloud.Error, but got: %#v", err)
 	}
 
-	expectedProgressUpdates := []int{50}
+	expectedProgressUpdates := []int{50, 100}
 	if !reflect.DeepEqual(progressUpdates, expectedProgressUpdates) {
 		t.Fatalf("expected progresses %v but received %v", expectedProgressUpdates, progressUpdates)
 	}


### PR DESCRIPTION
Include the running action progress in the actions progress calculation.

The function now considers a failed action as completed, and is included in the progress. Not counting the failed action as completed might send some weird progress values e.g. [0%, 75%, (failed action occurs here) 50%], while if we count them, we should have [0%, 75%, 100%].



Related to https://github.com/hetznercloud/cli/issues/528