### PR TITLE
feat: allow configuring retry options

### DIFF
--- a/hcloud/client.go
+++ b/hcloud/client.go
@@ -161,9 +161,26 @@ func WithPollBackoffFunc(f BackoffFunc) ClientOption {
 
 // WithBackoffFunc configures a Client to use the specified backoff function.
 // The backoff function is used for retrying HTTP requests.
+//
+// Deprecated: WithBackoffFunc is deprecated, use [WithRetryOpts] instead.
 func WithBackoffFunc(f BackoffFunc) ClientOption {
 	return func(client *Client) {
 		client.retryBackoffFunc = f
+	}
+}
+
+// RetryOpts defines the options used by [WithRetryOpts].
+type RetryOpts struct {
+	BackoffFunc BackoffFunc
+	MaxRetries  int
+}
+
+// WithRetryOpts configures a Client to use the specified options when retrying API
+// requests.
+func WithRetryOpts(opts RetryOpts) ClientOption {
+	return func(client *Client) {
+		client.retryBackoffFunc = opts.BackoffFunc
+		client.retryMaxRetries = opts.MaxRetries
 	}
 }
 

--- a/hcloud/client_test.go
+++ b/hcloud/client_test.go
@@ -41,7 +41,10 @@ func newTestEnvWithServer(server *httptest.Server, mux *http.ServeMux) testEnv {
 	client := NewClient(
 		WithEndpoint(server.URL),
 		WithToken("token"),
-		WithBackoffFunc(func(_ int) time.Duration { return 0 }),
+		WithRetryOpts(RetryOpts{
+			BackoffFunc: func(_ int) time.Duration { return 0 },
+			MaxRetries:  5,
+		}),
 		WithPollBackoffFunc(func(r int) time.Duration { return 0 }),
 	)
 	return testEnv{


### PR DESCRIPTION
This lets the user configure the retry options, with a custom back off function and the max number of retries. 