### PR TITLE
feat: include action ID in action error string

### DIFF
--- a/hcloud/action.go
+++ b/hcloud/action.go
@@ -64,9 +64,10 @@ func (e ActionError) Action() *Action {
 }
 
 func (e ActionError) Error() string {
-	if e.action != nil {
+	action := e.Action()
+	if action != nil {
 		// For easier debugging, the error string contains the Action ID.
-		return fmt.Sprintf("%s (%s, %d)", e.Message, e.Code, e.action.ID)
+		return fmt.Sprintf("%s (%s, %d)", e.Message, e.Code, action.ID)
 	}
 	return fmt.Sprintf("%s (%s)", e.Message, e.Code)
 }

--- a/hcloud/action.go
+++ b/hcloud/action.go
@@ -64,6 +64,10 @@ func (e ActionError) Action() *Action {
 }
 
 func (e ActionError) Error() string {
+	if e.action != nil {
+		// For easier debugging, the error string contains the Action ID.
+		return fmt.Sprintf("%s (%s, %d)", e.Message, e.Code, e.action.ID)
+	}
 	return fmt.Sprintf("%s (%s)", e.Message, e.Code)
 }
 

--- a/hcloud/action_test.go
+++ b/hcloud/action_test.go
@@ -7,8 +7,21 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/hetznercloud/hcloud-go/v2/hcloud/schema"
 )
+
+func TestActionError(t *testing.T) {
+	assert.Equal(t,
+		"action failed (failed)",
+		ActionError{Code: "failed", Message: "action failed"}.Error(),
+	)
+	assert.Equal(t,
+		"action failed (failed, 12345)",
+		ActionError{Code: "failed", Message: "action failed", action: &Action{ID: 12345}}.Error(),
+	)
+}
 
 func TestActionClientGetByID(t *testing.T) {
 	env := newTestEnv()


### PR DESCRIPTION
This allows us to easily debug the failed action from user provided logs.