### PR TITLE
[Backport release-1.x] fix: send more precise progress values (#304)

### DIFF
--- a/hcloud/action.go
+++ b/hcloud/action.go
@@ -189,13 +189,15 @@ func (c *ActionClient) WatchOverallProgress(ctx context.Context, actions []*Acti
 		defer close(errCh)
 		defer close(progressCh)
 
-		successIDs := make([]int, 0, len(actions))
+		completedIDs := make([]int, 0, len(actions))
 		watchIDs := make(map[int]struct{}, len(actions))
+
 		for _, action := range actions {
 			watchIDs[action.ID] = struct{}{}
 		}
 
 		retries := 0
+		previousProgress := 0
 
 		for {
 			select {
@@ -224,18 +226,25 @@ func (c *ActionClient) WatchOverallProgress(ctx context.Context, actions []*Acti
 				return
 			}
 
+			progress := 0
 			for _, a := range as {
 				switch a.Status {
 				case ActionStatusRunning:
-					continue
+					progress += a.Progress
 				case ActionStatusSuccess:
 					delete(watchIDs, a.ID)
-					successIDs = append(successIDs, a.ID)
-					sendProgress(progressCh, int(float64(len(actions)-len(successIDs))/float64(len(actions))*100))
+					completedIDs = append(completedIDs, a.ID)
 				case ActionStatusError:
 					delete(watchIDs, a.ID)
+					completedIDs = append(completedIDs, a.ID)
 					errCh <- fmt.Errorf("action %d failed: %w", a.ID, a.Error())
 				}
+			}
+
+			progress += (len(completedIDs) * 100)
+			if progress != 0 && progress != previousProgress {
+				sendProgress(progressCh, int(progress/len(actions)))
+				previousProgress = progress
 			}
 
 			if len(watchIDs) == 0 {

--- a/hcloud/action_test.go
+++ b/hcloud/action_test.go
@@ -281,7 +281,7 @@ func TestActionClientWatchOverallProgress(t *testing.T) {
 		t.Fatalf("expected hcloud.Error, but got: %#v", err)
 	}
 
-	expectedProgressUpdates := []int{50}
+	expectedProgressUpdates := []int{50, 100}
 	if !reflect.DeepEqual(progressUpdates, expectedProgressUpdates) {
 		t.Fatalf("expected progresses %v but received %v", expectedProgressUpdates, progressUpdates)
 	}


### PR DESCRIPTION
Backport 867aa632521ad3acfb04beb52b6307330740fc68 from #304.