### PR TITLE
 feat(exp): rename `*utils` package to `*util`

### DIFF
--- a/hcloud/action_waiter_test.go
+++ b/hcloud/action_waiter_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/hetznercloud/hcloud-go/v2/hcloud/exp/mockutils"
+	"github.com/hetznercloud/hcloud-go/v2/hcloud/exp/mockutil"
 )
 
 func TestWaitFor(t *testing.T) {
@@ -14,7 +14,7 @@ func TestWaitFor(t *testing.T) {
 		[]MockedTestCase{
 			{
 				Name: "succeed",
-				WantRequests: []mockutils.Request{
+				WantRequests: []mockutil.Request{
 					{Method: "GET", Path: "/actions?id=1509772237&page=1&sort=status&sort=id",
 						Status: 200,
 						JSONRaw: `{
@@ -52,7 +52,7 @@ func TestWaitFor(t *testing.T) {
 			},
 			{
 				Name: "fail with unknown action",
-				WantRequests: []mockutils.Request{
+				WantRequests: []mockutil.Request{
 					{Method: "GET", Path: "/actions?id=1509772237&page=1&sort=status&sort=id",
 						Status: 200,
 						JSONRaw: `{
@@ -82,7 +82,7 @@ func TestWaitFor(t *testing.T) {
 			},
 			{
 				Name: "fail with server error",
-				WantRequests: []mockutils.Request{
+				WantRequests: []mockutil.Request{
 					{Method: "GET", Path: "/actions?id=1509772237&page=1&sort=status&sort=id",
 						Status: 500,
 					},
@@ -97,7 +97,7 @@ func TestWaitFor(t *testing.T) {
 			},
 			{
 				Name: "succeed with retry",
-				WantRequests: []mockutils.Request{
+				WantRequests: []mockutil.Request{
 					{Method: "GET", Path: "/actions?id=1509772237&page=1&sort=status&sort=id",
 						Status: 503,
 					},
@@ -127,7 +127,7 @@ func TestWaitForFunc(t *testing.T) {
 		[]MockedTestCase{
 			{
 				Name: "succeed",
-				WantRequests: []mockutils.Request{
+				WantRequests: []mockutil.Request{
 					{Method: "GET", Path: "/actions?id=1509772237&id=1509772238&page=1&sort=status&sort=id",
 						Status: 200,
 						JSONRaw: `{

--- a/hcloud/exp/README.md
+++ b/hcloud/exp/README.md
@@ -1,6 +1,6 @@
 # Experimental
 
-The [`exp`](./) namespace holds experimental features for the `hcloud-go` library. The [`exp/kit`](./kit/) namespace is reserved for features not directly related to the `hcloud-go` library, for example the [`sshutils`](./kit/sshutils) package has functions to generate ssh keys.
+The [`exp`](./) namespace holds experimental features for the `hcloud-go` library. The [`exp/kit`](./kit/) namespace is reserved for features not directly related to the `hcloud-go` library, for example the [`sshutil`](./kit/sshutil) package has functions to generate ssh keys.
 
 > [!CAUTION]
 > Breaking changes may occur without notice. Do not use in production!

--- a/hcloud/exp/actionutil/actions.go
+++ b/hcloud/exp/actionutil/actions.go
@@ -1,4 +1,4 @@
-package actionutils
+package actionutil
 
 import "github.com/hetznercloud/hcloud-go/v2/hcloud"
 

--- a/hcloud/exp/actionutil/actions_test.go
+++ b/hcloud/exp/actionutil/actions_test.go
@@ -1,4 +1,4 @@
-package actionutils
+package actionutil
 
 import (
 	"testing"

--- a/hcloud/exp/kit/envutil/env.go
+++ b/hcloud/exp/kit/envutil/env.go
@@ -1,4 +1,4 @@
-package envutils
+package envutil
 
 import (
 	"fmt"

--- a/hcloud/exp/kit/envutil/env_test.go
+++ b/hcloud/exp/kit/envutil/env_test.go
@@ -1,4 +1,4 @@
-package envutils
+package envutil
 
 import (
 	"os"

--- a/hcloud/exp/kit/sshutil/ssh_key.go
+++ b/hcloud/exp/kit/sshutil/ssh_key.go
@@ -1,4 +1,4 @@
-package sshutils
+package sshutil
 
 import (
 	"crypto"

--- a/hcloud/exp/kit/sshutil/ssh_key_test.go
+++ b/hcloud/exp/kit/sshutil/ssh_key_test.go
@@ -1,4 +1,4 @@
-package sshutils
+package sshutil
 
 import (
 	"strings"

--- a/hcloud/exp/labelutil/selector.go
+++ b/hcloud/exp/labelutil/selector.go
@@ -1,4 +1,4 @@
-package labelutils
+package labelutil
 
 import (
 	"fmt"

--- a/hcloud/exp/labelutil/selector_test.go
+++ b/hcloud/exp/labelutil/selector_test.go
@@ -1,4 +1,4 @@
-package labelutils
+package labelutil
 
 import "testing"
 

--- a/hcloud/exp/mockutil/http.go
+++ b/hcloud/exp/mockutil/http.go
@@ -1,4 +1,4 @@
-package mockutils
+package mockutil
 
 import (
 	"encoding/json"

--- a/hcloud/exp/mockutil/http_test.go
+++ b/hcloud/exp/mockutil/http_test.go
@@ -1,4 +1,4 @@
-package mockutils
+package mockutil
 
 import (
 	"fmt"

--- a/hcloud/mocked_test.go
+++ b/hcloud/mocked_test.go
@@ -4,19 +4,19 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/hetznercloud/hcloud-go/v2/hcloud/exp/mockutils"
+	"github.com/hetznercloud/hcloud-go/v2/hcloud/exp/mockutil"
 )
 
 type MockedTestCase struct {
 	Name         string
-	WantRequests []mockutils.Request
+	WantRequests []mockutil.Request
 	Run          func(env testEnv)
 }
 
 func RunMockedTestCases(t *testing.T, testCases []MockedTestCase) {
 	for _, testCase := range testCases {
 		t.Run(testCase.Name, func(t *testing.T) {
-			testServer := httptest.NewServer(mockutils.Handler(t, testCase.WantRequests))
+			testServer := httptest.NewServer(mockutil.Handler(t, testCase.WantRequests))
 
 			env := newTestEnvWithServer(testServer, nil)
 			defer env.Teardown()


### PR DESCRIPTION
Use a smaller and clearer package name.