### PR TITLE
docs(action): fix link to WaitForFunc

### DIFF
--- a/hcloud/action_waiter.go
+++ b/hcloud/action_waiter.go
@@ -101,7 +101,7 @@ func (c *ActionClient) WaitForFunc(ctx context.Context, handleUpdate func(update
 // If a single action fails, the function will stop waiting and the error set in the
 // action will be returned as an [ActionError].
 //
-// For more flexibility, see the [WaitForFunc] function.
+// For more flexibility, see the [ActionClient.WaitForFunc] function.
 func (c *ActionClient) WaitFor(ctx context.Context, actions ...*Action) error {
 	return c.WaitForFunc(
 		ctx,

--- a/hcloud/zz_action_client_iface.go
+++ b/hcloud/zz_action_client_iface.go
@@ -74,6 +74,6 @@ type IActionClient interface {
 	// If a single action fails, the function will stop waiting and the error set in the
 	// action will be returned as an [ActionError].
 	//
-	// For more flexibility, see the [WaitForFunc] function.
+	// For more flexibility, see the [ActionClient.WaitForFunc] function.
 	WaitFor(ctx context.Context, actions ...*Action) error
 }


### PR DESCRIPTION
Link was not working properly in current `main`: https://pkg.go.dev/github.com/hetznercloud/hcloud-go/v2/hcloud@v2.7.3-0.20240503164107-1e3fa7033d8a#ActionClient.WaitFor