### PR TITLE
fix: deprecate pricing floating ip field

### DIFF
--- a/hcloud/pricing.go
+++ b/hcloud/pricing.go
@@ -8,7 +8,8 @@ import (
 
 // Pricing specifies pricing information for various resources.
 type Pricing struct {
-	Image       ImagePricing
+	Image ImagePricing
+	// Deprecated: [Pricing.FloatingIP] is deprecated, use [Pricing.FloatingIPs] instead.
 	FloatingIP  FloatingIPPricing
 	FloatingIPs []FloatingIPTypePricing
 	PrimaryIPs  []PrimaryIPPricing

--- a/hcloud/schema/pricing.go
+++ b/hcloud/schema/pricing.go
@@ -2,9 +2,10 @@ package schema
 
 // Pricing defines the schema for pricing information.
 type Pricing struct {
-	Currency    string                  `json:"currency"`
-	VATRate     string                  `json:"vat_rate"`
-	Image       PricingImage            `json:"image"`
+	Currency string       `json:"currency"`
+	VATRate  string       `json:"vat_rate"`
+	Image    PricingImage `json:"image"`
+	// Deprecated: [Pricing.FloatingIP] is deprecated, use [Pricing.FloatingIPs] instead.
 	FloatingIP  PricingFloatingIP       `json:"floating_ip"`
 	FloatingIPs []PricingFloatingIPType `json:"floating_ips"`
 	PrimaryIPs  []PricingPrimaryIP      `json:"primary_ips"`

--- a/hcloud/schema_gen.go
+++ b/hcloud/schema_gen.go
@@ -658,8 +658,8 @@ func imagePricingFromSchema(s schema.Pricing) ImagePricing {
 func floatingIPPricingFromSchema(s schema.Pricing) FloatingIPPricing {
 	return FloatingIPPricing{
 		Monthly: Price{
-			Net:      s.FloatingIP.PriceMonthly.Net,
-			Gross:    s.FloatingIP.PriceMonthly.Gross,
+			Net:      s.FloatingIP.PriceMonthly.Net,   // nolint:staticcheck // Field is deprecated, but removal is not planned
+			Gross:    s.FloatingIP.PriceMonthly.Gross, // nolint:staticcheck // Field is deprecated, but removal is not planned
 			Currency: s.Currency,
 			VATRate:  s.VATRate,
 		},


### PR DESCRIPTION
See https://docs.hetzner.cloud/changelog#2024-08-29-field-floating_ip-in-pricing-response-is-now-deprecated