### PR TITLE
chore: do not retry on bare HTTP 429 or HTTP 503

### DIFF
--- a/hcloud/action_waiter_test.go
+++ b/hcloud/action_waiter_test.go
@@ -99,7 +99,7 @@ func TestWaitFor(t *testing.T) {
 				Name: "succeed with retry",
 				WantRequests: []mockutils.Request{
 					{Method: "GET", Path: "/actions?id=1509772237&page=1&sort=status&sort=id",
-						Status: 503,
+						Status: 502,
 					},
 					{Method: "GET", Path: "/actions?id=1509772237&page=1&sort=status&sort=id",
 						Status: 200,

--- a/hcloud/client_handler_retry.go
+++ b/hcloud/client_handler_retry.go
@@ -69,11 +69,8 @@ func retryPolicy(resp *Response, err error) bool {
 			}
 		case errors.Is(err, ErrStatusCode):
 			switch resp.Response.StatusCode {
-			// 4xx errors
-			case http.StatusTooManyRequests:
-				return true
 			// 5xx errors
-			case http.StatusBadGateway, http.StatusServiceUnavailable, http.StatusGatewayTimeout:
+			case http.StatusBadGateway, http.StatusGatewayTimeout:
 				return true
 			}
 		case errors.As(err, &netErr):

--- a/hcloud/hcloud.go
+++ b/hcloud/hcloud.go
@@ -14,9 +14,7 @@ The following rules defines when a request can be retried:
 When the [http.Client] returned a network timeout error.
 
 When the API returned an HTTP error, with the status code:
-  - [http.StatusTooManyRequests]
   - [http.StatusBadGateway]
-  - [http.StatusServiceUnavailable]
   - [http.StatusGatewayTimeout]
 
 When the API returned an application error, with the code:


### PR DESCRIPTION
Related to #470

This is only a `chore` to prevent confusion with the now updated release-please commits in #470  

We prefer not to retry requests:
- If the ingress returns a "bare" 429, as the backend was not able to respond anyway.
- If the ingress returns a "bare" 503, to prevent possible self-made DDoS, and preventing a disaster recovery.