### PR TITLE
docs: document difference between the `exp` and `exp/kit` namespaces

### DIFF
--- a/hcloud/exp/README.md
+++ b/hcloud/exp/README.md
@@ -1,6 +1,6 @@
 # Experimental
 
-The `exp` namespace holds experimental features for the `hcloud-go` library.
+The [`exp`](./) namespace holds experimental features for the `hcloud-go` library. The [`exp/kit`](./kit/) namespace is reserved for features not directly related to the `hcloud-go` library, for example the [`sshutils`](./kit/sshutils) package has functions to generate ssh keys.
 
 > [!CAUTION]
 > Breaking changes may occur without notice. Do not use in production!


### PR DESCRIPTION
Both namespace have different purposes, this was not documented.