### PR TITLE
feat: require Go >= 1.20

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,9 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: ["1.19", "1.20", "1.21"]
+        go-version:
+          - "1.20"
+          - "1.21"
 
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,16 +30,16 @@ jobs:
 
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
-    - uses: actions/setup-go@v5
-      with:
-        go-version: ${{ matrix.go-version }}
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: ${{ matrix.go-version }}
 
-    - run: go test -coverprofile=coverage.txt -v -race ./...
+      - run: go test -coverprofile=coverage.txt -v -race ./...
 
-    - uses: codecov/codecov-action@v4
-      with:
-        token: ${{ secrets.CODECOV_TOKEN }}
+      - uses: codecov/codecov-action@v4
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
 
   generate:
     runs-on: ubuntu-latest

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ module github.com/hetznercloud/hcloud-go/v2
 // all dependends to update to the new version.
 // As long as we do not depend on any newer language feature this can be kept at the current value.
 // It should never be higher than the lowest currently supported version of Go.
-go 1.19
+go 1.20
 
 require (
 	github.com/google/go-cmp v0.6.0


### PR DESCRIPTION
This follows our Go version policy https://github.com/hetznercloud/hcloud-go#go-version-support, but we don't want to force an unjustified go version upgrade for users of this library, so we only require go 1.20 instead of go 1.21.

The prometheus client_golang bumped the required go version to 1.20, we need to follow to be able to upgrade this dependency: https://github.com/hetznercloud/hcloud-go/pull/388