### PR TITLE
refactor: explode Client.Do method into a chain of handlers 

### DIFF
--- a/hcloud/client.go
+++ b/hcloud/client.go
@@ -1,15 +1,12 @@
 package hcloud
 
 import (
-	"bytes"
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
 	"math"
 	"net/http"
-	"net/http/httputil"
 	"net/url"
 	"strconv"
 	"strings"
@@ -19,7 +16,6 @@ import (
 	"golang.org/x/net/http/httpguts"
 
 	"github.com/hetznercloud/hcloud-go/v2/hcloud/internal/instrumentation"
-	"github.com/hetznercloud/hcloud-go/v2/hcloud/schema"
 )
 
 // Endpoint is the base URL of the API.
@@ -66,6 +62,7 @@ type Client struct {
 	userAgent               string
 	debugWriter             io.Writer
 	instrumentationRegistry prometheus.Registerer
+	handler                 handler
 
 	Action           ActionClient
 	Certificate      CertificateClient
@@ -189,6 +186,8 @@ func NewClient(options ...ClientOption) *Client {
 		client.httpClient.Transport = i.InstrumentedRoundTripper()
 	}
 
+	client.handler = assembleHandlerChain(client)
+
 	client.Action = ActionClient{action: &ResourceActionClient{client: client}}
 	client.Datacenter = DatacenterClient{client: client}
 	client.FloatingIP = FloatingIPClient{client: client, Action: &ResourceActionClient{client: client, resource: "floating_ips"}}
@@ -238,81 +237,8 @@ func (c *Client) NewRequest(ctx context.Context, method, path string, body io.Re
 // Do performs an HTTP request against the API.
 // v can be nil, an io.Writer to write the response body to or a pointer to
 // a struct to json.Unmarshal the response to.
-func (c *Client) Do(r *http.Request, v interface{}) (*Response, error) {
-	var retries int
-	var body []byte
-	var err error
-	if r.ContentLength > 0 {
-		body, err = io.ReadAll(r.Body)
-		if err != nil {
-			r.Body.Close()
-			return nil, err
-		}
-		r.Body.Close()
-	}
-	for {
-		if r.ContentLength > 0 {
-			r.Body = io.NopCloser(bytes.NewReader(body))
-		}
-
-		if c.debugWriter != nil {
-			dumpReq, err := dumpRequest(r)
-			if err != nil {
-				return nil, err
-			}
-			fmt.Fprintf(c.debugWriter, "--- Request:\n%s\n\n", dumpReq)
-		}
-
-		resp, err := c.httpClient.Do(r)
-		if err != nil {
-			return nil, err
-		}
-		response := &Response{Response: resp}
-		body, err := io.ReadAll(resp.Body)
-		if err != nil {
-			resp.Body.Close()
-			return response, err
-		}
-		resp.Body.Close()
-		resp.Body = io.NopCloser(bytes.NewReader(body))
-
-		if c.debugWriter != nil {
-			dumpResp, err := httputil.DumpResponse(resp, true)
-			if err != nil {
-				return nil, err
-			}
-			fmt.Fprintf(c.debugWriter, "--- Response:\n%s\n\n", dumpResp)
-		}
-
-		if err = response.readMeta(body); err != nil {
-			return response, fmt.Errorf("hcloud: error reading response meta data: %s", err)
-		}
-
-		if response.StatusCode >= 400 && response.StatusCode <= 599 {
-			err = errorFromResponse(response, body)
-			if err == nil {
-				err = fmt.Errorf("hcloud: server responded with status code %d", resp.StatusCode)
-			} else if IsError(err, ErrorCodeConflict) {
-				c.backoff(retries)
-				retries++
-				continue
-			}
-			return response, err
-		}
-		if v != nil {
-			if w, ok := v.(io.Writer); ok {
-				_, err = io.Copy(w, bytes.NewReader(body))
-			} else {
-				err = json.Unmarshal(body, v)
-			}
-		}
-
-		return response, err
-	}
-}
-
-func (c *Client) backoff(retries int) {
-	time.Sleep(c.backoffFunc(retries))
+func (c *Client) Do(req *http.Request, v any) (*Response, error) {
+	return c.handler.Do(req, v)
 }
 
 func (c *Client) all(f func(int) (*Response, error)) error {
@@ -342,43 +268,6 @@ func (c *Client) buildUserAgent() {
 	}
 }
 
-func dumpRequest(r *http.Request) ([]byte, error) {
-	// Duplicate the request, so we can redact the auth header
-	rDuplicate := r.Clone(context.Background())
-	rDuplicate.Header.Set("Authorization", "REDACTED")
-
-	// To get the request body we need to read it before the request was actually sent.
-	// See https://github.com/golang/go/issues/29792
-	dumpReq, err := httputil.DumpRequestOut(rDuplicate, true)
-	if err != nil {
-		return nil, err
-	}
-
-	// Set original request body to the duplicate created by DumpRequestOut. The request body is not duplicated
-	// by .Clone() and instead just referenced, so it would be completely read otherwise.
-	r.Body = rDuplicate.Body
-
-	return dumpReq, nil
-}
-
-func errorFromResponse(resp *Response, body []byte) error {
-	if !strings.HasPrefix(resp.Header.Get("Content-Type"), "application/json") {
-		return nil
-	}
-
-	var respBody schema.ErrorResponse
-	if err := json.Unmarshal(body, &respBody); err != nil {
-		return nil
-	}
-	if respBody.Error.Code == "" && respBody.Error.Message == "" {
-		return nil
-	}
-
-	hcErr := ErrorFromSchema(respBody.Error)
-	hcErr.response = resp
-	return hcErr
-}
-
 const (
 	headerCorrelationID = "X-Correlation-Id"
 )
@@ -387,33 +276,15 @@ const (
 type Response struct {
 	*http.Response
 	Meta Meta
+
+	// body holds a copy of the http.Response body that must be used within the handler
+	// chain. The http.Response.Body is reserved for external users.
+	body []byte
 }
 
-func (r *Response) readMeta(body []byte) error {
-	if h := r.Header.Get("RateLimit-Limit"); h != "" {
-		r.Meta.Ratelimit.Limit, _ = strconv.Atoi(h)
-	}
-	if h := r.Header.Get("RateLimit-Remaining"); h != "" {
-		r.Meta.Ratelimit.Remaining, _ = strconv.Atoi(h)
-	}
-	if h := r.Header.Get("RateLimit-Reset"); h != "" {
-		if ts, err := strconv.ParseInt(h, 10, 64); err == nil {
-			r.Meta.Ratelimit.Reset = time.Unix(ts, 0)
-		}
-	}
-
-	if strings.HasPrefix(r.Header.Get("Content-Type"), "application/json") {
-		var s schema.MetaResponse
-		if err := json.Unmarshal(body, &s); err != nil {
-			return err
-		}
-		if s.Meta.Pagination != nil {
-			p := PaginationFromSchema(*s.Meta.Pagination)
-			r.Meta.Pagination = &p
-		}
-	}
-
-	return nil
+// hasJSONBody returns whether the response has a JSON body.
+func (r *Response) hasJSONBody() bool {
+	return len(r.body) > 0 && strings.HasPrefix(r.Header.Get("Content-Type"), "application/json")
 }
 
 // internalCorrelationID returns the unique ID of the request as set by the API. This ID can help with support requests,

--- a/hcloud/client.go
+++ b/hcloud/client.go
@@ -1,6 +1,7 @@
 package hcloud
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -280,6 +281,23 @@ type Response struct {
 	// body holds a copy of the http.Response body that must be used within the handler
 	// chain. The http.Response.Body is reserved for external users.
 	body []byte
+}
+
+// populateBody copies the original [http.Response] body into the internal [Response] body
+// property, and restore the original [http.Response] body as if it was untouched.
+func (r *Response) populateBody() error {
+	// Read full response body and save it for later use
+	body, err := io.ReadAll(r.Body)
+	r.Body.Close()
+	if err != nil {
+		return err
+	}
+	r.body = body
+
+	// Restore the body as if it was untouched, as it might be read by external users
+	r.Body = io.NopCloser(bytes.NewReader(body))
+
+	return nil
 }
 
 // hasJSONBody returns whether the response has a JSON body.

--- a/hcloud/client_handler.go
+++ b/hcloud/client_handler.go
@@ -20,16 +20,16 @@ func assembleHandlerChain(client *Client) handler {
 	// Start down the chain: sending the http request
 	h := newHTTPHandler(client.httpClient)
 
+	// Insert debug writer if enabled
+	if client.debugWriter != nil {
+		h = wrapDebugHandler(h, client.debugWriter)
+	}
+
 	// Read rate limit headers
 	h = wrapRateLimitHandler(h)
 
 	// Build error from response
 	h = wrapErrorHandler(h)
-
-	// Insert debug writer if enabled
-	if client.debugWriter != nil {
-		h = wrapDebugHandler(h, client.debugWriter)
-	}
 
 	// Retry request if condition are met
 	h = wrapRetryHandler(h, client.backoffFunc)

--- a/hcloud/client_handler.go
+++ b/hcloud/client_handler.go
@@ -1,0 +1,41 @@
+package hcloud
+
+import (
+	"net/http"
+)
+
+// handler is an interface representing a client request transaction. The handler are
+// meant to be chained, similarly to the [http.RoundTripper] interface.
+//
+// The handler chain is placed between the [Client] API operations and the
+// [http.Client].
+type handler interface {
+	Do(req *http.Request, v any) (resp *Response, err error)
+}
+
+// assembleHandlerChain assembles the chain of handlers used to make API requests.
+//
+// The order of the handlers is important.
+func assembleHandlerChain(client *Client) handler {
+	// Start down the chain: sending the http request
+	h := newHTTPHandler(client.httpClient)
+
+	// Read rate limit headers
+	h = wrapRateLimitHandler(h)
+
+	// Build error from response
+	h = wrapErrorHandler(h)
+
+	// Insert debug writer if enabled
+	if client.debugWriter != nil {
+		h = wrapDebugHandler(h, client.debugWriter)
+	}
+
+	// Retry request if condition are met
+	h = wrapRetryHandler(h, client.backoffFunc)
+
+	// Finally parse the response body into the provided schema
+	h = wrapParseHandler(h)
+
+	return h
+}

--- a/hcloud/client_handler.go
+++ b/hcloud/client_handler.go
@@ -1,6 +1,7 @@
 package hcloud
 
 import (
+	"context"
 	"net/http"
 )
 
@@ -38,4 +39,18 @@ func assembleHandlerChain(client *Client) handler {
 	h = wrapParseHandler(h)
 
 	return h
+}
+
+// cloneRequest clones both the request and the request body.
+func cloneRequest(req *http.Request, ctx context.Context) (cloned *http.Request, err error) { //revive:disable:context-as-argument
+	cloned = req.Clone(ctx)
+
+	if req.ContentLength > 0 {
+		cloned.Body, err = req.GetBody()
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return cloned, nil
 }

--- a/hcloud/client_handler_debug.go
+++ b/hcloud/client_handler_debug.go
@@ -19,9 +19,8 @@ type debugHandler struct {
 }
 
 func (h *debugHandler) Do(req *http.Request, v any) (resp *Response, err error) {
-	// Duplicate the request, so we can redact the auth header and read the body
-
-	// Clone the request using the new context
+	// Clone the request, so we can redact the auth header, read the body
+	// and use a new context.
 	cloned := req.Clone(context.Background())
 
 	if req.ContentLength > 0 {

--- a/hcloud/client_handler_debug.go
+++ b/hcloud/client_handler_debug.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"log"
 	"net/http"
 	"net/http/httputil"
 )
@@ -34,8 +33,7 @@ func (h *debugHandler) Do(req *http.Request, v any) (resp *Response, err error) 
 
 	dumpReq, err := httputil.DumpRequestOut(cloned, true)
 	if err != nil {
-		log.Println(err)
-		return
+		return nil, err
 	}
 
 	fmt.Fprintf(h.output, "--- Request:\n%s\n\n", dumpReq)
@@ -47,8 +45,7 @@ func (h *debugHandler) Do(req *http.Request, v any) (resp *Response, err error) 
 
 	dumpResp, err := httputil.DumpResponse(resp.Response, true)
 	if err != nil {
-		log.Println(err)
-		return
+		return nil, err
 	}
 
 	fmt.Fprintf(h.output, "--- Response:\n%s\n\n", dumpResp)

--- a/hcloud/client_handler_debug.go
+++ b/hcloud/client_handler_debug.go
@@ -1,0 +1,58 @@
+package hcloud
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"net/http/httputil"
+)
+
+func wrapDebugHandler(wrapped handler, output io.Writer) handler {
+	return &debugHandler{wrapped, output}
+}
+
+type debugHandler struct {
+	handler handler
+	output  io.Writer
+}
+
+func (h *debugHandler) Do(req *http.Request, v any) (resp *Response, err error) {
+	// Duplicate the request, so we can redact the auth header and read the body
+
+	// Clone the request using the new context
+	cloned := req.Clone(context.Background())
+
+	if req.ContentLength > 0 {
+		cloned.Body, err = req.GetBody()
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	cloned.Header.Set("Authorization", "REDACTED")
+
+	dumpReq, err := httputil.DumpRequestOut(cloned, true)
+	if err != nil {
+		log.Println(err)
+		return
+	}
+
+	fmt.Fprintf(h.output, "--- Request:\n%s\n\n", dumpReq)
+
+	resp, err = h.handler.Do(req, v)
+	if err != nil {
+		return resp, err
+	}
+
+	dumpResp, err := httputil.DumpResponse(resp.Response, true)
+	if err != nil {
+		log.Println(err)
+		return
+	}
+
+	fmt.Fprintf(h.output, "--- Response:\n%s\n\n", dumpResp)
+
+	return resp, err
+}

--- a/hcloud/client_handler_debug.go
+++ b/hcloud/client_handler_debug.go
@@ -20,13 +20,9 @@ type debugHandler struct {
 func (h *debugHandler) Do(req *http.Request, v any) (resp *Response, err error) {
 	// Clone the request, so we can redact the auth header, read the body
 	// and use a new context.
-	cloned := req.Clone(context.Background())
-
-	if req.ContentLength > 0 {
-		cloned.Body, err = req.GetBody()
-		if err != nil {
-			return nil, err
-		}
+	cloned, err := cloneRequest(req, context.Background())
+	if err != nil {
+		return nil, err
 	}
 
 	cloned.Header.Set("Authorization", "REDACTED")

--- a/hcloud/client_handler_debug_test.go
+++ b/hcloud/client_handler_debug_test.go
@@ -1,0 +1,103 @@
+package hcloud
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"net/http"
+	"regexp"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDebugHandler(t *testing.T) {
+	testCases := []struct {
+		name    string
+		wrapped func(req *http.Request, v any) (*Response, error)
+		want    string
+	}{
+		{
+			name: "network error",
+			wrapped: func(_ *http.Request, _ any) (*Response, error) {
+				return nil, fmt.Errorf("network error")
+			},
+			want: `--- Request:
+GET /v1/ HTTP/1.1
+Host: api.hetzner.cloud
+User-Agent: hcloud-go/testing
+Authorization: REDACTED
+Accept-Encoding: gzip
+
+
+
+`,
+		},
+		{
+			name: "http 503 error",
+			wrapped: func(_ *http.Request, _ any) (*Response, error) {
+				return fakeResponse(t, 503, "", false), nil
+			},
+			want: `--- Request:
+GET /v1/ HTTP/1.1
+Host: api.hetzner.cloud
+User-Agent: hcloud-go/testing
+Authorization: REDACTED
+Accept-Encoding: gzip
+
+
+
+--- Response:
+HTTP/1.1 503 Service Unavailable
+Connection: close
+
+
+
+`,
+		},
+		{
+			name: "http 200",
+			wrapped: func(_ *http.Request, _ any) (*Response, error) {
+				return fakeResponse(t, 200, `{"data": {"id": 1234, "name": "testing"}}`, true), nil
+			},
+			want: `--- Request:
+GET /v1/ HTTP/1.1
+Host: api.hetzner.cloud
+User-Agent: hcloud-go/testing
+Authorization: REDACTED
+Accept-Encoding: gzip
+
+
+
+--- Response:
+HTTP/1.1 200 OK
+Connection: close
+Content-Type: application/json
+
+{"data": {"id": 1234, "name": "testing"}}
+
+`,
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			buf := bytes.NewBuffer(nil)
+
+			m := &mockHandler{testCase.wrapped}
+			h := wrapDebugHandler(m, buf)
+
+			client := NewClient(WithToken("dummy"))
+			client.userAgent = "hcloud-go/testing"
+
+			req, err := client.NewRequest(context.Background(), "GET", "/", nil)
+			require.NoError(t, err)
+
+			h.Do(req, nil)
+
+			re := regexp.MustCompile(`\r`)
+			output := re.ReplaceAllString(buf.String(), "")
+			assert.Equal(t, testCase.want, output)
+		})
+	}
+}

--- a/hcloud/client_handler_error.go
+++ b/hcloud/client_handler_error.go
@@ -1,0 +1,50 @@
+package hcloud
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/hetznercloud/hcloud-go/v2/hcloud/schema"
+)
+
+func wrapErrorHandler(wrapped handler) handler {
+	return &errorHandler{wrapped}
+}
+
+type errorHandler struct {
+	handler handler
+}
+
+func (h *errorHandler) Do(req *http.Request, v any) (resp *Response, err error) {
+	resp, err = h.handler.Do(req, v)
+	if err != nil {
+		return resp, err
+	}
+
+	if resp.StatusCode >= 400 && resp.StatusCode <= 599 {
+		err = errorFromBody(resp)
+		if err == nil {
+			err = fmt.Errorf("hcloud: server responded with status code %d", resp.StatusCode)
+		}
+	}
+	return resp, err
+}
+
+func errorFromBody(resp *Response) error {
+	if !resp.hasJSONBody() {
+		return nil
+	}
+
+	var s schema.ErrorResponse
+	if err := json.Unmarshal(resp.body, &s); err != nil {
+		return nil
+	}
+	if s.Error.Code == "" && s.Error.Message == "" {
+		return nil
+	}
+
+	hcErr := ErrorFromSchema(s.Error)
+	hcErr.response = resp
+	return hcErr
+}

--- a/hcloud/client_handler_error_test.go
+++ b/hcloud/client_handler_error_test.go
@@ -1,0 +1,58 @@
+package hcloud
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestErrorHandler(t *testing.T) {
+	testCases := []struct {
+		name    string
+		wrapped func(req *http.Request, v any) (*Response, error)
+		want    func(t *testing.T, resp *Response, err error)
+	}{
+		{
+			name: "network error",
+			wrapped: func(_ *http.Request, _ any) (*Response, error) {
+				return nil, fmt.Errorf("network error")
+			},
+			want: func(t *testing.T, resp *Response, err error) {
+				assert.Nil(t, resp)
+				assert.EqualError(t, err, "network error")
+			},
+		},
+		{
+			name: "http 503 error",
+			wrapped: func(_ *http.Request, _ any) (*Response, error) {
+				return fakeResponse(t, 503, "", false), nil
+			},
+			want: func(t *testing.T, resp *Response, err error) {
+				assert.Equal(t, 503, resp.StatusCode)
+				assert.EqualError(t, err, "hcloud: server responded with status code 503")
+			},
+		},
+		{
+			name: "http 422 error",
+			wrapped: func(_ *http.Request, _ any) (*Response, error) {
+				return fakeResponse(t, 422, `{"error": {"code": "service_error", "message": "An error occurred"}}`, true), nil
+			},
+			want: func(t *testing.T, resp *Response, err error) {
+				assert.Equal(t, 422, resp.StatusCode)
+				assert.EqualError(t, err, "An error occurred (service_error)")
+			},
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			m := &mockHandler{testCase.wrapped}
+			h := wrapErrorHandler(m)
+
+			resp, err := h.Do(nil, nil)
+
+			testCase.want(t, resp, err)
+		})
+	}
+}

--- a/hcloud/client_handler_error_test.go
+++ b/hcloud/client_handler_error_test.go
@@ -15,6 +15,16 @@ func TestErrorHandler(t *testing.T) {
 		want    func(t *testing.T, resp *Response, err error)
 	}{
 		{
+			name: "no error",
+			wrapped: func(_ *http.Request, _ any) (*Response, error) {
+				return fakeResponse(t, 200, `{"data": "Hello"}`, true), nil
+			},
+			want: func(t *testing.T, resp *Response, err error) {
+				assert.Equal(t, 200, resp.StatusCode)
+				assert.NoError(t, err)
+			},
+		},
+		{
 			name: "network error",
 			wrapped: func(_ *http.Request, _ any) (*Response, error) {
 				return nil, fmt.Errorf("network error")

--- a/hcloud/client_handler_http.go
+++ b/hcloud/client_handler_http.go
@@ -1,8 +1,6 @@
 package hcloud
 
 import (
-	"bytes"
-	"io"
 	"net/http"
 )
 
@@ -21,16 +19,10 @@ func (h *httpHandler) Do(req *http.Request, _ interface{}) (*Response, error) {
 		return resp, err
 	}
 
-	// Read full response body and save it for later use
-	body, err := io.ReadAll(resp.Body)
-	resp.Body.Close()
+	err = resp.populateBody()
 	if err != nil {
 		return resp, err
 	}
-	resp.body = body
-
-	// Restore the body as if it was untouched, as it might be read by external users
-	resp.Body = io.NopCloser(bytes.NewReader(body))
 
 	return resp, err
 }

--- a/hcloud/client_handler_http.go
+++ b/hcloud/client_handler_http.go
@@ -1,0 +1,36 @@
+package hcloud
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+)
+
+func newHTTPHandler(httpClient *http.Client) handler {
+	return &httpHandler{httpClient}
+}
+
+type httpHandler struct {
+	httpClient *http.Client
+}
+
+func (h *httpHandler) Do(req *http.Request, _ interface{}) (*Response, error) {
+	httpResponse, err := h.httpClient.Do(req) //nolint: bodyclose
+	resp := &Response{Response: httpResponse}
+	if err != nil {
+		return resp, err
+	}
+
+	// Read full response body and save it for later use
+	body, err := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	if err != nil {
+		return resp, err
+	}
+	resp.body = body
+
+	// Restore the body as if it was untouched, as it might be read by external users
+	resp.Body = io.NopCloser(bytes.NewReader(body))
+
+	return resp, err
+}

--- a/hcloud/client_handler_http_test.go
+++ b/hcloud/client_handler_http_test.go
@@ -1,0 +1,36 @@
+package hcloud
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHTTPHandler(t *testing.T) {
+	testServer := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Write([]byte("hello"))
+		}),
+	)
+
+	h := newHTTPHandler(&http.Client{})
+
+	req, err := http.NewRequest("GET", testServer.URL, nil)
+	require.NoError(t, err)
+
+	resp, err := h.Do(req, nil)
+	require.NoError(t, err)
+
+	// Ensure the internal response body is populated
+	assert.Equal(t, []byte("hello"), resp.body)
+
+	// Ensure the original response body is readable by external users
+	body, err := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	require.NoError(t, err)
+	assert.Equal(t, []byte("hello"), body)
+}

--- a/hcloud/client_handler_parse.go
+++ b/hcloud/client_handler_parse.go
@@ -1,0 +1,50 @@
+package hcloud
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/hetznercloud/hcloud-go/v2/hcloud/schema"
+)
+
+func wrapParseHandler(wrapped handler) handler {
+	return &parseHandler{wrapped}
+}
+
+type parseHandler struct {
+	handler handler
+}
+
+func (h *parseHandler) Do(req *http.Request, v any) (resp *Response, err error) {
+	// respBody is not needed down the handler chain
+	resp, err = h.handler.Do(req, nil)
+	if err != nil {
+		return resp, err
+	}
+
+	if resp.hasJSONBody() {
+		// Parse the response meta
+		var s schema.MetaResponse
+		if err := json.Unmarshal(resp.body, &s); err != nil {
+			return resp, fmt.Errorf("hcloud: error reading response meta data: %w", err)
+		}
+		if s.Meta.Pagination != nil {
+			p := PaginationFromSchema(*s.Meta.Pagination)
+			resp.Meta.Pagination = &p
+		}
+	}
+
+	// Parse the response schema
+	if v != nil {
+		if w, ok := v.(io.Writer); ok {
+			_, err = io.Copy(w, bytes.NewReader(resp.body))
+		} else {
+			err = json.Unmarshal(resp.body, v)
+		}
+	}
+
+	return resp, err
+}

--- a/hcloud/client_handler_parse_test.go
+++ b/hcloud/client_handler_parse_test.go
@@ -1,0 +1,55 @@
+package hcloud
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseHandler(t *testing.T) {
+	type SomeStruct struct {
+		Data string `json:"data"`
+	}
+
+	testCases := []struct {
+		name    string
+		wrapped func(req *http.Request, v any) (*Response, error)
+		want    func(t *testing.T, v SomeStruct, resp *Response, err error)
+	}{
+		{
+			name: "no error",
+			wrapped: func(_ *http.Request, _ any) (*Response, error) {
+				return fakeResponse(t, 200, `{"data": "Hello", "meta": {"pagination": {"page": 1}}}`, true), nil
+			},
+			want: func(t *testing.T, v SomeStruct, resp *Response, err error) {
+				assert.NoError(t, err)
+				assert.Equal(t, v.Data, "Hello")
+				assert.Equal(t, resp.Meta.Pagination.Page, 1)
+			},
+		},
+		{
+			name: "any error",
+			wrapped: func(_ *http.Request, _ any) (*Response, error) {
+				return nil, fmt.Errorf("any error")
+			},
+			want: func(t *testing.T, v SomeStruct, resp *Response, err error) {
+				assert.EqualError(t, err, "any error")
+				assert.Equal(t, v.Data, "")
+			},
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			m := &mockHandler{testCase.wrapped}
+			h := wrapParseHandler(m)
+
+			s := SomeStruct{}
+
+			resp, err := h.Do(nil, &s)
+
+			testCase.want(t, s, resp, err)
+		})
+	}
+}

--- a/hcloud/client_handler_parse_test.go
+++ b/hcloud/client_handler_parse_test.go
@@ -37,6 +37,7 @@ func TestParseHandler(t *testing.T) {
 			want: func(t *testing.T, v SomeStruct, resp *Response, err error) {
 				assert.EqualError(t, err, "any error")
 				assert.Equal(t, v.Data, "")
+				assert.Nil(t, resp)
 			},
 		},
 	}

--- a/hcloud/client_handler_rate_limit.go
+++ b/hcloud/client_handler_rate_limit.go
@@ -1,0 +1,33 @@
+package hcloud
+
+import (
+	"net/http"
+	"strconv"
+	"time"
+)
+
+func wrapRateLimitHandler(wrapped handler) handler {
+	return &rateLimitHandler{wrapped}
+}
+
+type rateLimitHandler struct {
+	handler handler
+}
+
+func (h *rateLimitHandler) Do(req *http.Request, v any) (resp *Response, err error) {
+	resp, err = h.handler.Do(req, v)
+
+	if h := resp.Header.Get("RateLimit-Limit"); h != "" {
+		resp.Meta.Ratelimit.Limit, _ = strconv.Atoi(h)
+	}
+	if h := resp.Header.Get("RateLimit-Remaining"); h != "" {
+		resp.Meta.Ratelimit.Remaining, _ = strconv.Atoi(h)
+	}
+	if h := resp.Header.Get("RateLimit-Reset"); h != "" {
+		if ts, err := strconv.ParseInt(h, 10, 64); err == nil {
+			resp.Meta.Ratelimit.Reset = time.Unix(ts, 0)
+		}
+	}
+
+	return resp, err
+}

--- a/hcloud/client_handler_rate_limit.go
+++ b/hcloud/client_handler_rate_limit.go
@@ -17,15 +17,17 @@ type rateLimitHandler struct {
 func (h *rateLimitHandler) Do(req *http.Request, v any) (resp *Response, err error) {
 	resp, err = h.handler.Do(req, v)
 
-	if h := resp.Header.Get("RateLimit-Limit"); h != "" {
-		resp.Meta.Ratelimit.Limit, _ = strconv.Atoi(h)
-	}
-	if h := resp.Header.Get("RateLimit-Remaining"); h != "" {
-		resp.Meta.Ratelimit.Remaining, _ = strconv.Atoi(h)
-	}
-	if h := resp.Header.Get("RateLimit-Reset"); h != "" {
-		if ts, err := strconv.ParseInt(h, 10, 64); err == nil {
-			resp.Meta.Ratelimit.Reset = time.Unix(ts, 0)
+	if resp != nil && resp.Header != nil {
+		if h := resp.Header.Get("RateLimit-Limit"); h != "" {
+			resp.Meta.Ratelimit.Limit, _ = strconv.Atoi(h)
+		}
+		if h := resp.Header.Get("RateLimit-Remaining"); h != "" {
+			resp.Meta.Ratelimit.Remaining, _ = strconv.Atoi(h)
+		}
+		if h := resp.Header.Get("RateLimit-Reset"); h != "" {
+			if ts, err := strconv.ParseInt(h, 10, 64); err == nil {
+				resp.Meta.Ratelimit.Reset = time.Unix(ts, 0)
+			}
 		}
 	}
 

--- a/hcloud/client_handler_rate_limit_test.go
+++ b/hcloud/client_handler_rate_limit_test.go
@@ -1,0 +1,55 @@
+package hcloud
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRateLimitHandler(t *testing.T) {
+	testCases := []struct {
+		name    string
+		wrapped func(req *http.Request, v any) (*Response, error)
+		want    func(t *testing.T, resp *Response, err error)
+	}{
+		{
+			name: "response",
+			wrapped: func(_ *http.Request, _ any) (*Response, error) {
+				resp := fakeResponse(t, 200, "", false)
+				resp.Header.Set("RateLimit-Limit", "1000")
+				resp.Header.Set("RateLimit-Remaining", "999")
+				resp.Header.Set("RateLimit-Reset", "1511954577")
+				return resp, nil
+			},
+			want: func(t *testing.T, resp *Response, err error) {
+				assert.NoError(t, err)
+				assert.Equal(t, 1000, resp.Meta.Ratelimit.Limit)
+				assert.Equal(t, 999, resp.Meta.Ratelimit.Remaining)
+				assert.Equal(t, time.Unix(1511954577, 0), resp.Meta.Ratelimit.Reset)
+			},
+		},
+		{
+			name: "any error",
+			wrapped: func(_ *http.Request, _ any) (*Response, error) {
+				return nil, fmt.Errorf("any error")
+			},
+			want: func(t *testing.T, resp *Response, err error) {
+				assert.EqualError(t, err, "any error")
+				assert.Nil(t, resp)
+			},
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			m := &mockHandler{testCase.wrapped}
+			h := wrapRateLimitHandler(m)
+
+			resp, err := h.Do(nil, nil)
+
+			testCase.want(t, resp, err)
+		})
+	}
+}

--- a/hcloud/client_handler_retry.go
+++ b/hcloud/client_handler_retry.go
@@ -19,13 +19,9 @@ func (h *retryHandler) Do(req *http.Request, v any) (resp *Response, err error) 
 
 	for {
 		// Clone the request using the original context
-		cloned := req.Clone(req.Context())
-
-		if req.ContentLength > 0 {
-			cloned.Body, err = req.GetBody()
-			if err != nil {
-				return nil, err
-			}
+		cloned, err := cloneRequest(req, req.Context())
+		if err != nil {
+			return nil, err
 		}
 
 		resp, err = h.handler.Do(cloned, v)

--- a/hcloud/client_handler_retry.go
+++ b/hcloud/client_handler_retry.go
@@ -34,7 +34,6 @@ func (h *retryHandler) Do(req *http.Request, v any) (resp *Response, err error) 
 			// - request preparation
 			// - network connectivity
 			// - http status code (see [errorHandler])
-			// - response parsing
 			if IsError(err, ErrorCodeConflict) {
 				time.Sleep(h.backoffFunc(retries))
 				retries++

--- a/hcloud/client_handler_retry.go
+++ b/hcloud/client_handler_retry.go
@@ -1,0 +1,47 @@
+package hcloud
+
+import (
+	"net/http"
+	"time"
+)
+
+func wrapRetryHandler(wrapped handler, backoffFunc BackoffFunc) handler {
+	return &retryHandler{wrapped, backoffFunc}
+}
+
+type retryHandler struct {
+	handler     handler
+	backoffFunc BackoffFunc
+}
+
+func (h *retryHandler) Do(req *http.Request, v any) (resp *Response, err error) {
+	retries := 0
+
+	for {
+		// Clone the request using the original context
+		cloned := req.Clone(req.Context())
+
+		if req.ContentLength > 0 {
+			cloned.Body, err = req.GetBody()
+			if err != nil {
+				return nil, err
+			}
+		}
+
+		resp, err = h.handler.Do(cloned, v)
+		if err != nil {
+			// Beware the diversity of the errors:
+			// - request preparation
+			// - network connectivity
+			// - http status code (see [errorHandler])
+			// - response parsing
+			if IsError(err, ErrorCodeConflict) {
+				time.Sleep(h.backoffFunc(retries))
+				retries++
+				continue
+			}
+		}
+
+		return resp, err
+	}
+}

--- a/hcloud/client_handler_retry_test.go
+++ b/hcloud/client_handler_retry_test.go
@@ -1,0 +1,68 @@
+package hcloud
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/hetznercloud/hcloud-go/v2/hcloud/schema"
+)
+
+func TestRetryHandler(t *testing.T) {
+	testCases := []struct {
+		name    string
+		wrapped func(req *http.Request, v any) (*Response, error)
+		want    int
+	}{
+		{
+			name: "network error",
+			wrapped: func(_ *http.Request, _ any) (*Response, error) {
+				return nil, fmt.Errorf("network error")
+			},
+			want: 0,
+		},
+		{
+			name: "http 503 error",
+			wrapped: func(_ *http.Request, _ any) (*Response, error) {
+				return nil, nil
+			},
+			want: 0,
+		},
+		{
+			name: "api conflict error",
+			wrapped: func(_ *http.Request, _ any) (*Response, error) {
+				return nil, ErrorFromSchema(schema.Error{Code: string(ErrorCodeConflict)})
+			},
+			want: 1,
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			m := &mockHandler{testCase.wrapped}
+
+			retryCount := 0
+			h := wrapRetryHandler(m, func(_ int) time.Duration {
+				// Reset the mock handler to exit the retry loop
+				m.f = func(_ *http.Request, _ any) (*Response, error) { return nil, nil }
+
+				retryCount++
+				return 0
+			})
+
+			client := NewClient(WithToken("dummy"))
+			req, err := client.NewRequest(context.Background(), "GET", "/", nil)
+			require.NoError(t, err)
+
+			assert.Equal(t, 0, retryCount)
+
+			h.Do(req, nil)
+
+			assert.Equal(t, testCase.want, retryCount)
+		})
+	}
+}

--- a/hcloud/client_handler_test.go
+++ b/hcloud/client_handler_test.go
@@ -1,0 +1,35 @@
+package hcloud
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+type mockHandler struct {
+	f func(req *http.Request, v any) (resp *Response, err error)
+}
+
+func (h *mockHandler) Do(req *http.Request, v interface{}) (*Response, error) { return h.f(req, v) }
+
+func fakeResponse(t *testing.T, statusCode int, body string, json bool) *Response {
+	t.Helper()
+
+	w := httptest.NewRecorder()
+	if body != "" && json {
+		w.Header().Set("Content-Type", "application/json")
+	}
+	w.WriteHeader(statusCode)
+
+	if body != "" {
+		_, err := w.Write([]byte(body))
+		require.NoError(t, err)
+	}
+
+	resp := &Response{Response: w.Result()} //nolint: bodyclose
+	require.NoError(t, resp.populateBody())
+
+	return resp
+}


### PR DESCRIPTION
This explodes the multiple concerns mixed in the `Do` method into multiple handlers that are chained, similar to the `http.RoundTripper`.