### PR TITLE
feat(exp): add mockutil.Server helper

### DIFF
--- a/hcloud/exp/mockutil/http.go
+++ b/hcloud/exp/mockutil/http.go
@@ -3,6 +3,7 @@ package mockutil
 import (
 	"encoding/json"
 	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -82,4 +83,14 @@ func Handler(t *testing.T, requests []Request) http.HandlerFunc {
 
 		index++
 	})
+}
+
+// Server is a [httptest.Server] wrapping a [Handler] that closes itself at the end of the test.
+func Server(t *testing.T, requests []Request) *httptest.Server {
+	t.Helper()
+
+	server := httptest.NewServer(Handler(t, requests))
+	t.Cleanup(server.Close)
+
+	return server
 }

--- a/hcloud/exp/mockutil/http_test.go
+++ b/hcloud/exp/mockutil/http_test.go
@@ -5,7 +5,6 @@ import (
 	"io"
 	"math/rand"
 	"net/http"
-	"net/http/httptest"
 	"strings"
 	"testing"
 
@@ -14,7 +13,7 @@ import (
 )
 
 func TestHandler(t *testing.T) {
-	server := httptest.NewServer(Handler(t, []Request{
+	server := Server(t, []Request{
 		{
 			Method: "GET", Path: "/",
 			Status: 200,
@@ -40,8 +39,7 @@ func TestHandler(t *testing.T) {
 			},
 			Status: 200,
 		},
-	}))
-	defer server.Close()
+	})
 
 	// Request 1
 	resp, err := http.Get(server.URL)


### PR DESCRIPTION
This helper ensures that the wrapped test server will be closed at the end of each test.