### PR TITLE
fix: LoadBalancerUpdateServiceOpts not converted correctly

### DIFF
--- a/hcloud/schema_gen.go
+++ b/hcloud/schema_gen.go
@@ -78,6 +78,8 @@ You can find a documentation of goverter here: https://goverter.jmattheis.de/
 // goverter:extend schemaFromLoadBalancerCreateOptsTargetServer
 // goverter:extend schemaFromLoadBalancerCreateOptsTargetIP
 // goverter:extend stringMapToStringMapPtr
+// goverter:extend int64SlicePtrFromCertificatePtrSlice
+// goverter:extend stringSlicePtrFromStringSlice
 type converter interface {
 
 	// goverter:map Error.Code ErrorCode
@@ -925,4 +927,23 @@ func mapZeroFloat32ToNil(f float32) *float32 {
 
 func isDeprecationNotNil(d *DeprecationInfo) bool {
 	return d != nil
+}
+
+// this is needed so that a nil slice is mapped to nil instead of &nil
+func int64SlicePtrFromCertificatePtrSlice(s []*Certificate) *[]int64 {
+	if s == nil {
+		return nil
+	}
+	var ids = make([]int64, len(s))
+	for i, cert := range s {
+		ids[i] = cert.ID
+	}
+	return &ids
+}
+
+func stringSlicePtrFromStringSlice(s []string) *[]string {
+	if s == nil {
+		return nil
+	}
+	return &s
 }

--- a/hcloud/schema_gen.go
+++ b/hcloud/schema_gen.go
@@ -929,7 +929,7 @@ func isDeprecationNotNil(d *DeprecationInfo) bool {
 	return d != nil
 }
 
-// this is needed so that a nil slice is mapped to nil instead of &nil
+// int64SlicePtrFromCertificatePtrSlice is needed so that a nil slice is mapped to nil instead of &nil.
 func int64SlicePtrFromCertificatePtrSlice(s []*Certificate) *[]int64 {
 	if s == nil {
 		return nil

--- a/hcloud/schema_test.go
+++ b/hcloud/schema_test.go
@@ -1797,8 +1797,18 @@ func TestLoadBalancerUpdateServiceOptsToSchema(t *testing.T) {
 		Request schema.LoadBalancerActionUpdateServiceRequest
 	}{
 		"empty": {
-			Opts:    LoadBalancerUpdateServiceOpts{},
-			Request: schema.LoadBalancerActionUpdateServiceRequest{},
+			Opts: LoadBalancerUpdateServiceOpts{
+				HTTP: &LoadBalancerUpdateServiceOptsHTTP{},
+				HealthCheck: &LoadBalancerUpdateServiceOptsHealthCheck{
+					HTTP: &LoadBalancerUpdateServiceOptsHealthCheckHTTP{},
+				},
+			},
+			Request: schema.LoadBalancerActionUpdateServiceRequest{
+				HTTP: &schema.LoadBalancerActionUpdateServiceRequestHTTP{},
+				HealthCheck: &schema.LoadBalancerActionUpdateServiceRequestHealthCheck{
+					HTTP: &schema.LoadBalancerActionUpdateServiceRequestHealthCheckHTTP{},
+				},
+			},
 		},
 		"all set": {
 			Opts: LoadBalancerUpdateServiceOpts{

--- a/hcloud/zz_schema.go
+++ b/hcloud/zz_schema.go
@@ -1706,14 +1706,7 @@ func (c *converterImpl) pHcloudLoadBalancerAddServiceOptsHTTPToPSchemaLoadBalanc
 			pInt = &xint
 		}
 		schemaLoadBalancerActionAddServiceRequestHTTP.CookieLifetime = pInt
-		var int64List []int64
-		if (*source).Certificates != nil {
-			int64List = make([]int64, len((*source).Certificates))
-			for i := 0; i < len((*source).Certificates); i++ {
-				int64List[i] = int64FromCertificate((*source).Certificates[i])
-			}
-		}
-		schemaLoadBalancerActionAddServiceRequestHTTP.Certificates = &int64List
+		schemaLoadBalancerActionAddServiceRequestHTTP.Certificates = int64SlicePtrFromCertificatePtrSlice((*source).Certificates)
 		schemaLoadBalancerActionAddServiceRequestHTTP.RedirectHTTP = (*source).RedirectHTTP
 		schemaLoadBalancerActionAddServiceRequestHTTP.StickySessions = (*source).StickySessions
 		pSchemaLoadBalancerActionAddServiceRequestHTTP = &schemaLoadBalancerActionAddServiceRequestHTTP
@@ -1727,7 +1720,7 @@ func (c *converterImpl) pHcloudLoadBalancerAddServiceOptsHealthCheckHTTPToPSchem
 		schemaLoadBalancerActionAddServiceRequestHealthCheckHTTP.Domain = (*source).Domain
 		schemaLoadBalancerActionAddServiceRequestHealthCheckHTTP.Path = (*source).Path
 		schemaLoadBalancerActionAddServiceRequestHealthCheckHTTP.Response = (*source).Response
-		schemaLoadBalancerActionAddServiceRequestHealthCheckHTTP.StatusCodes = &(*source).StatusCodes
+		schemaLoadBalancerActionAddServiceRequestHealthCheckHTTP.StatusCodes = stringSlicePtrFromStringSlice((*source).StatusCodes)
 		schemaLoadBalancerActionAddServiceRequestHealthCheckHTTP.TLS = (*source).TLS
 		pSchemaLoadBalancerActionAddServiceRequestHealthCheckHTTP = &schemaLoadBalancerActionAddServiceRequestHealthCheckHTTP
 	}
@@ -1777,14 +1770,7 @@ func (c *converterImpl) pHcloudLoadBalancerCreateOptsServiceHTTPToPSchemaLoadBal
 			pInt = &xint
 		}
 		schemaLoadBalancerCreateRequestServiceHTTP.CookieLifetime = pInt
-		var int64List []int64
-		if (*source).Certificates != nil {
-			int64List = make([]int64, len((*source).Certificates))
-			for i := 0; i < len((*source).Certificates); i++ {
-				int64List[i] = int64FromCertificate((*source).Certificates[i])
-			}
-		}
-		schemaLoadBalancerCreateRequestServiceHTTP.Certificates = &int64List
+		schemaLoadBalancerCreateRequestServiceHTTP.Certificates = int64SlicePtrFromCertificatePtrSlice((*source).Certificates)
 		schemaLoadBalancerCreateRequestServiceHTTP.RedirectHTTP = (*source).RedirectHTTP
 		schemaLoadBalancerCreateRequestServiceHTTP.StickySessions = (*source).StickySessions
 		pSchemaLoadBalancerCreateRequestServiceHTTP = &schemaLoadBalancerCreateRequestServiceHTTP
@@ -1798,7 +1784,7 @@ func (c *converterImpl) pHcloudLoadBalancerCreateOptsServiceHealthCheckHTTPToPSc
 		schemaLoadBalancerCreateRequestServiceHealthCheckHTTP.Domain = (*source).Domain
 		schemaLoadBalancerCreateRequestServiceHealthCheckHTTP.Path = (*source).Path
 		schemaLoadBalancerCreateRequestServiceHealthCheckHTTP.Response = (*source).Response
-		schemaLoadBalancerCreateRequestServiceHealthCheckHTTP.StatusCodes = &(*source).StatusCodes
+		schemaLoadBalancerCreateRequestServiceHealthCheckHTTP.StatusCodes = stringSlicePtrFromStringSlice((*source).StatusCodes)
 		schemaLoadBalancerCreateRequestServiceHealthCheckHTTP.TLS = (*source).TLS
 		pSchemaLoadBalancerCreateRequestServiceHealthCheckHTTP = &schemaLoadBalancerCreateRequestServiceHealthCheckHTTP
 	}
@@ -1885,14 +1871,7 @@ func (c *converterImpl) pHcloudLoadBalancerUpdateServiceOptsHTTPToPSchemaLoadBal
 			pInt = &xint
 		}
 		schemaLoadBalancerActionUpdateServiceRequestHTTP.CookieLifetime = pInt
-		var int64List []int64
-		if (*source).Certificates != nil {
-			int64List = make([]int64, len((*source).Certificates))
-			for i := 0; i < len((*source).Certificates); i++ {
-				int64List[i] = int64FromCertificate((*source).Certificates[i])
-			}
-		}
-		schemaLoadBalancerActionUpdateServiceRequestHTTP.Certificates = &int64List
+		schemaLoadBalancerActionUpdateServiceRequestHTTP.Certificates = int64SlicePtrFromCertificatePtrSlice((*source).Certificates)
 		schemaLoadBalancerActionUpdateServiceRequestHTTP.RedirectHTTP = (*source).RedirectHTTP
 		schemaLoadBalancerActionUpdateServiceRequestHTTP.StickySessions = (*source).StickySessions
 		pSchemaLoadBalancerActionUpdateServiceRequestHTTP = &schemaLoadBalancerActionUpdateServiceRequestHTTP
@@ -1906,7 +1885,7 @@ func (c *converterImpl) pHcloudLoadBalancerUpdateServiceOptsHealthCheckHTTPToPSc
 		schemaLoadBalancerActionUpdateServiceRequestHealthCheckHTTP.Domain = (*source).Domain
 		schemaLoadBalancerActionUpdateServiceRequestHealthCheckHTTP.Path = (*source).Path
 		schemaLoadBalancerActionUpdateServiceRequestHealthCheckHTTP.Response = (*source).Response
-		schemaLoadBalancerActionUpdateServiceRequestHealthCheckHTTP.StatusCodes = &(*source).StatusCodes
+		schemaLoadBalancerActionUpdateServiceRequestHealthCheckHTTP.StatusCodes = stringSlicePtrFromStringSlice((*source).StatusCodes)
 		schemaLoadBalancerActionUpdateServiceRequestHealthCheckHTTP.TLS = (*source).TLS
 		pSchemaLoadBalancerActionUpdateServiceRequestHealthCheckHTTP = &schemaLoadBalancerActionUpdateServiceRequestHealthCheckHTTP
 	}


### PR DESCRIPTION
In the conversion from LoadBalancerUpdateServiceOpts to schema.LoadBalancerActionUpdateServiceRequest, there are conversions from slices to slice pointers. Slice pointers exist in schemas to differentiate between absent and empty.

Goverter converts nil slices to &nil. This leads to the field being marshaled to `null` in JSON (even with the `omitempty` flag) instead of being not present (See https://github.com/hetznercloud/cli/issues/702)

This PR fixes this issue by adding manual conversion methods and adds tests to account for this behavior.