### PR TITLE
fix(exp): rename to `sshutils` package name

### DIFF
--- a/hcloud/exp/kit/sshutils/ssh_key.go
+++ b/hcloud/exp/kit/sshutils/ssh_key.go
@@ -1,4 +1,4 @@
-package sshkey
+package sshutils
 
 import (
 	"crypto"

--- a/hcloud/exp/kit/sshutils/ssh_key_test.go
+++ b/hcloud/exp/kit/sshutils/ssh_key_test.go
@@ -1,4 +1,4 @@
-package sshkey
+package sshutils
 
 import (
 	"strings"


### PR DESCRIPTION
The package url and name were different. Use the `sshutils` package name to prevent collision with the stdlib ssh package.