### PR TITLE
feat(exp): rename `AppendNextActions` to `AppendNext`

### DIFF
--- a/hcloud/exp/actionutils/actions.go
+++ b/hcloud/exp/actionutils/actions.go
@@ -2,8 +2,8 @@ package actionutils
 
 import "github.com/hetznercloud/hcloud-go/v2/hcloud"
 
-// AppendNextActions return the action and the next actions in a new slice.
-func AppendNextActions(action *hcloud.Action, nextActions []*hcloud.Action) []*hcloud.Action {
+// AppendNext return the action and the next actions in a new slice.
+func AppendNext(action *hcloud.Action, nextActions []*hcloud.Action) []*hcloud.Action {
 	all := make([]*hcloud.Action, 0, 1+len(nextActions))
 	all = append(all, action)
 	all = append(all, nextActions...)

--- a/hcloud/exp/actionutils/actions_test.go
+++ b/hcloud/exp/actionutils/actions_test.go
@@ -8,11 +8,11 @@ import (
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
 )
 
-func TestAppendNextActions(t *testing.T) {
+func TestAppendNext(t *testing.T) {
 	action := &hcloud.Action{ID: 1}
 	nextActions := []*hcloud.Action{{ID: 2}, {ID: 3}}
 
-	actions := AppendNextActions(action, nextActions)
+	actions := AppendNext(action, nextActions)
 
 	assert.Equal(t, []*hcloud.Action{{ID: 1}, {ID: 2}, {ID: 3}}, actions)
 }


### PR DESCRIPTION
Use a smaller name, as we already refer to actions in the package name: 
- `actionutils.AppendNextActions ` => `actionutils.AppendNext` 