### PR TITLE
feat(network): add new network zone ap-southeast [release-1.x]

### DIFF
--- a/hcloud/network.go
+++ b/hcloud/network.go
@@ -19,9 +19,10 @@ type NetworkZone string
 
 // List of available Network Zones.
 const (
-	NetworkZoneEUCentral NetworkZone = "eu-central"
-	NetworkZoneUSEast    NetworkZone = "us-east"
-	NetworkZoneUSWest    NetworkZone = "us-west"
+	NetworkZoneEUCentral   NetworkZone = "eu-central"
+	NetworkZoneUSEast      NetworkZone = "us-east"
+	NetworkZoneUSWest      NetworkZone = "us-west"
+	NetworkZoneAPSouthEast NetworkZone = "ap-southeast"
 )
 
 // NetworkSubnetType specifies a type of a subnet.


### PR DESCRIPTION
Network Zone was added today and includes the `sin` (Singapore) location.

Learn more at https://docs.hetzner.cloud/changelog#2024-08-06-new-location-singapore