### PR TITLE
fix: `invalid_input` API errors may not return details

### DIFF
--- a/hcloud/schema/error.go
+++ b/hcloud/schema/error.go
@@ -17,7 +17,7 @@ func (e *Error) UnmarshalJSON(data []byte) (err error) {
 	if err = json.Unmarshal(data, alias); err != nil {
 		return
 	}
-	if e.Code == "invalid_input" {
+	if e.Code == "invalid_input" && len(e.DetailsRaw) > 0 {
 		details := ErrorDetailsInvalidInput{}
 		if err = json.Unmarshal(e.DetailsRaw, &details); err != nil {
 			return


### PR DESCRIPTION
The create uploaded certificate endpoint may return the following error:

```
{
  "error": {
    "code": "invalid_input",
    "message": "certificate must use larger key size"
  }
}
```

This change ensure that we do not get a json unmarshal error (unexpected end of json) while trying to parse a non-existing details data.