### PR TITLE
docs: installation command in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,12 @@ Package hcloud is a library for the Hetzner Cloud API.
 The library’s documentation is available at [pkg.go.dev](https://godoc.org/github.com/hetznercloud/hcloud-go/v2/hcloud),
 the public API documentation is available at [docs.hetzner.cloud](https://docs.hetzner.cloud/).
 
+## Installation
+
+```sh
+go get github.com/hetznercloud/hcloud-go/v2/hcloud
+```
+
 ## Example
 
 ```go


### PR DESCRIPTION
This makes it easy to install the correct dependency, as it deviates from our GitHub URL (`github.com/hetznercloud/hcloud-go` vs `github.com/hetznercloud/hcloud-go/v2/hcloud`)