### PR TITLE
feat(server): deprecate ServerRescueTypeLinux32

### DIFF
--- a/hcloud/server.go
+++ b/hcloud/server.go
@@ -147,6 +147,7 @@ type ServerRescueType string
 
 // List of rescue types.
 const (
+	// Deprecated: Use ServerRescueTypeLinux64 instead.
 	ServerRescueTypeLinux32 ServerRescueType = "linux32"
 	ServerRescueTypeLinux64 ServerRescueType = "linux64"
 )


### PR DESCRIPTION
The `linux32` type is no longer allowed when enabling rescue mode ([See docs](https://docs.hetzner.cloud/changelog#2024-01-08-server-action-enable-rescue-no-longer-supports-32bit))