### PR TITLE
fix(exp): allow request path matching in the want function

### DIFF
--- a/hcloud/exp/mockutils/mockutils.go
+++ b/hcloud/exp/mockutils/mockutils.go
@@ -43,10 +43,14 @@ func Handler(t *testing.T, requests []Request) http.HandlerFunc {
 		}
 
 		expected := requests[index]
-		require.Equal(t,
-			expected.Method+" "+expected.Path,
-			r.Method+" "+r.RequestURI,
-		)
+
+		expectedCall := expected.Method
+		foundCall := r.Method
+		if expected.Path != "" {
+			expectedCall += " " + expected.Path
+			foundCall += " " + r.RequestURI
+		}
+		require.Equal(t, expectedCall, foundCall)
 
 		if expected.Want != nil {
 			expected.Want(t, r)


### PR DESCRIPTION
If the `Request.Path` value is not set, this allows the path matching to happen in the `Request.Want` function.

We sometimes have random values in the URL that require more advanced paths matching.