### PR TITLE
fix(exp): configure response headers before sending them

### DIFF
--- a/hcloud/exp/mockutils/mockutils.go
+++ b/hcloud/exp/mockutils/mockutils.go
@@ -52,19 +52,22 @@ func Handler(t *testing.T, requests []Request) http.HandlerFunc {
 			expected.Want(t, r)
 		}
 
-		w.WriteHeader(expected.Status)
 		switch {
 		case expected.JSON != nil:
 			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(expected.Status)
 			if err := json.NewEncoder(w).Encode(expected.JSON); err != nil {
 				t.Fatal(err)
 			}
 		case expected.JSONRaw != "":
 			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(expected.Status)
 			_, err := w.Write([]byte(expected.JSONRaw))
 			if err != nil {
 				t.Fatal(err)
 			}
+		default:
+			w.WriteHeader(expected.Status)
 		}
 
 		index++

--- a/hcloud/exp/mockutils/mockutils_test.go
+++ b/hcloud/exp/mockutils/mockutils_test.go
@@ -27,6 +27,10 @@ func TestHandler(t *testing.T) {
 			Status:  400,
 			JSONRaw: `{"error": "failed"}`,
 		},
+		{
+			Method: "GET", Path: "/",
+			Status: 503,
+		},
 	}))
 	defer server.Close()
 
@@ -34,13 +38,22 @@ func TestHandler(t *testing.T) {
 	resp, err := http.Get(server.URL)
 	require.NoError(t, err)
 	assert.Equal(t, 200, resp.StatusCode)
+	assert.Equal(t, "application/json", resp.Header.Get("Content-Type"))
 	assert.Equal(t, `{"data":"Hello"}`, readBody(t, resp))
 
 	// Request 2
 	resp, err = http.Get(server.URL)
 	require.NoError(t, err)
 	assert.Equal(t, 400, resp.StatusCode)
+	assert.Equal(t, "application/json", resp.Header.Get("Content-Type"))
 	assert.Equal(t, `{"error": "failed"}`, readBody(t, resp))
+
+	// Request 3
+	resp, err = http.Get(server.URL)
+	require.NoError(t, err)
+	assert.Equal(t, 503, resp.StatusCode)
+	assert.Equal(t, "", resp.Header.Get("Content-Type"))
+	assert.Equal(t, "", readBody(t, resp))
 }
 
 func readBody(t *testing.T, resp *http.Response) string {


### PR DESCRIPTION
Ensure the headers are configured before we set the status code and send the headers.