### PR TITLE
chore: replace deprecated server type with cx22

### DIFF
--- a/hcloud/schema_test.go
+++ b/hcloud/schema_test.go
@@ -600,7 +600,7 @@ func TestServerPrivateNetSchema(t *testing.T) {
 func TestServerTypeSchema(t *testing.T) {
 	data := []byte(`{
 		"id": 1,
-		"name": "cx10",
+		"name": "cx22",
 		"description": "description",
 		"cores": 4,
 		"memory": 1.0,

--- a/hcloud/server_type_test.go
+++ b/hcloud/server_type_test.go
@@ -77,7 +77,7 @@ func TestServerTypeClient(t *testing.T) {
 		defer env.Teardown()
 
 		env.Mux.HandleFunc("/server_types", func(w http.ResponseWriter, r *http.Request) {
-			if r.URL.RawQuery != "name=cx10" {
+			if r.URL.RawQuery != "name=cx22" {
 				t.Fatal("missing name query")
 			}
 			json.NewEncoder(w).Encode(schema.ServerTypeListResponse{
@@ -90,7 +90,7 @@ func TestServerTypeClient(t *testing.T) {
 		})
 
 		ctx := context.Background()
-		serverType, _, err := env.Client.ServerType.GetByName(ctx, "cx10")
+		serverType, _, err := env.Client.ServerType.GetByName(ctx, "cx22")
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -102,7 +102,7 @@ func TestServerTypeClient(t *testing.T) {
 		}
 
 		t.Run("via Get", func(t *testing.T) {
-			serverType, _, err := env.Client.ServerType.Get(ctx, "cx10")
+			serverType, _, err := env.Client.ServerType.Get(ctx, "cx22")
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -120,7 +120,7 @@ func TestServerTypeClient(t *testing.T) {
 		defer env.Teardown()
 
 		env.Mux.HandleFunc("/server_types", func(w http.ResponseWriter, r *http.Request) {
-			if r.URL.RawQuery != "name=cx10" {
+			if r.URL.RawQuery != "name=cx22" {
 				t.Fatal("missing name query")
 			}
 			json.NewEncoder(w).Encode(schema.ServerTypeListResponse{
@@ -129,7 +129,7 @@ func TestServerTypeClient(t *testing.T) {
 		})
 
 		ctx := context.Background()
-		serverType, _, err := env.Client.ServerType.GetByName(ctx, "cx10")
+		serverType, _, err := env.Client.ServerType.GetByName(ctx, "cx22")
 		if err != nil {
 			t.Fatal(err)
 		}


### PR DESCRIPTION
Learn more: https://docs.hetzner.cloud/changelog#2024-06-06-old-server-types-with-shared-intel-vcpus-are-deprecated