### PR TITLE
feat(error): include http response in api errors

### DIFF
--- a/hcloud/client.go
+++ b/hcloud/client.go
@@ -286,8 +286,8 @@ func (c *Client) Do(r *http.Request, v interface{}) (*Response, error) {
 			return response, fmt.Errorf("hcloud: error reading response meta data: %s", err)
 		}
 
-		if resp.StatusCode >= 400 && resp.StatusCode <= 599 {
-			err = errorFromResponse(resp, body)
+		if response.StatusCode >= 400 && response.StatusCode <= 599 {
+			err = errorFromResponse(response, body)
 			if err == nil {
 				err = fmt.Errorf("hcloud: server responded with status code %d", resp.StatusCode)
 			} else if IsError(err, ErrorCodeConflict) {
@@ -359,7 +359,7 @@ func dumpRequest(r *http.Request) ([]byte, error) {
 	return dumpReq, nil
 }
 
-func errorFromResponse(resp *http.Response, body []byte) error {
+func errorFromResponse(resp *Response, body []byte) error {
 	if !strings.HasPrefix(resp.Header.Get("Content-Type"), "application/json") {
 		return nil
 	}

--- a/hcloud/client.go
+++ b/hcloud/client.go
@@ -373,7 +373,7 @@ func errorFromResponse(resp *http.Response, body []byte) error {
 	}
 
 	hcErr := ErrorFromSchema(respBody.Error)
-	hcErr.HTTPStatusCode = resp.StatusCode
+	hcErr.response = resp
 	return hcErr
 }
 

--- a/hcloud/client.go
+++ b/hcloud/client.go
@@ -371,7 +371,10 @@ func errorFromResponse(resp *http.Response, body []byte) error {
 	if respBody.Error.Code == "" && respBody.Error.Message == "" {
 		return nil
 	}
-	return ErrorFromSchema(respBody.Error)
+
+	hcErr := ErrorFromSchema(respBody.Error)
+	hcErr.HTTPStatusCode = resp.StatusCode
+	return hcErr
 }
 
 // Response represents a response from the API. It embeds http.Response.

--- a/hcloud/client_test.go
+++ b/hcloud/client_test.go
@@ -85,8 +85,8 @@ func TestClientError(t *testing.T) {
 	if apiError.Message != "An error occurred" {
 		t.Errorf("unexpected error message: %q", apiError.Message)
 	}
-	if apiError.HTTPStatusCode != http.StatusUnprocessableEntity {
-		t.Errorf("unexpected http status code: %q", apiError.HTTPStatusCode)
+	if apiError.Response().StatusCode != http.StatusUnprocessableEntity {
+		t.Errorf("unexpected http status code: %q", apiError.Response().StatusCode)
 	}
 }
 

--- a/hcloud/client_test.go
+++ b/hcloud/client_test.go
@@ -85,6 +85,9 @@ func TestClientError(t *testing.T) {
 	if apiError.Message != "An error occurred" {
 		t.Errorf("unexpected error message: %q", apiError.Message)
 	}
+	if apiError.HTTPStatusCode != http.StatusUnprocessableEntity {
+		t.Errorf("unexpected http status code: %q", apiError.HTTPStatusCode)
+	}
 }
 
 func TestClientInvalidToken(t *testing.T) {

--- a/hcloud/error.go
+++ b/hcloud/error.go
@@ -3,6 +3,7 @@ package hcloud
 import (
 	"fmt"
 	"net"
+	"net/http"
 )
 
 // ErrorCode represents an error code returned from the API.
@@ -94,13 +95,17 @@ type Error struct {
 	Code    ErrorCode
 	Message string
 	Details interface{}
-	// HTTPStatusCode is the status code of the response that included the error.
-	// It can be converted to a user readable string using net/http.StatusText().
-	HTTPStatusCode int
+
+	response *http.Response
 }
 
 func (e Error) Error() string {
 	return fmt.Sprintf("%s (%s)", e.Message, e.Code)
+}
+
+// Response returns the error underlying HTTP response.
+func (e Error) Response() *http.Response {
+	return e.response
 }
 
 // ErrorDetailsInvalidInput contains the details of an 'invalid_input' error.

--- a/hcloud/error.go
+++ b/hcloud/error.go
@@ -94,6 +94,9 @@ type Error struct {
 	Code    ErrorCode
 	Message string
 	Details interface{}
+	// HTTPStatusCode is the status code of the response that included the error.
+	// It can be converted to a user readable string using net/http.StatusText().
+	HTTPStatusCode int
 }
 
 func (e Error) Error() string {

--- a/hcloud/error.go
+++ b/hcloud/error.go
@@ -3,7 +3,6 @@ package hcloud
 import (
 	"fmt"
 	"net"
-	"net/http"
 )
 
 // ErrorCode represents an error code returned from the API.
@@ -96,15 +95,15 @@ type Error struct {
 	Message string
 	Details interface{}
 
-	response *http.Response
+	response *Response
 }
 
 func (e Error) Error() string {
 	return fmt.Sprintf("%s (%s)", e.Message, e.Code)
 }
 
-// Response returns the error underlying HTTP response.
-func (e Error) Response() *http.Response {
+// Response returns the [Response] that contained the error if available.
+func (e Error) Response() *Response {
 	return e.response
 }
 


### PR DESCRIPTION
This allows us to show more useful information in debug logs in downstream projects. 