### PR TITLE
feat: new APIs for traffic pricings

### DIFF
--- a/hcloud/pricing.go
+++ b/hcloud/pricing.go
@@ -102,6 +102,10 @@ type ServerTypeLocationPricing struct {
 	Location *Location
 	Hourly   Price
 	Monthly  Price
+
+	// IncludedTraffic is the free traffic per month in bytes
+	IncludedTraffic uint64
+	PerTBTraffic    Price
 }
 
 // LoadBalancerTypePricing provides pricing information for a Load Balancer type.

--- a/hcloud/pricing.go
+++ b/hcloud/pricing.go
@@ -8,10 +8,12 @@ import (
 
 // Pricing specifies pricing information for various resources.
 type Pricing struct {
-	Image             ImagePricing
-	FloatingIP        FloatingIPPricing
-	FloatingIPs       []FloatingIPTypePricing
-	PrimaryIPs        []PrimaryIPPricing
+	Image       ImagePricing
+	FloatingIP  FloatingIPPricing
+	FloatingIPs []FloatingIPTypePricing
+	PrimaryIPs  []PrimaryIPPricing
+	// Deprecated: [Pricing.Traffic] is deprecated and will report 0 after 2024-08-05.
+	// Use traffic pricing from [Pricing.ServerTypes] or [Pricing.LoadBalancerTypes] instead.
 	Traffic           TrafficPricing
 	ServerBackup      ServerBackupPricing
 	ServerTypes       []ServerTypePricing

--- a/hcloud/pricing.go
+++ b/hcloud/pricing.go
@@ -120,6 +120,10 @@ type LoadBalancerTypeLocationPricing struct {
 	Location *Location
 	Hourly   Price
 	Monthly  Price
+
+	// IncludedTraffic is the free traffic per month in bytes
+	IncludedTraffic uint64
+	PerTBTraffic    Price
 }
 
 // PricingClient is a client for the pricing API.

--- a/hcloud/schema/pricing.go
+++ b/hcloud/schema/pricing.go
@@ -72,6 +72,9 @@ type PricingServerTypePrice struct {
 	Location     string `json:"location"`
 	PriceHourly  Price  `json:"price_hourly"`
 	PriceMonthly Price  `json:"price_monthly"`
+
+	IncludedTraffic   uint64 `json:"included_traffic"`
+	PricePerTBTraffic Price  `json:"price_per_tb_traffic"`
 }
 
 // PricingLoadBalancerType defines the schema of pricing information for a Load Balancer type.

--- a/hcloud/schema/pricing.go
+++ b/hcloud/schema/pricing.go
@@ -2,12 +2,14 @@ package schema
 
 // Pricing defines the schema for pricing information.
 type Pricing struct {
-	Currency          string                    `json:"currency"`
-	VATRate           string                    `json:"vat_rate"`
-	Image             PricingImage              `json:"image"`
-	FloatingIP        PricingFloatingIP         `json:"floating_ip"`
-	FloatingIPs       []PricingFloatingIPType   `json:"floating_ips"`
-	PrimaryIPs        []PricingPrimaryIP        `json:"primary_ips"`
+	Currency    string                  `json:"currency"`
+	VATRate     string                  `json:"vat_rate"`
+	Image       PricingImage            `json:"image"`
+	FloatingIP  PricingFloatingIP       `json:"floating_ip"`
+	FloatingIPs []PricingFloatingIPType `json:"floating_ips"`
+	PrimaryIPs  []PricingPrimaryIP      `json:"primary_ips"`
+	// Deprecated: [Pricing.Traffic] is deprecated and will report 0 after 2024-08-05.
+	// Use traffic pricing from [Pricing.ServerTypes] or [Pricing.LoadBalancerTypes] instead.
 	Traffic           PricingTraffic            `json:"traffic"`
 	ServerBackup      PricingServerBackup       `json:"server_backup"`
 	ServerTypes       []PricingServerType       `json:"server_types"`

--- a/hcloud/schema/pricing.go
+++ b/hcloud/schema/pricing.go
@@ -90,6 +90,9 @@ type PricingLoadBalancerTypePrice struct {
 	Location     string `json:"location"`
 	PriceHourly  Price  `json:"price_hourly"`
 	PriceMonthly Price  `json:"price_monthly"`
+
+	IncludedTraffic   uint64 `json:"included_traffic"`
+	PricePerTBTraffic Price  `json:"price_per_tb_traffic"`
 }
 
 // PricingGetResponse defines the schema of the response when retrieving pricing information.

--- a/hcloud/schema/server_type.go
+++ b/hcloud/schema/server_type.go
@@ -2,15 +2,18 @@ package schema
 
 // ServerType defines the schema of a server type.
 type ServerType struct {
-	ID              int64                    `json:"id"`
-	Name            string                   `json:"name"`
-	Description     string                   `json:"description"`
-	Cores           int                      `json:"cores"`
-	Memory          float32                  `json:"memory"`
-	Disk            int                      `json:"disk"`
-	StorageType     string                   `json:"storage_type"`
-	CPUType         string                   `json:"cpu_type"`
-	Architecture    string                   `json:"architecture"`
+	ID           int64   `json:"id"`
+	Name         string  `json:"name"`
+	Description  string  `json:"description"`
+	Cores        int     `json:"cores"`
+	Memory       float32 `json:"memory"`
+	Disk         int     `json:"disk"`
+	StorageType  string  `json:"storage_type"`
+	CPUType      string  `json:"cpu_type"`
+	Architecture string  `json:"architecture"`
+
+	// Deprecated: [ServerType.IncludedTraffic] is deprecated and will always report 0 after 2024-08-05.
+	// Use [ServerType.Prices] instead to get the included traffic for each location.
 	IncludedTraffic int64                    `json:"included_traffic"`
 	Prices          []PricingServerTypePrice `json:"prices"`
 	Deprecated      bool                     `json:"deprecated"`

--- a/hcloud/schema_gen.go
+++ b/hcloud/schema_gen.go
@@ -207,10 +207,12 @@ type converter interface {
 
 	// goverter:map PriceHourly Hourly
 	// goverter:map PriceMonthly Monthly
+	// goverter:map PricePerTBTraffic PerTBTraffic
 	LoadBalancerTypeLocationPricingFromSchema(schema.PricingLoadBalancerTypePrice) LoadBalancerTypeLocationPricing
 
 	// goverter:map Hourly PriceHourly
 	// goverter:map Monthly PriceMonthly
+	// goverter:map PerTBTraffic PricePerTBTraffic
 	SchemaFromLoadBalancerTypeLocationPricing(LoadBalancerTypeLocationPricing) schema.PricingLoadBalancerTypePrice
 
 	LoadBalancerServiceFromSchema(schema.LoadBalancerService) LoadBalancerService
@@ -774,6 +776,13 @@ func loadBalancerTypePricingFromSchema(s schema.Pricing) []LoadBalancerTypePrici
 					VATRate:  s.VATRate,
 					Net:      price.PriceMonthly.Net,
 					Gross:    price.PriceMonthly.Gross,
+				},
+				IncludedTraffic: price.IncludedTraffic,
+				PerTBTraffic: Price{
+					Currency: s.Currency,
+					VATRate:  s.VATRate,
+					Net:      price.PricePerTBTraffic.Net,
+					Gross:    price.PricePerTBTraffic.Gross,
 				},
 			}
 		}

--- a/hcloud/schema_gen.go
+++ b/hcloud/schema_gen.go
@@ -263,6 +263,7 @@ type converter interface {
 
 	// goverter:map PriceHourly Hourly
 	// goverter:map PriceMonthly Monthly
+	// goverter:map PricePerTBTraffic PerTBTraffic
 	serverTypePricingFromSchema(schema.PricingServerTypePrice) ServerTypeLocationPricing
 
 	// goverter:map Image.PerGBMonth.Currency Currency
@@ -306,6 +307,7 @@ type converter interface {
 
 	// goverter:map Monthly PriceMonthly
 	// goverter:map Hourly PriceHourly
+	// goverter:map PerTBTraffic PricePerTBTraffic
 	schemaFromServerTypeLocationPricing(ServerTypeLocationPricing) schema.PricingServerTypePrice
 
 	FirewallFromSchema(schema.Firewall) *Firewall
@@ -733,6 +735,13 @@ func serverTypePricingFromSchema(s schema.Pricing) []ServerTypePricing {
 					VATRate:  s.VATRate,
 					Net:      price.PriceMonthly.Net,
 					Gross:    price.PriceMonthly.Gross,
+				},
+				IncludedTraffic: price.IncludedTraffic,
+				PerTBTraffic: Price{
+					Currency: s.Currency,
+					VATRate:  s.VATRate,
+					Net:      price.PricePerTBTraffic.Net,
+					Gross:    price.PricePerTBTraffic.Gross,
 				},
 			}
 		}

--- a/hcloud/schema_gen.go
+++ b/hcloud/schema_gen.go
@@ -711,8 +711,8 @@ func primaryIPPricingFromSchema(s schema.Pricing) []PrimaryIPPricing {
 func trafficPricingFromSchema(s schema.Pricing) TrafficPricing {
 	return TrafficPricing{
 		PerTB: Price{
-			Net:      s.Traffic.PricePerTB.Net,
-			Gross:    s.Traffic.PricePerTB.Gross,
+			Net:      s.Traffic.PricePerTB.Net,   // nolint:staticcheck // Field is deprecated, but we still need to map it as long as it is available
+			Gross:    s.Traffic.PricePerTB.Gross, // nolint:staticcheck // Field is deprecated, but we still need to map it as long as it is available
 			Currency: s.Currency,
 			VATRate:  s.VATRate,
 		},

--- a/hcloud/server_type.go
+++ b/hcloud/server_type.go
@@ -20,7 +20,9 @@ type ServerType struct {
 	StorageType  StorageType
 	CPUType      CPUType
 	Architecture Architecture
-	// IncludedTraffic is the free traffic per month in bytes
+
+	// Deprecated: [ServerType.IncludedTraffic] is deprecated and will always report 0 after 2024-08-05.
+	// Use [ServerType.Pricings] instead to get the included traffic for each location.
 	IncludedTraffic int64
 	Pricings        []ServerTypeLocationPricing
 	DeprecatableResource

--- a/hcloud/zz_schema.go
+++ b/hcloud/zz_schema.go
@@ -2165,6 +2165,8 @@ func (c *converterImpl) schemaFromServerTypeLocationPricing(source ServerTypeLoc
 	schemaPricingServerTypePrice.Location = c.pHcloudLocationToString(source.Location)
 	schemaPricingServerTypePrice.PriceHourly = c.hcloudPriceToSchemaPrice(source.Hourly)
 	schemaPricingServerTypePrice.PriceMonthly = c.hcloudPriceToSchemaPrice(source.Monthly)
+	schemaPricingServerTypePrice.IncludedTraffic = source.IncludedTraffic
+	schemaPricingServerTypePrice.PricePerTBTraffic = c.hcloudPriceToSchemaPrice(source.PerTBTraffic)
 	return schemaPricingServerTypePrice
 }
 func (c *converterImpl) schemaFromServerTypePricing(source ServerTypePricing) schema.PricingServerType {
@@ -2274,6 +2276,8 @@ func (c *converterImpl) serverTypePricingFromSchema(source schema.PricingServerT
 	hcloudServerTypeLocationPricing.Location = &hcloudLocation
 	hcloudServerTypeLocationPricing.Hourly = c.PriceFromSchema(source.PriceHourly)
 	hcloudServerTypeLocationPricing.Monthly = c.PriceFromSchema(source.PriceMonthly)
+	hcloudServerTypeLocationPricing.IncludedTraffic = source.IncludedTraffic
+	hcloudServerTypeLocationPricing.PerTBTraffic = c.PriceFromSchema(source.PricePerTBTraffic)
 	return hcloudServerTypeLocationPricing
 }
 func (c *converterImpl) timeTimeToTimeTime(source time.Time) time.Time {

--- a/hcloud/zz_schema.go
+++ b/hcloud/zz_schema.go
@@ -315,6 +315,8 @@ func (c *converterImpl) LoadBalancerTypeLocationPricingFromSchema(source schema.
 	hcloudLoadBalancerTypeLocationPricing.Location = &hcloudLocation
 	hcloudLoadBalancerTypeLocationPricing.Hourly = c.PriceFromSchema(source.PriceHourly)
 	hcloudLoadBalancerTypeLocationPricing.Monthly = c.PriceFromSchema(source.PriceMonthly)
+	hcloudLoadBalancerTypeLocationPricing.IncludedTraffic = source.IncludedTraffic
+	hcloudLoadBalancerTypeLocationPricing.PerTBTraffic = c.PriceFromSchema(source.PricePerTBTraffic)
 	return hcloudLoadBalancerTypeLocationPricing
 }
 func (c *converterImpl) LocationFromSchema(source schema.Location) *Location {
@@ -799,6 +801,8 @@ func (c *converterImpl) SchemaFromLoadBalancerTypeLocationPricing(source LoadBal
 	schemaPricingLoadBalancerTypePrice.Location = c.pHcloudLocationToString(source.Location)
 	schemaPricingLoadBalancerTypePrice.PriceHourly = c.hcloudPriceToSchemaPrice(source.Hourly)
 	schemaPricingLoadBalancerTypePrice.PriceMonthly = c.hcloudPriceToSchemaPrice(source.Monthly)
+	schemaPricingLoadBalancerTypePrice.IncludedTraffic = source.IncludedTraffic
+	schemaPricingLoadBalancerTypePrice.PricePerTBTraffic = c.hcloudPriceToSchemaPrice(source.PerTBTraffic)
 	return schemaPricingLoadBalancerTypePrice
 }
 func (c *converterImpl) SchemaFromLoadBalancerUpdateServiceOpts(source LoadBalancerUpdateServiceOpts) schema.LoadBalancerActionUpdateServiceRequest {


### PR DESCRIPTION
The API has been updated to provide a better insight and more flexibility for displaying the pricing of traffic for servers and load balancers.

In addition to the new fields, the old fields are deprecated and will be set to `null` in the API on 2024-08-05.

As far as we could tell they are not widely used in Open Source code, please check if you are using them in any private code. Some linters automatically check for deprecated fields, if you use `golangci-lint` this is provided by the `staticcheck` linter.

You can learn more about this change in [our changelog](https://docs.hetzner.cloud/changelog#2024-07-25-cloud-api-returns-traffic-information-in-different-format).

### Upgrading

#### Server Type Included Traffic

If you were using the field `hcloud.ServerType.IncludedTraffic`, you can now get the information through `hcloud.ServerType.Pricings`:

```go
func main() {
    // previous
    includedTraffic := serverType.IncludedTraffic

    // now
    locationOfInterest := "fsn1"
    var includedTraffic uint64
    for _, price := range serverType.Pricings {
        if price.Location.Name == locationOfInterest {
            includedTraffic = price.IncludedTraffic
            break
        }
    }
}
```

#### Traffic Prices

If you were using the field `hcloud.Pricing.Traffic`, you can now get the information through `hcloud.Pricing.ServerTypes` or `hcloud.Pricing.LoadBalancerTypes`:

```go
func main() {
    // previous
    trafficPrice := pricing.Traffic

    // now
    serverTypeOfInterest := "cx22"
    locationOfInterest := "fsn1"

    var trafficPrice hcloud.Price
    for _, serverTypePricings := range pricing.ServerTypes {
        if serverTypePricings.ServerType.Name == serverTypeOfInterest {
            for _, price := range serverTypePricings {
               if price.Location.Name == locationOfInterest {
                   trafficPrice = price.PerTBTraffic
                   break
               }
            }
        }
    }
}
```

### release-please Info

BEGIN_COMMIT_OVERRIDE
feat(server-type): new traffic price fields
feat(load-balancer-type): new traffic price fields
feat(pricing): mark traffic field as deprecated
feat(server-type): mark included traffic field as deprecated
END_COMMIT_OVERRIDE