### PR TITLE
feat: add volume format property

### DIFF
--- a/hcloud/schema/volume.go
+++ b/hcloud/schema/volume.go
@@ -10,6 +10,7 @@ type Volume struct {
 	Status      string            `json:"status"`
 	Location    Location          `json:"location"`
 	Size        int               `json:"size"`
+	Format      *string           `json:"format"`
 	Protection  VolumeProtection  `json:"protection"`
 	Labels      map[string]string `json:"labels"`
 	LinuxDevice string            `json:"linux_device"`

--- a/hcloud/schema_test.go
+++ b/hcloud/schema_test.go
@@ -662,6 +662,7 @@ func TestVolumeSchema(t *testing.T) {
 		"name": "db-storage",
 		"status": "creating",
 		"server": 2,
+		"format": "xfs",
 		"location": {
 			"id": 1,
 			"name": "fsn1",

--- a/hcloud/volume.go
+++ b/hcloud/volume.go
@@ -30,7 +30,7 @@ type Volume struct {
 
 const (
 	VolumeFormatExt4 = "ext4"
-	VolumeFormatXfs  = "xfs"
+	VolumeFormatXFS  = "xfs"
 )
 
 // VolumeProtection represents the protection level of a volume.

--- a/hcloud/volume.go
+++ b/hcloud/volume.go
@@ -21,11 +21,17 @@ type Volume struct {
 	Server      *Server
 	Location    *Location
 	Size        int
+	Format      *string
 	Protection  VolumeProtection
 	Labels      map[string]string
 	LinuxDevice string
 	Created     time.Time
 }
+
+const (
+	VolumeFormatExt4 = "ext4"
+	VolumeFormatXfs  = "xfs"
+)
 
 // VolumeProtection represents the protection level of a volume.
 type VolumeProtection struct {

--- a/hcloud/zz_schema.go
+++ b/hcloud/zz_schema.go
@@ -1215,6 +1215,7 @@ func (c *converterImpl) SchemaFromVolume(source *Volume) schema.Volume {
 		schemaVolume2.Status = string((*source).Status)
 		schemaVolume2.Location = c.SchemaFromLocation((*source).Location)
 		schemaVolume2.Size = (*source).Size
+		schemaVolume2.Format = (*source).Format
 		schemaVolume2.Protection = c.hcloudVolumeProtectionToSchemaVolumeProtection((*source).Protection)
 		schemaVolume2.Labels = (*source).Labels
 		schemaVolume2.LinuxDevice = (*source).LinuxDevice
@@ -1397,6 +1398,7 @@ func (c *converterImpl) VolumeFromSchema(source schema.Volume) *Volume {
 	hcloudVolume.Server = pHcloudServer
 	hcloudVolume.Location = c.LocationFromSchema(source.Location)
 	hcloudVolume.Size = source.Size
+	hcloudVolume.Format = source.Format
 	hcloudVolume.Protection = c.schemaVolumeProtectionToHcloudVolumeProtection(source.Protection)
 	hcloudVolume.Labels = source.Labels
 	hcloudVolume.LinuxDevice = source.LinuxDevice


### PR DESCRIPTION
This property was previously missing, although it was already used in VolumeCreateOpts. It's now a string pointer with common values (ext4 and xfs) available as string constants.