### PR TITLE
feat(iso): support deprecation info API

### DIFF
--- a/hcloud/iso.go
+++ b/hcloud/iso.go
@@ -17,12 +17,9 @@ type ISO struct {
 	Description  string
 	Type         ISOType
 	Architecture *Architecture
-	Deprecated   time.Time
-}
-
-// IsDeprecated returns true if the ISO is deprecated.
-func (iso *ISO) IsDeprecated() bool {
-	return !iso.Deprecated.IsZero()
+	// Deprecated: Use [ISO.Deprecation] instead.
+	Deprecated time.Time
+	DeprecatableResource
 }
 
 // ISOType specifies the type of an ISO image.

--- a/hcloud/iso_test.go
+++ b/hcloud/iso_test.go
@@ -20,7 +20,7 @@ func TestISOIsDeprecated(t *testing.T) {
 
 	t.Run("deprecated", func(t *testing.T) {
 		iso := &ISO{
-			Deprecated: time.Now(),
+			DeprecatableResource: DeprecatableResource{Deprecation: &DeprecationInfo{Announced: time.Now()}},
 		}
 		if !iso.IsDeprecated() {
 			t.Errorf("unexpected value for IsDeprecated: %v", iso.IsDeprecated())

--- a/hcloud/schema.go
+++ b/hcloud/schema.go
@@ -124,6 +124,9 @@ func ISOFromSchema(s schema.ISO) *ISO {
 		Description: s.Description,
 		Type:        ISOType(s.Type),
 		Deprecated:  s.Deprecated,
+		DeprecatableResource: DeprecatableResource{
+			DeprecationFromSchema(s.Deprecation),
+		},
 	}
 	if s.Architecture != nil {
 		iso.Architecture = Ptr(Architecture(*s.Architecture))

--- a/hcloud/schema/iso.go
+++ b/hcloud/schema/iso.go
@@ -10,6 +10,7 @@ type ISO struct {
 	Type         string    `json:"type"`
 	Architecture *string   `json:"architecture"`
 	Deprecated   time.Time `json:"deprecated"`
+	DeprecatableResource
 }
 
 // ISOGetResponse defines the schema of the response when retrieving a single ISO.


### PR DESCRIPTION
See these changelog entries for the announcement:

- https://docs.hetzner.cloud/changelog#2023-10-12-deprecation-info-for-isos
- https://docs.hetzner.cloud/changelog#2023-10-12-field-deprecated-on-isos-is-now-deprecated

The removed function `func (iso *ISO) IsDeprecated() bool` will still be available, but through the `DeprecatableResource` embbeded struct. User code will still work as before, but use the new data source instead.