### PR TITLE
feat: add jitter in the client default retry exponential backoff

### DIFF
--- a/hcloud/client.go
+++ b/hcloud/client.go
@@ -219,12 +219,19 @@ func WithInstrumentation(registry prometheus.Registerer) ClientOption {
 // NewClient creates a new client.
 func NewClient(options ...ClientOption) *Client {
 	client := &Client{
-		endpoint:         Endpoint,
-		tokenValid:       true,
-		httpClient:       &http.Client{},
-		retryBackoffFunc: ExponentialBackoff(2, time.Second),
-		retryMaxRetries:  5,
-		pollBackoffFunc:  ConstantBackoff(500 * time.Millisecond),
+		endpoint:   Endpoint,
+		tokenValid: true,
+		httpClient: &http.Client{},
+
+		retryBackoffFunc: ExponentialBackoffWithOpts(ExponentialBackoffOpts{
+			Base:       time.Second,
+			Multiplier: 2,
+			Cap:        time.Minute,
+			Jitter:     true,
+		}),
+		retryMaxRetries: 5,
+
+		pollBackoffFunc: ConstantBackoff(500 * time.Millisecond),
 	}
 
 	for _, option := range options {

--- a/hcloud/hcloud.go
+++ b/hcloud/hcloud.go
@@ -5,9 +5,9 @@ The Hetzner Cloud API reference is available at https://docs.hetzner.cloud.
 
 # Retry mechanism
 
-The [Client.Do] method will retry failed requests that match certain criteria. The default
-retry interval is defined by an exponential backoff algorithm truncated to 60s. The
-default maximal number of retries is 5.
+The [Client.Do] method will retry failed requests that match certain criteria. The
+default retry interval is defined by an exponential backoff algorithm truncated to 60s
+with jitter. The default maximal number of retries is 5.
 
 The following rules defines when a request can be retried:
 


### PR DESCRIPTION
Enable jitter in the client default retry exponential backoff function.