### PR TITLE
chore: remove unused and deprecated lint config

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,7 +1,5 @@
 ---
 linters-settings:
-  errcheck:
-    exclude: ./.errcheck_excludes.txt
   exhaustive:
     default-signifies-exhaustive: true
   gci:


### PR DESCRIPTION
```
$ golangci-lint run --fix                
WARN [config_reader] The configuration option `linters.errcheck.exclude` is deprecated, please use `linters.errcheck.exclude-functions`. 

```