### PR TITLE
refactor: reuse mockutils package

### DIFF
--- a/hcloud/action_waiter_test.go
+++ b/hcloud/action_waiter_test.go
@@ -5,6 +5,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
+	"github.com/hetznercloud/hcloud-go/v2/hcloud/exp/mockutils"
 )
 
 func TestWaitFor(t *testing.T) {
@@ -12,21 +14,26 @@ func TestWaitFor(t *testing.T) {
 		[]MockedTestCase{
 			{
 				Name: "succeed",
-				WantRequests: []MockedRequest{
-					{"GET", "/actions?id=1509772237&page=1&sort=status&sort=id", nil, 200,
-						`{
+				WantRequests: []mockutils.Request{
+					{
+						Method: "GET", Path: "/actions?id=1509772237&page=1&sort=status&sort=id",
+						Status: 200,
+						JSONRaw: `{
 							"actions": [
 								{ "id": 1509772237, "status": "running", "progress": 0 }
 							],
 							"meta": { "pagination": { "page": 1 }}
-						}`},
-					{"GET", "/actions?id=1509772237&page=1&sort=status&sort=id", nil, 200,
-						`{
+						}`,
+					},
+					{Method: "GET", Path: "/actions?id=1509772237&page=1&sort=status&sort=id",
+						Status: 200,
+						JSONRaw: `{
 							"actions": [
 								{ "id": 1509772237, "status": "success", "progress": 100 }
 							],
 							"meta": { "pagination": { "page": 1 }}
-						}`},
+						}`,
+					},
 				},
 				Run: func(env testEnv) {
 					actions := []*Action{{ID: 1509772237, Status: ActionStatusRunning}}
@@ -46,12 +53,14 @@ func TestWaitFor(t *testing.T) {
 			},
 			{
 				Name: "fail with unknown action",
-				WantRequests: []MockedRequest{
-					{"GET", "/actions?id=1509772237&page=1&sort=status&sort=id", nil, 200,
-						`{
+				WantRequests: []mockutils.Request{
+					{Method: "GET", Path: "/actions?id=1509772237&page=1&sort=status&sort=id",
+						Status: 200,
+						JSONRaw: `{
 							"actions": [],
 							"meta": { "pagination": { "page": 1 }}
-						}`},
+						}`,
+					},
 				},
 				Run: func(env testEnv) {
 					actions := []*Action{{ID: 1509772237, Status: ActionStatusRunning}}
@@ -74,8 +83,9 @@ func TestWaitFor(t *testing.T) {
 			},
 			{
 				Name: "fail with api error",
-				WantRequests: []MockedRequest{
-					{"GET", "/actions?id=1509772237&page=1&sort=status&sort=id", nil, 503, ""},
+				WantRequests: []mockutils.Request{
+					{Method: "GET", Path: "/actions?id=1509772237&page=1&sort=status&sort=id",
+						Status: 503},
 				},
 				Run: func(env testEnv) {
 					actions := []*Action{{ID: 1509772237, Status: ActionStatusRunning}}
@@ -94,33 +104,40 @@ func TestWaitForFunc(t *testing.T) {
 		[]MockedTestCase{
 			{
 				Name: "succeed",
-				WantRequests: []MockedRequest{
-					{"GET", "/actions?id=1509772237&id=1509772238&page=1&sort=status&sort=id", nil, 200,
-						`{
+				WantRequests: []mockutils.Request{
+					{Method: "GET", Path: "/actions?id=1509772237&id=1509772238&page=1&sort=status&sort=id",
+						Status: 200,
+						JSONRaw: `{
 							"actions": [
 								{ "id": 1509772237, "status": "running", "progress": 40 },
 								{ "id": 1509772238, "status": "running", "progress": 0 }
 							],
 							"meta": { "pagination": { "page": 1 }}
-						}`},
-					{"GET", "/actions?id=1509772237&id=1509772238&page=1&sort=status&sort=id", nil, 200,
-						`{
+						}`,
+					},
+					{Method: "GET", Path: "/actions?id=1509772237&id=1509772238&page=1&sort=status&sort=id",
+						Status: 200,
+						JSONRaw: `{
 							"actions": [
 								{ "id": 1509772237, "status": "running", "progress": 60 },
 								{ "id": 1509772238, "status": "running", "progress": 50 }
 							],
 							"meta": { "pagination": { "page": 1 }}
-						}`},
-					{"GET", "/actions?id=1509772237&id=1509772238&page=1&sort=status&sort=id", nil, 200,
-						`{
+						}`,
+					},
+					{Method: "GET", Path: "/actions?id=1509772237&id=1509772238&page=1&sort=status&sort=id",
+						Status: 200,
+						JSONRaw: `{
 							"actions": [
 								{ "id": 1509772237, "status": "success", "progress": 100 },
 								{ "id": 1509772238, "status": "running", "progress": 75 }
 							],
 							"meta": { "pagination": { "page": 1 }}
-						}`},
-					{"GET", "/actions?id=1509772238&page=1&sort=status&sort=id", nil, 200,
-						`{
+						}`,
+					},
+					{Method: "GET", Path: "/actions?id=1509772238&page=1&sort=status&sort=id",
+						Status: 200,
+						JSONRaw: `{
 							"actions": [
 								{ "id": 1509772238, "status": "error", "progress": 75, 
 									"error": {
@@ -130,7 +147,8 @@ func TestWaitForFunc(t *testing.T) {
 								}
 							],
 							"meta": { "pagination": { "page": 1 }}
-						}`},
+						}`,
+					},
 				},
 				Run: func(env testEnv) {
 					actions := []*Action{

--- a/hcloud/action_waiter_test.go
+++ b/hcloud/action_waiter_test.go
@@ -15,8 +15,7 @@ func TestWaitFor(t *testing.T) {
 			{
 				Name: "succeed",
 				WantRequests: []mockutils.Request{
-					{
-						Method: "GET", Path: "/actions?id=1509772237&page=1&sort=status&sort=id",
+					{Method: "GET", Path: "/actions?id=1509772237&page=1&sort=status&sort=id",
 						Status: 200,
 						JSONRaw: `{
 							"actions": [

--- a/hcloud/mocked_test.go
+++ b/hcloud/mocked_test.go
@@ -1,75 +1,27 @@
 package hcloud
 
 import (
-	"io"
-	"net/http"
 	"net/http/httptest"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/hetznercloud/hcloud-go/v2/hcloud/exp/mockutils"
 )
 
 type MockedTestCase struct {
 	Name         string
-	WantRequests []MockedRequest
+	WantRequests []mockutils.Request
 	Run          func(env testEnv)
-}
-
-type MockedRequest struct {
-	Method              string
-	Path                string
-	WantRequestBodyFunc func(t *testing.T, r *http.Request, body []byte)
-
-	Status int
-	Body   string
 }
 
 func RunMockedTestCases(t *testing.T, testCases []MockedTestCase) {
 	for _, testCase := range testCases {
 		t.Run(testCase.Name, func(t *testing.T) {
-			env := newTestEnvWithServer(httptest.NewServer(MockedRequestHandler(t, testCase.WantRequests)), nil)
+			testServer := httptest.NewServer(mockutils.Handler(t, testCase.WantRequests))
+
+			env := newTestEnvWithServer(testServer, nil)
 			defer env.Teardown()
 
 			testCase.Run(env)
 		})
 	}
-}
-
-func MockedRequestHandler(t *testing.T, requests []MockedRequest) http.HandlerFunc {
-	index := 0
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if testing.Verbose() {
-			t.Logf("request %d: %s %s\n", index, r.Method, r.URL.Path)
-		}
-
-		if index >= len(requests) {
-			t.Fatalf("received unknown request %d", index)
-		}
-
-		response := requests[index]
-		assert.Equal(t, response.Method, r.Method)
-		assert.Equal(t, response.Path, r.RequestURI)
-
-		if response.WantRequestBodyFunc != nil {
-			buffer, err := io.ReadAll(r.Body)
-			defer func() {
-				if err := r.Body.Close(); err != nil {
-					t.Fatal(err)
-				}
-			}()
-			if err != nil {
-				t.Fatal(err)
-			}
-			response.WantRequestBodyFunc(t, r, buffer)
-		}
-
-		w.WriteHeader(response.Status)
-		w.Header().Set("Content-Type", "application/json")
-		_, err := w.Write([]byte(response.Body))
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		index++
-	})
 }


### PR DESCRIPTION
Removes the now duplicated mock request utils, and uses the one introduced in #460. 