### PR TITLE
feat: add volume format property (#397) [Backport release-1.x]

### DIFF
--- a/hcloud/schema.go
+++ b/hcloud/schema.go
@@ -380,6 +380,7 @@ func VolumeFromSchema(s schema.Volume) *Volume {
 		Name:        s.Name,
 		Location:    LocationFromSchema(s.Location),
 		Size:        s.Size,
+		Format:      s.Format,
 		Status:      VolumeStatus(s.Status),
 		LinuxDevice: s.LinuxDevice,
 		Protection: VolumeProtection{

--- a/hcloud/schema/volume.go
+++ b/hcloud/schema/volume.go
@@ -10,6 +10,7 @@ type Volume struct {
 	Status      string            `json:"status"`
 	Location    Location          `json:"location"`
 	Size        int               `json:"size"`
+	Format      *string           `json:"format"`
 	Protection  VolumeProtection  `json:"protection"`
 	Labels      map[string]string `json:"labels"`
 	LinuxDevice string            `json:"linux_device"`

--- a/hcloud/schema_test.go
+++ b/hcloud/schema_test.go
@@ -1235,6 +1235,7 @@ func TestVolumeFromSchema(t *testing.T) {
 		"name": "db-storage",
 		"status": "creating",
 		"server": 2,
+        "format": "xfs",
 		"location": {
 			"id": 1,
 			"name": "fsn1",
@@ -1276,6 +1277,9 @@ func TestVolumeFromSchema(t *testing.T) {
 	}
 	if volume.Server != nil && volume.Server.ID != 2 {
 		t.Errorf("unexpected server ID: %v", volume.Server.ID)
+	}
+	if volume.Format == nil || *volume.Format != "xfs" {
+		t.Errorf("unexpected format: %v", volume.Format)
 	}
 	if volume.Location == nil || volume.Location.ID != 1 {
 		t.Errorf("unexpected location: %v", volume.Location)

--- a/hcloud/volume.go
+++ b/hcloud/volume.go
@@ -21,11 +21,17 @@ type Volume struct {
 	Server      *Server
 	Location    *Location
 	Size        int
+	Format      *string
 	Protection  VolumeProtection
 	Labels      map[string]string
 	LinuxDevice string
 	Created     time.Time
 }
+
+const (
+	VolumeFormatExt4 = "ext4"
+	VolumeFormatXFS  = "xfs"
+)
 
 // VolumeProtection represents the protection level of a volume.
 type VolumeProtection struct {


### PR DESCRIPTION
This property was previously missing, although it was already used in VolumeCreateOpts. It's now a string pointer with common values (ext4 and xfs) available as string constants.

(cherry picked from commit c0940afce9eb01c0e6838502c91aa569ab411a03)

BEGIN_COMMIT_OVERRIDE
feat: add volume format property
END_COMMIT_OVERRIDE