### PR TITLE
feat: allow retrieving the action from an action error

### DIFF
--- a/hcloud/action.go
+++ b/hcloud/action.go
@@ -54,6 +54,13 @@ const (
 type ActionError struct {
 	Code    string
 	Message string
+
+	action *Action
+}
+
+// Action returns the [Action] that triggered the error if available.
+func (e ActionError) Action() *Action {
+	return e.action
 }
 
 func (e ActionError) Error() string {
@@ -65,6 +72,7 @@ func (a *Action) Error() error {
 		return ActionError{
 			Code:    a.ErrorCode,
 			Message: a.ErrorMessage,
+			action:  a,
 		}
 	}
 	return nil


### PR DESCRIPTION
When an action error occurs within the action waiter utilities, we are missing information about the related action that failed. With this change, we can now retrieve the action that triggered the failure after casting the error to an action error.