### PR TITLE
feat: alias deprecated field to deprecation info struct

### DIFF
--- a/hcloud/schema/iso.go
+++ b/hcloud/schema/iso.go
@@ -1,15 +1,12 @@
 package schema
 
-import "time"
-
 // ISO defines the schema of an ISO image.
 type ISO struct {
-	ID           int64      `json:"id"`
-	Name         string     `json:"name"`
-	Description  string     `json:"description"`
-	Type         string     `json:"type"`
-	Architecture *string    `json:"architecture"`
-	Deprecated   *time.Time `json:"deprecated"`
+	ID           int64   `json:"id"`
+	Name         string  `json:"name"`
+	Description  string  `json:"description"`
+	Type         string  `json:"type"`
+	Architecture *string `json:"architecture"`
 	DeprecatableResource
 }
 

--- a/hcloud/schema_gen.go
+++ b/hcloud/schema_gen.go
@@ -107,7 +107,19 @@ type converter interface {
 
 	ISOFromSchema(schema.ISO) *ISO
 
+	// We cannot use goverter settings when mapping a struct to a struct pointer
+	// See [converter.ISOFromSchema]
+	// See https://github.com/jmattheis/goverter/issues/114
+	// goverter:map DeprecatableResource.Deprecation.UnavailableAfter Deprecated
+	intISOFromSchema(schema.ISO) ISO
+
 	SchemaFromISO(*ISO) schema.ISO
+
+	// We cannot use goverter settings when mapping a struct to a struct pointer
+	// See [converter.SchemaFromISO]
+	// See https://github.com/jmattheis/goverter/issues/114
+	// goverter:map DeprecatableResource.Deprecation.UnavailableAfter Deprecated
+	intSchemaFromISO(ISO) schema.ISO
 
 	LocationFromSchema(schema.Location) *Location
 

--- a/hcloud/schema_gen.go
+++ b/hcloud/schema_gen.go
@@ -115,12 +115,6 @@ type converter interface {
 
 	SchemaFromISO(*ISO) schema.ISO
 
-	// We cannot use goverter settings when mapping a struct to a struct pointer
-	// See [converter.SchemaFromISO]
-	// See https://github.com/jmattheis/goverter/issues/114
-	// goverter:map DeprecatableResource.Deprecation.UnavailableAfter Deprecated
-	intSchemaFromISO(ISO) schema.ISO
-
 	LocationFromSchema(schema.Location) *Location
 
 	SchemaFromLocation(*Location) schema.Location

--- a/hcloud/schema_test.go
+++ b/hcloud/schema_test.go
@@ -249,22 +249,38 @@ func TestPrimaryIPSchema(t *testing.T) {
 }
 
 func TestISOSchema(t *testing.T) {
-	data := []byte(`{
-		"id": 4711,
-		"name": "FreeBSD-11.0-RELEASE-amd64-dvd1",
-		"description": "FreeBSD 11.0 x64",
-		"type": "public",
-		"architecture": "x86",
-		"deprecated": "2018-02-28T00:00:00+00:00"
-	}`)
+	for name, tc := range map[string]string{
+		"without deprecation": `{
+			"id": 4711,
+			"name": "FreeBSD-11.0-RELEASE-amd64-dvd1",
+			"description": "FreeBSD 11.0 x64",
+			"type": "public",
+			"architecture": "x86"
+		}`,
+		"with deprecation": `{
+			"id": 4711,
+			"name": "FreeBSD-11.0-RELEASE-amd64-dvd1",
+			"description": "FreeBSD 11.0 x64",
+			"type": "public",
+			"architecture": "x86",
+			"deprecation": {
+				"announced": "2018-01-28T00:00:00+00:00",
+				"unavailable_after": "2018-04-28T00:00:00+00:00"
+			},
+			"deprecated": "2018-04-28T00:00:00+00:00"
+		}`,
+	} {
+		t.Run(name, func(t *testing.T) {
+			data := []byte(tc)
+			var s schema.ISO
+			assert.NoError(t, json.Unmarshal(data, &s))
 
-	var s schema.ISO
-	assert.NoError(t, json.Unmarshal(data, &s))
+			assert.Equal(t, s, SchemaFromISO(ISOFromSchema(s)))
 
-	assert.Equal(t, s, SchemaFromISO(ISOFromSchema(s)))
-
-	iso := ISOFromSchema(s)
-	assert.Equal(t, iso, ISOFromSchema(SchemaFromISO(iso)))
+			iso := ISOFromSchema(s)
+			assert.Equal(t, iso, ISOFromSchema(SchemaFromISO(iso)))
+		})
+	}
 }
 
 func TestDatacenterSchema(t *testing.T) {

--- a/hcloud/zz_schema.go
+++ b/hcloud/zz_schema.go
@@ -673,7 +673,19 @@ func (c *converterImpl) SchemaFromFloatingIP(source *FloatingIP) schema.Floating
 func (c *converterImpl) SchemaFromISO(source *ISO) schema.ISO {
 	var schemaISO schema.ISO
 	if source != nil {
-		schemaISO = c.intSchemaFromISO((*source))
+		var schemaISO2 schema.ISO
+		schemaISO2.ID = (*source).ID
+		schemaISO2.Name = (*source).Name
+		schemaISO2.Description = (*source).Description
+		schemaISO2.Type = string((*source).Type)
+		var pString *string
+		if (*source).Architecture != nil {
+			xstring := string(*(*source).Architecture)
+			pString = &xstring
+		}
+		schemaISO2.Architecture = pString
+		schemaISO2.DeprecatableResource = c.hcloudDeprecatableResourceToSchemaDeprecatableResource((*source).DeprecatableResource)
+		schemaISO = schemaISO2
 	}
 	return schemaISO
 }
@@ -1585,26 +1597,6 @@ func (c *converterImpl) intISOFromSchema(source schema.ISO) ISO {
 	hcloudISO.DeprecatableResource = c.schemaDeprecatableResourceToHcloudDeprecatableResource(source.DeprecatableResource)
 	return hcloudISO
 }
-func (c *converterImpl) intSchemaFromISO(source ISO) schema.ISO {
-	var schemaISO schema.ISO
-	schemaISO.ID = source.ID
-	schemaISO.Name = source.Name
-	schemaISO.Description = source.Description
-	schemaISO.Type = string(source.Type)
-	var pString *string
-	if source.Architecture != nil {
-		xstring := string(*source.Architecture)
-		pString = &xstring
-	}
-	schemaISO.Architecture = pString
-	var pTimeTime *time.Time
-	if source.DeprecatableResource.Deprecation != nil {
-		pTimeTime = &source.DeprecatableResource.Deprecation.UnavailableAfter
-	}
-	schemaISO.Deprecated = pTimeTime
-	schemaISO.DeprecatableResource = c.hcloudDeprecatableResourceToSchemaDeprecatableResource(source.DeprecatableResource)
-	return schemaISO
-}
 func (c *converterImpl) intSchemaFromImage(source Image) schema.Image {
 	var schemaImage schema.Image
 	schemaImage.ID = source.ID
@@ -1679,7 +1671,18 @@ func (c *converterImpl) pHcloudFirewallResourceServerToPSchemaFirewallResourceSe
 func (c *converterImpl) pHcloudISOToPSchemaISO(source *ISO) *schema.ISO {
 	var pSchemaISO *schema.ISO
 	if source != nil {
-		schemaISO := c.intSchemaFromISO((*source))
+		var schemaISO schema.ISO
+		schemaISO.ID = (*source).ID
+		schemaISO.Name = (*source).Name
+		schemaISO.Description = (*source).Description
+		schemaISO.Type = string((*source).Type)
+		var pString *string
+		if (*source).Architecture != nil {
+			xstring := string(*(*source).Architecture)
+			pString = &xstring
+		}
+		schemaISO.Architecture = pString
+		schemaISO.DeprecatableResource = c.hcloudDeprecatableResourceToSchemaDeprecatableResource((*source).DeprecatableResource)
 		pSchemaISO = &schemaISO
 	}
 	return pSchemaISO

--- a/hcloud/zz_schema.go
+++ b/hcloud/zz_schema.go
@@ -157,19 +157,7 @@ func (c *converterImpl) FloatingIPFromSchema(source schema.FloatingIP) *Floating
 	return &hcloudFloatingIP
 }
 func (c *converterImpl) ISOFromSchema(source schema.ISO) *ISO {
-	var hcloudISO ISO
-	hcloudISO.ID = source.ID
-	hcloudISO.Name = source.Name
-	hcloudISO.Description = source.Description
-	hcloudISO.Type = ISOType(source.Type)
-	var pHcloudArchitecture *Architecture
-	if source.Architecture != nil {
-		hcloudArchitecture := Architecture(*source.Architecture)
-		pHcloudArchitecture = &hcloudArchitecture
-	}
-	hcloudISO.Architecture = pHcloudArchitecture
-	hcloudISO.Deprecated = c.pTimeTimeToTimeTime(source.Deprecated)
-	hcloudISO.DeprecatableResource = c.schemaDeprecatableResourceToHcloudDeprecatableResource(source.DeprecatableResource)
+	hcloudISO := c.intISOFromSchema(source)
 	return &hcloudISO
 }
 func (c *converterImpl) ImageFromSchema(source schema.Image) *Image {
@@ -685,20 +673,7 @@ func (c *converterImpl) SchemaFromFloatingIP(source *FloatingIP) schema.Floating
 func (c *converterImpl) SchemaFromISO(source *ISO) schema.ISO {
 	var schemaISO schema.ISO
 	if source != nil {
-		var schemaISO2 schema.ISO
-		schemaISO2.ID = (*source).ID
-		schemaISO2.Name = (*source).Name
-		schemaISO2.Description = (*source).Description
-		schemaISO2.Type = string((*source).Type)
-		var pString *string
-		if (*source).Architecture != nil {
-			xstring := string(*(*source).Architecture)
-			pString = &xstring
-		}
-		schemaISO2.Architecture = pString
-		schemaISO2.Deprecated = timeToTimePtr((*source).Deprecated)
-		schemaISO2.DeprecatableResource = c.hcloudDeprecatableResourceToSchemaDeprecatableResource((*source).DeprecatableResource)
-		schemaISO = schemaISO2
+		schemaISO = c.intSchemaFromISO((*source))
 	}
 	return schemaISO
 }
@@ -1590,6 +1565,46 @@ func (c *converterImpl) hcloudVolumeProtectionToSchemaVolumeProtection(source Vo
 	schemaVolumeProtection.Delete = source.Delete
 	return schemaVolumeProtection
 }
+func (c *converterImpl) intISOFromSchema(source schema.ISO) ISO {
+	var hcloudISO ISO
+	hcloudISO.ID = source.ID
+	hcloudISO.Name = source.Name
+	hcloudISO.Description = source.Description
+	hcloudISO.Type = ISOType(source.Type)
+	var pHcloudArchitecture *Architecture
+	if source.Architecture != nil {
+		hcloudArchitecture := Architecture(*source.Architecture)
+		pHcloudArchitecture = &hcloudArchitecture
+	}
+	hcloudISO.Architecture = pHcloudArchitecture
+	var pTimeTime *time.Time
+	if source.DeprecatableResource.Deprecation != nil {
+		pTimeTime = &source.DeprecatableResource.Deprecation.UnavailableAfter
+	}
+	hcloudISO.Deprecated = c.pTimeTimeToTimeTime(pTimeTime)
+	hcloudISO.DeprecatableResource = c.schemaDeprecatableResourceToHcloudDeprecatableResource(source.DeprecatableResource)
+	return hcloudISO
+}
+func (c *converterImpl) intSchemaFromISO(source ISO) schema.ISO {
+	var schemaISO schema.ISO
+	schemaISO.ID = source.ID
+	schemaISO.Name = source.Name
+	schemaISO.Description = source.Description
+	schemaISO.Type = string(source.Type)
+	var pString *string
+	if source.Architecture != nil {
+		xstring := string(*source.Architecture)
+		pString = &xstring
+	}
+	schemaISO.Architecture = pString
+	var pTimeTime *time.Time
+	if source.DeprecatableResource.Deprecation != nil {
+		pTimeTime = &source.DeprecatableResource.Deprecation.UnavailableAfter
+	}
+	schemaISO.Deprecated = pTimeTime
+	schemaISO.DeprecatableResource = c.hcloudDeprecatableResourceToSchemaDeprecatableResource(source.DeprecatableResource)
+	return schemaISO
+}
 func (c *converterImpl) intSchemaFromImage(source Image) schema.Image {
 	var schemaImage schema.Image
 	schemaImage.ID = source.ID
@@ -1664,19 +1679,7 @@ func (c *converterImpl) pHcloudFirewallResourceServerToPSchemaFirewallResourceSe
 func (c *converterImpl) pHcloudISOToPSchemaISO(source *ISO) *schema.ISO {
 	var pSchemaISO *schema.ISO
 	if source != nil {
-		var schemaISO schema.ISO
-		schemaISO.ID = (*source).ID
-		schemaISO.Name = (*source).Name
-		schemaISO.Description = (*source).Description
-		schemaISO.Type = string((*source).Type)
-		var pString *string
-		if (*source).Architecture != nil {
-			xstring := string(*(*source).Architecture)
-			pString = &xstring
-		}
-		schemaISO.Architecture = pString
-		schemaISO.Deprecated = timeToTimePtr((*source).Deprecated)
-		schemaISO.DeprecatableResource = c.hcloudDeprecatableResourceToSchemaDeprecatableResource((*source).DeprecatableResource)
+		schemaISO := c.intSchemaFromISO((*source))
 		pSchemaISO = &schemaISO
 	}
 	return pSchemaISO
@@ -2046,19 +2049,7 @@ func (c *converterImpl) pSchemaFirewallResourceServerToPHcloudFirewallResourceSe
 func (c *converterImpl) pSchemaISOToPHcloudISO(source *schema.ISO) *ISO {
 	var pHcloudISO *ISO
 	if source != nil {
-		var hcloudISO ISO
-		hcloudISO.ID = (*source).ID
-		hcloudISO.Name = (*source).Name
-		hcloudISO.Description = (*source).Description
-		hcloudISO.Type = ISOType((*source).Type)
-		var pHcloudArchitecture *Architecture
-		if (*source).Architecture != nil {
-			hcloudArchitecture := Architecture(*(*source).Architecture)
-			pHcloudArchitecture = &hcloudArchitecture
-		}
-		hcloudISO.Architecture = pHcloudArchitecture
-		hcloudISO.Deprecated = c.pTimeTimeToTimeTime((*source).Deprecated)
-		hcloudISO.DeprecatableResource = c.schemaDeprecatableResourceToHcloudDeprecatableResource((*source).DeprecatableResource)
+		hcloudISO := c.intISOFromSchema((*source))
 		pHcloudISO = &hcloudISO
 	}
 	return pHcloudISO


### PR DESCRIPTION
Try to mitigate the removal of the deprecated field from the API, by linking the `deprecated` field value to the deprecation info object.
 