### PR TITLE
fix: improve error message format with correlation id

### DIFF
--- a/hcloud/error.go
+++ b/hcloud/error.go
@@ -104,7 +104,7 @@ func (e Error) Error() string {
 		correlationID := resp.internalCorrelationID()
 		if correlationID != "" {
 			// For easier debugging, the error string contains the Correlation ID of the response.
-			return fmt.Sprintf("%s (%s) (Correlation ID: %s)", e.Message, e.Code, correlationID)
+			return fmt.Sprintf("%s (%s, %s)", e.Message, e.Code, correlationID)
 		}
 	}
 	return fmt.Sprintf("%s (%s)", e.Message, e.Code)

--- a/hcloud/error_test.go
+++ b/hcloud/error_test.go
@@ -39,13 +39,13 @@ func TestError_Error(t *testing.T) {
 						Header: func() http.Header {
 							headers := http.Header{}
 							// [http.Header] requires normalized header names, easiest to do by using the Set method
-							headers.Set("X-Correlation-ID", "foobar")
+							headers.Set("X-Correlation-ID", "d5064a1f0bb9de4b")
 							return headers
 						}(),
 					},
 				},
 			},
-			want: "Creating image failed because of an unknown error. (unknown_error) (Correlation ID: foobar)",
+			want: "Creating image failed because of an unknown error. (unknown_error, d5064a1f0bb9de4b)",
 		},
 		{
 			name: "internal server error without correlation id",


### PR DESCRIPTION
This improves the format of our error message, as they might be printed to the users.

Before:
```
hcloud: server name is already used (uniqueness_error) (Correlation ID: d5064a1f0bb9de4b)
```

After:
```
hcloud: server name is already used (uniqueness_error, d5064a1f0bb9de4b)
```