### PR TITLE
feat: implement actions waiter

### DIFF
--- a/hcloud/action_waiter.go
+++ b/hcloud/action_waiter.go
@@ -15,8 +15,9 @@ type ActionWaiter interface {
 
 var _ ActionWaiter = (*ActionClient)(nil)
 
-// WaitForActions waits until all actions completed (succeeded or failed) by pooling the
-// API at the interval defined by [WithPollBackoffFunc].
+// WaitForFunc waits until all actions are completed by polling the API at the interval
+// defined by [WithPollBackoffFunc]. An action is considered as complete when its status is
+// either [ActionStatusSuccess] or [ActionStatusError].
 //
 // The handleUpdate callback is called every time an action is updated.
 func (c *ActionClient) WaitForFunc(ctx context.Context, handleUpdate func(update *Action) error, actions ...*Action) error {
@@ -90,13 +91,14 @@ func (c *ActionClient) WaitForFunc(ctx context.Context, handleUpdate func(update
 	return nil
 }
 
-// WaitFor waits until all actions succeeded by pooling the API at the interval
-// defined by [WithPollBackoffFunc].
+// WaitFor waits until all actions succeed by polling the API at the interval defined by
+// [WithPollBackoffFunc]. An action is considered as succeeded when its status is either
+// [ActionStatusSuccess].
 //
-// If a single action fails, the function will stop waiting and the action underlying
-// error will be returned.
+// If a single action fails, the function will stop waiting and the error set in the
+// action will be returned as an [ActionError].
 //
-// For more flexibility, see the [WaitForActionsFunc] function.
+// For more flexibility, see the [WaitForFunc] function.
 func (c *ActionClient) WaitFor(ctx context.Context, actions ...*Action) error {
 	return c.WaitForFunc(
 		ctx,

--- a/hcloud/action_waiter.go
+++ b/hcloud/action_waiter.go
@@ -1,0 +1,111 @@
+package hcloud
+
+import (
+	"context"
+	"fmt"
+	"maps"
+	"slices"
+	"time"
+)
+
+type ActionWaiter interface {
+	WaitForFunc(ctx context.Context, handleUpdate func(update *Action) error, actions ...*Action) error
+	WaitFor(ctx context.Context, actions ...*Action) error
+}
+
+var _ ActionWaiter = (*ActionClient)(nil)
+
+// WaitForActions waits until all actions completed (succeeded or failed) by pooling the
+// API at the interval defined by [WithPollBackoffFunc].
+//
+// The handleUpdate callback is called every time an action is updated.
+func (c *ActionClient) WaitForFunc(ctx context.Context, handleUpdate func(update *Action) error, actions ...*Action) error {
+	running := make(map[int64]struct{}, len(actions))
+	for _, action := range actions {
+		if action.Status == ActionStatusRunning {
+			running[action.ID] = struct{}{}
+		} else if handleUpdate != nil {
+			// We filter out already completed actions from the API polling loop; while
+			// this isn't a real update, the caller should be notified about the new
+			// state.
+			if err := handleUpdate(action); err != nil {
+				return err
+			}
+		}
+	}
+
+	retries := 0
+	for {
+		if len(running) == 0 {
+			break
+		}
+
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(c.action.client.pollBackoffFunc(retries)):
+			retries++
+		}
+
+		opts := ActionListOpts{Sort: []string{"status", "id"}}
+		for actionID := range running {
+			opts.ID = append(opts.ID, actionID)
+		}
+		slices.Sort(opts.ID)
+
+		updates, err := c.AllWithOpts(ctx, opts)
+		if err != nil {
+			return err
+		}
+
+		if len(updates) != len(running) {
+			// Some actions may not exist in the API, also fail early to prevent an
+			// infinite loop when updates == 0.
+
+			notFound := maps.Clone(running)
+			for _, update := range updates {
+				delete(notFound, update.ID)
+			}
+			notFoundIDs := make([]int64, 0, len(notFound))
+			for unknownID := range notFound {
+				notFoundIDs = append(notFoundIDs, unknownID)
+			}
+
+			return fmt.Errorf("actions not found: %v", notFoundIDs)
+		}
+
+		for _, update := range updates {
+			if update.Status != ActionStatusRunning {
+				delete(running, update.ID)
+			}
+
+			if handleUpdate != nil {
+				if err := handleUpdate(update); err != nil {
+					return err
+				}
+			}
+		}
+	}
+
+	return nil
+}
+
+// WaitFor waits until all actions succeeded by pooling the API at the interval
+// defined by [WithPollBackoffFunc].
+//
+// If a single action fails, the function will stop waiting and the action underlying
+// error will be returned.
+//
+// For more flexibility, see the [WaitForActionsFunc] function.
+func (c *ActionClient) WaitFor(ctx context.Context, actions ...*Action) error {
+	return c.WaitForFunc(
+		ctx,
+		func(update *Action) error {
+			if update.Status == ActionStatusError {
+				return update.Error()
+			}
+			return nil
+		},
+		actions...,
+	)
+}

--- a/hcloud/action_waiter.go
+++ b/hcloud/action_waiter.go
@@ -48,7 +48,10 @@ func (c *ActionClient) WaitForFunc(ctx context.Context, handleUpdate func(update
 			retries++
 		}
 
-		opts := ActionListOpts{Sort: []string{"status", "id"}}
+		opts := ActionListOpts{
+			Sort: []string{"status", "id"},
+			ID:   make([]int64, 0, len(running)),
+		}
 		for actionID := range running {
 			opts.ID = append(opts.ID, actionID)
 		}

--- a/hcloud/action_waiter_test.go
+++ b/hcloud/action_waiter_test.go
@@ -1,0 +1,169 @@
+package hcloud
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestWaitForActions(t *testing.T) {
+	RunMockedTestCases(t,
+		[]MockedTestCase{
+			{
+				Name: "succeed",
+				WantRequests: []MockedRequest{
+					{"GET", "/actions?id=1509772237&page=1&sort=status&sort=id", nil, 200,
+						`{
+							"actions": [
+								{ "id": 1509772237, "status": "running", "progress": 0 }
+							],
+							"meta": { "pagination": { "page": 1 }}
+						}`},
+					{"GET", "/actions?id=1509772237&page=1&sort=status&sort=id", nil, 200,
+						`{
+							"actions": [
+								{ "id": 1509772237, "status": "success", "progress": 100 }
+							],
+							"meta": { "pagination": { "page": 1 }}
+						}`},
+				},
+				Run: func(env testEnv) {
+					actions := []*Action{{ID: 1509772237, Status: "running"}}
+
+					err := env.Client.Action.WaitFor(context.Background(), actions...)
+					assert.NoError(t, err)
+				},
+			},
+			{
+				Name: "succeed with already succeeded action",
+				Run: func(env testEnv) {
+					actions := []*Action{{ID: 1509772237, Status: "success"}}
+
+					err := env.Client.Action.WaitFor(context.Background(), actions...)
+					assert.NoError(t, err)
+				},
+			},
+			{
+				Name: "fail with unknown action",
+				WantRequests: []MockedRequest{
+					{"GET", "/actions?id=1509772237&page=1&sort=status&sort=id", nil, 200,
+						`{
+							"actions": [],
+							"meta": { "pagination": { "page": 1 }}
+						}`},
+				},
+				Run: func(env testEnv) {
+					actions := []*Action{{ID: 1509772237, Status: "running"}}
+
+					err := env.Client.Action.WaitFor(context.Background(), actions...)
+					assert.Error(t, err)
+					assert.Equal(t, "actions not found: [1509772237]", err.Error())
+				},
+			},
+			{
+				Name: "fail with canceled context",
+				Run: func(env testEnv) {
+					actions := []*Action{{ID: 1509772237, Status: "running"}}
+
+					ctx, cancelFunc := context.WithCancel(context.Background())
+					cancelFunc()
+					err := env.Client.Action.WaitFor(ctx, actions...)
+					assert.Error(t, err)
+				},
+			},
+			{
+				Name: "fail with api error",
+				WantRequests: []MockedRequest{
+					{"GET", "/actions?id=1509772237&page=1&sort=status&sort=id", nil, 503, ""},
+				},
+				Run: func(env testEnv) {
+					actions := []*Action{{ID: 1509772237, Status: "running"}}
+
+					err := env.Client.Action.WaitFor(context.Background(), actions...)
+					assert.Error(t, err)
+					assert.Equal(t, "hcloud: server responded with status code 503", err.Error())
+				},
+			},
+		},
+	)
+}
+
+func TestWaitForActionsFunc(t *testing.T) {
+	RunMockedTestCases(t,
+		[]MockedTestCase{
+			{
+				Name: "succeed",
+				WantRequests: []MockedRequest{
+					{"GET", "/actions?id=1509772237&id=1509772238&page=1&sort=status&sort=id", nil, 200,
+						`{
+							"actions": [
+								{ "id": 1509772237, "status": "running", "progress": 40 },
+								{ "id": 1509772238, "status": "running", "progress": 0 }
+							],
+							"meta": { "pagination": { "page": 1 }}
+						}`},
+					{"GET", "/actions?id=1509772237&id=1509772238&page=1&sort=status&sort=id", nil, 200,
+						`{
+							"actions": [
+								{ "id": 1509772237, "status": "running", "progress": 60 },
+								{ "id": 1509772238, "status": "running", "progress": 50 }
+							],
+							"meta": { "pagination": { "page": 1 }}
+						}`},
+					{"GET", "/actions?id=1509772237&id=1509772238&page=1&sort=status&sort=id", nil, 200,
+						`{
+							"actions": [
+								{ "id": 1509772237, "status": "success", "progress": 100 },
+								{ "id": 1509772238, "status": "running", "progress": 75 }
+							],
+							"meta": { "pagination": { "page": 1 }}
+						}`},
+					{"GET", "/actions?id=1509772238&page=1&sort=status&sort=id", nil, 200,
+						`{
+							"actions": [
+								{ "id": 1509772238, "status": "error", "progress": 75, 
+									"error": {
+										"code": "action_failed", 
+										"message": "Something went wrong with the action"
+									}
+								}
+							],
+							"meta": { "pagination": { "page": 1 }}
+						}`},
+				},
+				Run: func(env testEnv) {
+					actions := []*Action{
+						{ID: 1509772236, Status: "success"},
+						{ID: 1509772237, Status: "running"},
+						{ID: 1509772238, Status: "running"},
+					}
+					progress := make([]int, 0)
+
+					progressByAction := make(map[int64]int, len(actions))
+					err := env.Client.Action.WaitForFunc(context.Background(), func(update *Action) error {
+						switch update.Status {
+						case ActionStatusRunning:
+							progressByAction[update.ID] = update.Progress
+						case ActionStatusSuccess:
+							progressByAction[update.ID] = 100
+						case ActionStatusError:
+							progressByAction[update.ID] = 100
+						}
+
+						sum := 0
+						for _, value := range progressByAction {
+							sum += value
+						}
+						progress = append(progress, sum/len(actions))
+
+						return nil
+					}, actions...)
+
+					assert.Nil(t, err)
+					assert.Equal(t, []int{33, 46, 46, 53, 70, 83, 91, 100}, progress)
+				},
+			},
+		},
+	)
+}

--- a/hcloud/action_waiter_test.go
+++ b/hcloud/action_waiter_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestWaitForActions(t *testing.T) {
+func TestWaitFor(t *testing.T) {
 	RunMockedTestCases(t,
 		[]MockedTestCase{
 			{
@@ -89,7 +89,7 @@ func TestWaitForActions(t *testing.T) {
 	)
 }
 
-func TestWaitForActionsFunc(t *testing.T) {
+func TestWaitForFunc(t *testing.T) {
 	RunMockedTestCases(t,
 		[]MockedTestCase{
 			{

--- a/hcloud/action_waiter_test.go
+++ b/hcloud/action_waiter_test.go
@@ -29,7 +29,7 @@ func TestWaitFor(t *testing.T) {
 						}`},
 				},
 				Run: func(env testEnv) {
-					actions := []*Action{{ID: 1509772237, Status: "running"}}
+					actions := []*Action{{ID: 1509772237, Status: ActionStatusRunning}}
 
 					err := env.Client.Action.WaitFor(context.Background(), actions...)
 					assert.NoError(t, err)
@@ -38,7 +38,7 @@ func TestWaitFor(t *testing.T) {
 			{
 				Name: "succeed with already succeeded action",
 				Run: func(env testEnv) {
-					actions := []*Action{{ID: 1509772237, Status: "success"}}
+					actions := []*Action{{ID: 1509772237, Status: ActionStatusSuccess}}
 
 					err := env.Client.Action.WaitFor(context.Background(), actions...)
 					assert.NoError(t, err)
@@ -54,7 +54,7 @@ func TestWaitFor(t *testing.T) {
 						}`},
 				},
 				Run: func(env testEnv) {
-					actions := []*Action{{ID: 1509772237, Status: "running"}}
+					actions := []*Action{{ID: 1509772237, Status: ActionStatusRunning}}
 
 					err := env.Client.Action.WaitFor(context.Background(), actions...)
 					assert.Error(t, err)
@@ -64,7 +64,7 @@ func TestWaitFor(t *testing.T) {
 			{
 				Name: "fail with canceled context",
 				Run: func(env testEnv) {
-					actions := []*Action{{ID: 1509772237, Status: "running"}}
+					actions := []*Action{{ID: 1509772237, Status: ActionStatusRunning}}
 
 					ctx, cancelFunc := context.WithCancel(context.Background())
 					cancelFunc()
@@ -78,7 +78,7 @@ func TestWaitFor(t *testing.T) {
 					{"GET", "/actions?id=1509772237&page=1&sort=status&sort=id", nil, 503, ""},
 				},
 				Run: func(env testEnv) {
-					actions := []*Action{{ID: 1509772237, Status: "running"}}
+					actions := []*Action{{ID: 1509772237, Status: ActionStatusRunning}}
 
 					err := env.Client.Action.WaitFor(context.Background(), actions...)
 					assert.Error(t, err)
@@ -134,9 +134,9 @@ func TestWaitForFunc(t *testing.T) {
 				},
 				Run: func(env testEnv) {
 					actions := []*Action{
-						{ID: 1509772236, Status: "success"},
-						{ID: 1509772237, Status: "running"},
-						{ID: 1509772238, Status: "running"},
+						{ID: 1509772236, Status: ActionStatusSuccess},
+						{ID: 1509772237, Status: ActionStatusRunning},
+						{ID: 1509772238, Status: ActionStatusRunning},
 					}
 					progress := make([]int, 0)
 

--- a/hcloud/client_test.go
+++ b/hcloud/client_test.go
@@ -31,6 +31,10 @@ func (env *testEnv) Teardown() {
 func newTestEnv() testEnv {
 	mux := http.NewServeMux()
 	server := httptest.NewServer(mux)
+	return newTestEnvWithServer(server, mux)
+}
+
+func newTestEnvWithServer(server *httptest.Server, mux *http.ServeMux) testEnv {
 	client := NewClient(
 		WithEndpoint(server.URL),
 		WithToken("token"),

--- a/hcloud/interface_gen.go
+++ b/hcloud/interface_gen.go
@@ -1,6 +1,6 @@
 package hcloud
 
-//go:generate go run github.com/vburenin/ifacemaker -f action.go -f action_watch.go -s ActionClient -i IActionClient -p hcloud -o zz_action_client_iface.go
+//go:generate go run github.com/vburenin/ifacemaker -f action.go -f action_watch.go -f action_waiter.go -s ActionClient -i IActionClient -p hcloud -o zz_action_client_iface.go
 //go:generate go run github.com/vburenin/ifacemaker -f action.go -s ResourceActionClient -i IResourceActionClient -p hcloud -o zz_resource_action_client_iface.go
 //go:generate go run github.com/vburenin/ifacemaker -f datacenter.go -s DatacenterClient -i IDatacenterClient -p hcloud -o zz_datacenter_client_iface.go
 //go:generate go run github.com/vburenin/ifacemaker -f floating_ip.go -s FloatingIPClient -i IFloatingIPClient -p hcloud -o zz_floating_ip_client_iface.go

--- a/hcloud/mocked_test.go
+++ b/hcloud/mocked_test.go
@@ -1,0 +1,75 @@
+package hcloud
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type MockedTestCase struct {
+	Name         string
+	WantRequests []MockedRequest
+	Run          func(env testEnv)
+}
+
+type MockedRequest struct {
+	Method              string
+	Path                string
+	WantRequestBodyFunc func(t *testing.T, r *http.Request, body []byte)
+
+	Status int
+	Body   string
+}
+
+func RunMockedTestCases(t *testing.T, testCases []MockedTestCase) {
+	for _, testCase := range testCases {
+		t.Run(testCase.Name, func(t *testing.T) {
+			env := newTestEnvWithServer(httptest.NewServer(MockedRequestHandler(t, testCase.WantRequests)), nil)
+			defer env.Teardown()
+
+			testCase.Run(env)
+		})
+	}
+}
+
+func MockedRequestHandler(t *testing.T, requests []MockedRequest) http.HandlerFunc {
+	index := 0
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if testing.Verbose() {
+			t.Logf("request %d: %s %s\n", index, r.Method, r.URL.Path)
+		}
+
+		if index >= len(requests) {
+			t.Fatalf("received unknown request %d", index)
+		}
+
+		response := requests[index]
+		assert.Equal(t, response.Method, r.Method)
+		assert.Equal(t, response.Path, r.RequestURI)
+
+		if response.WantRequestBodyFunc != nil {
+			buffer, err := io.ReadAll(r.Body)
+			defer func() {
+				if err := r.Body.Close(); err != nil {
+					t.Fatal(err)
+				}
+			}()
+			if err != nil {
+				t.Fatal(err)
+			}
+			response.WantRequestBodyFunc(t, r, buffer)
+		}
+
+		w.WriteHeader(response.Status)
+		w.Header().Set("Content-Type", "application/json")
+		_, err := w.Write([]byte(response.Body))
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		index++
+	})
+}

--- a/hcloud/zz_action_client_iface.go
+++ b/hcloud/zz_action_client_iface.go
@@ -61,17 +61,19 @@ type IActionClient interface {
 	//
 	// Deprecated: WatchProgress is deprecated, use [WaitForFunc] instead.
 	WatchProgress(ctx context.Context, action *Action) (<-chan int, <-chan error)
-	// WaitForActions waits until all actions completed (succeeded or failed) by pooling the
-	// API at the interval defined by [WithPollBackoffFunc].
+	// WaitForFunc waits until all actions are completed by polling the API at the interval
+	// defined by [WithPollBackoffFunc]. An action is considered as complete when its status is
+	// either [ActionStatusSuccess] or [ActionStatusError].
 	//
 	// The handleUpdate callback is called every time an action is updated.
 	WaitForFunc(ctx context.Context, handleUpdate func(update *Action) error, actions ...*Action) error
-	// WaitFor waits until all actions succeeded by pooling the API at the interval
-	// defined by [WithPollBackoffFunc].
+	// WaitFor waits until all actions succeed by polling the API at the interval defined by
+	// [WithPollBackoffFunc]. An action is considered as succeeded when its status is either
+	// [ActionStatusSuccess].
 	//
-	// If a single action fails, the function will stop waiting and the action underlying
-	// error will be returned.
+	// If a single action fails, the function will stop waiting and the error set in the
+	// action will be returned as an [ActionError].
 	//
-	// For more flexibility, see the [WaitForActionsFunc] function.
+	// For more flexibility, see the [WaitForFunc] function.
 	WaitFor(ctx context.Context, actions ...*Action) error
 }

--- a/hcloud/zz_action_client_iface.go
+++ b/hcloud/zz_action_client_iface.go
@@ -57,4 +57,17 @@ type IActionClient interface {
 	// WatchProgress uses the [WithPollBackoffFunc] of the [Client] to wait until
 	// sending the next request.
 	WatchProgress(ctx context.Context, action *Action) (<-chan int, <-chan error)
+	// WaitForActions waits until all actions completed (succeeded or failed) by pooling the
+	// API at the interval defined by [WithPollBackoffFunc].
+	//
+	// The handleUpdate callback is called every time an action is updated.
+	WaitForFunc(ctx context.Context, handleUpdate func(update *Action) error, actions ...*Action) error
+	// WaitFor waits until all actions succeeded by pooling the API at the interval
+	// defined by [WithPollBackoffFunc].
+	//
+	// If a single action fails, the function will stop waiting and the action underlying
+	// error will be returned.
+	//
+	// For more flexibility, see the [WaitForActionsFunc] function.
+	WaitFor(ctx context.Context, actions ...*Action) error
 }

--- a/hcloud/zz_action_client_iface.go
+++ b/hcloud/zz_action_client_iface.go
@@ -37,6 +37,8 @@ type IActionClient interface {
 	//
 	// WatchOverallProgress uses the [WithPollBackoffFunc] of the [Client] to wait
 	// until sending the next request.
+	//
+	// Deprecated: WatchOverallProgress is deprecated, use [WaitForFunc] instead.
 	WatchOverallProgress(ctx context.Context, actions []*Action) (<-chan int, <-chan error)
 	// WatchProgress watches one action's progress until it completes with success
 	// or error. This watching happens in a goroutine and updates are provided
@@ -56,6 +58,8 @@ type IActionClient interface {
 	//
 	// WatchProgress uses the [WithPollBackoffFunc] of the [Client] to wait until
 	// sending the next request.
+	//
+	// Deprecated: WatchProgress is deprecated, use [WaitForFunc] instead.
 	WatchProgress(ctx context.Context, action *Action) (<-chan int, <-chan error)
 	// WaitForActions waits until all actions completed (succeeded or failed) by pooling the
 	// API at the interval defined by [WithPollBackoffFunc].


### PR DESCRIPTION
Implement a simpler and more versatile waiting functions for actions.

Most use cases when waiting for actions is to return early if an action fails. If all actions must be waited until completion, the users should use the `WaitForFunc` function.

If the final actions objects are needed, the users should use the `WaitForFunc` function to store the final actions using the `handleUpdate` callback.

This deprecates the `ActionClient.WatchOverallProgress`  and `ActionClient.WatchProgress` methods.