### PR TITLE
fix: ensure the pollBackoffFunc is correctly assigned

### DIFF
--- a/hcloud/client.go
+++ b/hcloud/client.go
@@ -125,7 +125,7 @@ func WithPollInterval(pollInterval time.Duration) ClientOption {
 // function when polling from the API.
 func WithPollBackoffFunc(f BackoffFunc) ClientOption {
 	return func(client *Client) {
-		client.backoffFunc = f
+		client.pollBackoffFunc = f
 	}
 }
 


### PR DESCRIPTION
We assign the custom poll back off function to the wrong variable `backoffFunc`, it should be stored in `pollBackoffFunc`.

https://github.com/hetznercloud/hcloud-go/blob/d6505ac13d68be8d52e9bfd8a483f68cf821a2f4/hcloud/client.go#L62

Related to https://github.com/hetznercloud/terraform-provider-hcloud/issues/761