### PR TITLE
feat: add support for Go 1.23

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.22"
+          go-version: "1.23"
 
       - uses: golangci/golangci-lint-action@v6
         with:
@@ -26,6 +26,7 @@ jobs:
         go-version:
           - "1.21"
           - "1.22"
+          - "1.23"
 
     runs-on: ubuntu-latest
     steps:
@@ -49,7 +50,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.22"
+          go-version: "1.23"
           cache: false
 
       - run: go generate ./...

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -22,7 +22,7 @@ cache:
 
 build:
   stage: build
-  image: golang:1.22
+  image: golang:1.23
   script:
     - go env
     - go mod download
@@ -35,7 +35,7 @@ test:lint:
 
 test:unit:
   stage: test
-  image: golang:1.22
+  image: golang:1.23
   script:
     - go test -v -race -coverprofile=coverage.txt -covermode=atomic ./...
     - go get github.com/boumenot/gocover-cobertura

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,10 @@ module github.com/hetznercloud/hcloud-go/v2
 // It should never be higher than the lowest currently supported version of Go.
 go 1.21
 
+// The toolchain version describes which Go version to use for testing, generating etc.
+// It should always be the newest version.
+toolchain go1.23.1
+
 require (
 	github.com/google/go-cmp v0.6.0
 	github.com/jmattheis/goverter v1.5.1


### PR DESCRIPTION
This PR updates our Go tooling version to 1.23 while keeping the minimum required Go version for dependencies at Go 1.21.