### PR TITLE
feat(error): show internal correlation id in error messages

### DIFF
--- a/hcloud/action_test.go
+++ b/hcloud/action_test.go
@@ -322,6 +322,7 @@ func TestResourceActionClientAll(t *testing.T) {
 }
 
 func TestActionClientWatchOverallProgress(t *testing.T) {
+	t.Parallel()
 	env := newTestEnv()
 	defer env.Teardown()
 

--- a/hcloud/client.go
+++ b/hcloud/client.go
@@ -379,6 +379,10 @@ func errorFromResponse(resp *Response, body []byte) error {
 	return hcErr
 }
 
+const (
+	headerCorrelationID = "X-Correlation-Id"
+)
+
 // Response represents a response from the API. It embeds http.Response.
 type Response struct {
 	*http.Response
@@ -410,6 +414,12 @@ func (r *Response) readMeta(body []byte) error {
 	}
 
 	return nil
+}
+
+// internalCorrelationID returns the unique ID of the request as set by the API. This ID can help with support requests,
+// as it allows the people working on identify this request in particular.
+func (r *Response) internalCorrelationID() string {
+	return r.Header.Get(headerCorrelationID)
 }
 
 // Meta represents meta information included in an API response.

--- a/hcloud/error.go
+++ b/hcloud/error.go
@@ -100,6 +100,13 @@ type Error struct {
 }
 
 func (e Error) Error() string {
+	if resp := e.Response(); resp != nil {
+		correlationID := resp.internalCorrelationID()
+		if correlationID != "" {
+			// For easier debugging, the error string contains the Correlation ID of the response.
+			return fmt.Sprintf("%s (%s) (Correlation ID: %s)", e.Message, e.Code, correlationID)
+		}
+	}
 	return fmt.Sprintf("%s (%s)", e.Message, e.Code)
 }
 


### PR DESCRIPTION
This commit changes the way error responses from the API are formatted for display to users. When available, it adds the Correlation (Trace) ID header to the error string.
    
We often have users that post the error string, but rarely do users have debug logging active. By adding the correlation ID to error messages, we can more quickly investigate why something went wrong using the Hetzner internal tracing system.
    
This is common practice in Web Apps, they usually show a request/trace ID or an encrypted blob in case of an internal server error.