### PR TITLE
feat(exp): add `actionutil.AllForResource`

### DIFF
--- a/hcloud/exp/actionutil/actions.go
+++ b/hcloud/exp/actionutil/actions.go
@@ -1,6 +1,11 @@
 package actionutil
 
-import "github.com/hetznercloud/hcloud-go/v2/hcloud"
+import (
+	"context"
+	"slices"
+
+	"github.com/hetznercloud/hcloud-go/v2/hcloud"
+)
 
 // AppendNext return the action and the next actions in a new slice.
 func AppendNext(action *hcloud.Action, nextActions []*hcloud.Action) []*hcloud.Action {
@@ -8,4 +13,25 @@ func AppendNext(action *hcloud.Action, nextActions []*hcloud.Action) []*hcloud.A
 	all = append(all, action)
 	all = append(all, nextActions...)
 	return all
+}
+
+func AllForResource(
+	ctx context.Context,
+	actionClient *hcloud.ResourceActionClient,
+	opts hcloud.ActionListOpts,
+	resourceType hcloud.ActionResourceType,
+	resourceID int64,
+) ([]*hcloud.Action, error) {
+	actions, err := actionClient.All(ctx, opts)
+	if err != nil {
+		return nil, err
+	}
+
+	actions = slices.Clip(slices.DeleteFunc(actions, func(action *hcloud.Action) bool {
+		return !slices.ContainsFunc(action.Resources, func(resource *hcloud.ActionResource) bool {
+			return resource.Type == resourceType && resource.ID == resourceID
+		})
+	}))
+
+	return actions, nil
 }

--- a/hcloud/exp/actionutil/actions_test.go
+++ b/hcloud/exp/actionutil/actions_test.go
@@ -1,11 +1,15 @@
 package actionutil
 
 import (
+	"context"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
+	"github.com/hetznercloud/hcloud-go/v2/hcloud/exp/mockutil"
+	"github.com/hetznercloud/hcloud-go/v2/hcloud/schema"
 )
 
 func TestAppendNext(t *testing.T) {
@@ -15,4 +19,32 @@ func TestAppendNext(t *testing.T) {
 	actions := AppendNext(action, nextActions)
 
 	assert.Equal(t, []*hcloud.Action{{ID: 1}, {ID: 2}, {ID: 3}}, actions)
+}
+
+func TestAllForResource(t *testing.T) {
+	ctx := context.Background()
+
+	server := httptest.NewServer(mockutil.Handler(t, []mockutil.Request{
+		{
+			Method: "GET", Path: "/firewalls/actions?page=1&status=running",
+			Status: 200,
+			JSON: schema.ActionListResponse{
+				Actions: []schema.Action{
+					{Resources: []schema.ActionResourceReference{{Type: "server", ID: 8}}},
+					{Resources: []schema.ActionResourceReference{{Type: "server", ID: 8}, {Type: "firewall", ID: 10}}},
+					{Resources: []schema.ActionResourceReference{{Type: "server", ID: 10}}},
+					{Resources: []schema.ActionResourceReference{{Type: "firewall", ID: 8}}},
+				},
+			},
+		},
+	}))
+	client := hcloud.NewClient(hcloud.WithEndpoint(server.URL))
+
+	actions, err := AllForResource(ctx,
+		client.Firewall.Action,
+		hcloud.ActionListOpts{Status: []hcloud.ActionStatus{hcloud.ActionStatusRunning}},
+		hcloud.ActionResourceTypeServer, 8,
+	)
+	assert.NoError(t, err)
+	assert.Len(t, actions, 2)
 }


### PR DESCRIPTION
Allow the users to fetch actions related to a specific resource.

This may be used as follows:
```go
actions, err := actionutil.AllForResource(ctx,
	client.Firewall.Action,
	hcloud.ActionListOpts{Status: []hcloud.ActionStatus{hcloud.ActionStatusRunning}},
	hcloud.ActionResourceTypeServer, server.ID,
)
if err != nil {
	return err
}
if err := client.Action.WaitFor(ctx, actions...); err != nil {
	return err
}
```