### PR TITLE
fix: make schemas consistent with API

### DIFF
--- a/hcloud/schema/image.go
+++ b/hcloud/schema/image.go
@@ -11,7 +11,7 @@ type Image struct {
 	Description  string            `json:"description"`
 	ImageSize    *float32          `json:"image_size"`
 	DiskSize     float32           `json:"disk_size"`
-	Created      time.Time         `json:"created"`
+	Created      *time.Time        `json:"created"`
 	CreatedFrom  *ImageCreatedFrom `json:"created_from"`
 	BoundTo      *int64            `json:"bound_to"`
 	OSFlavor     string            `json:"os_flavor"`
@@ -19,8 +19,8 @@ type Image struct {
 	Architecture string            `json:"architecture"`
 	RapidDeploy  bool              `json:"rapid_deploy"`
 	Protection   ImageProtection   `json:"protection"`
-	Deprecated   time.Time         `json:"deprecated"`
-	Deleted      time.Time         `json:"deleted"`
+	Deprecated   *time.Time        `json:"deprecated"`
+	Deleted      *time.Time        `json:"deleted"`
 	Labels       map[string]string `json:"labels"`
 }
 

--- a/hcloud/schema/iso.go
+++ b/hcloud/schema/iso.go
@@ -4,12 +4,12 @@ import "time"
 
 // ISO defines the schema of an ISO image.
 type ISO struct {
-	ID           int64     `json:"id"`
-	Name         string    `json:"name"`
-	Description  string    `json:"description"`
-	Type         string    `json:"type"`
-	Architecture *string   `json:"architecture"`
-	Deprecated   time.Time `json:"deprecated"`
+	ID           int64      `json:"id"`
+	Name         string     `json:"name"`
+	Description  string     `json:"description"`
+	Type         string     `json:"type"`
+	Architecture *string    `json:"architecture"`
+	Deprecated   *time.Time `json:"deprecated"`
 	DeprecatableResource
 }
 

--- a/hcloud/schema/server_type.go
+++ b/hcloud/schema/server_type.go
@@ -13,6 +13,7 @@ type ServerType struct {
 	Architecture    string                   `json:"architecture"`
 	IncludedTraffic int64                    `json:"included_traffic"`
 	Prices          []PricingServerTypePrice `json:"prices"`
+	Deprecated      bool                     `json:"deprecated"`
 	DeprecatableResource
 }
 

--- a/hcloud/schema_gen.go
+++ b/hcloud/schema_gen.go
@@ -149,11 +149,16 @@ type converter interface {
 	ServerTypeFromSchema(schema.ServerType) *ServerType
 
 	// goverter:map Pricings Prices
+	// goverter:map DeprecatableResource.Deprecation Deprecated | isDeprecationNotNil
 	SchemaFromServerType(*ServerType) schema.ServerType
 
 	ImageFromSchema(schema.Image) *Image
 
 	SchemaFromImage(*Image) schema.Image
+
+	// Needed because of how goverter works internally, see https://github.com/jmattheis/goverter/issues/114
+	// goverter:map ImageSize | mapZeroFloat32ToNil
+	intSchemaFromImage(Image) schema.Image
 
 	// goverter:ignore Currency
 	// goverter:ignore VATRate
@@ -905,4 +910,16 @@ func rawSchemaFromErrorDetails(v interface{}) json.RawMessage {
 	}
 	msg, _ := json.Marshal(d)
 	return msg
+}
+
+func mapZeroFloat32ToNil(f float32) *float32 {
+	fmt.Println(f)
+	if f == 0 {
+		return nil
+	}
+	return &f
+}
+
+func isDeprecationNotNil(d *DeprecationInfo) bool {
+	return d != nil
 }


### PR DESCRIPTION
In some places the schema definitions are not consistent with the API documentation, for example properties may not have pointer receivers even though they are marked as optional in the documentation. This results in inconsistent JSON when converting `JSON -> Schema -> JSON` (as seen for example in https://github.com/hetznercloud/cli/issues/461, where one output is the exact API response and one is serialized and then converted back to JSON).

This PR aims to fix this issue by making the schema definitions consistent.