### PR TITLE
docs(action): fix link to WaitForFunc (#429) [Backport release-1.x]

### DIFF
--- a/hcloud/action_waiter.go
+++ b/hcloud/action_waiter.go
@@ -101,7 +101,7 @@ func (c *ActionClient) WaitForFunc(ctx context.Context, handleUpdate func(update
 // If a single action fails, the function will stop waiting and the error set in the
 // action will be returned as an [ActionError].
 //
-// For more flexibility, see the [WaitForFunc] function.
+// For more flexibility, see the [ActionClient.WaitForFunc] function.
 func (c *ActionClient) WaitFor(ctx context.Context, actions ...*Action) error {
 	return c.WaitForFunc(
 		ctx,


### PR DESCRIPTION
Link was not working properly in current `main`:
https://pkg.go.dev/github.com/hetznercloud/hcloud-go/v2/hcloud@v2.7.3-0.20240503164107-1e3fa7033d8a#ActionClient.WaitFor

(cherry picked from commit 94229eba296bbb03727eec7a028276a14db33431)

BEGIN_COMMIT_OVERRIDE
docs(action): fix link to WaitForFunc
END_COMMIT_OVERRIDE