### PR TITLE
feat: add deprecated_api_endpoint error code

### DIFF
--- a/hcloud/error.go
+++ b/hcloud/error.go
@@ -30,6 +30,7 @@ const (
 	ErrorCodeRobotUnavailable      ErrorCode = "robot_unavailable"       // Robot was not available. The caller may retry the operation after a short delay
 	ErrorCodeResourceLocked        ErrorCode = "resource_locked"         // The resource is locked. The caller should contact support
 	ErrorUnsupportedError          ErrorCode = "unsupported_error"       // The given resource does not support this
+	ErrorDeprecatedAPIEndpoint     ErrorCode = "deprecated_api_endpoint" // The request can not be answered because the API functionality was removed
 
 	// Server related error codes.
 
@@ -125,6 +126,11 @@ type ErrorDetailsInvalidInput struct {
 type ErrorDetailsInvalidInputField struct {
 	Name     string
 	Messages []string
+}
+
+// ErrorDetailsDeprecatedAPIEndpoint contains the details of a 'deprecated_api_endpoint' error.
+type ErrorDetailsDeprecatedAPIEndpoint struct {
+	Announcement string
 }
 
 // IsError returns whether err is an API error with one of the given error codes.

--- a/hcloud/schema/error.go
+++ b/hcloud/schema/error.go
@@ -24,6 +24,13 @@ func (e *Error) UnmarshalJSON(data []byte) (err error) {
 		}
 		alias.Details = details
 	}
+	if e.Code == "deprecated_api_endpoint" && len(e.DetailsRaw) > 0 {
+		details := ErrorDetailsDeprecatedAPIEndpoint{}
+		if err = json.Unmarshal(e.DetailsRaw, &details); err != nil {
+			return
+		}
+		alias.Details = details
+	}
 	return
 }
 
@@ -39,4 +46,10 @@ type ErrorDetailsInvalidInput struct {
 		Name     string   `json:"name"`
 		Messages []string `json:"messages"`
 	} `json:"fields"`
+}
+
+// ErrorDetailsDeprecatedAPIEndpoint defines the schema of the Details field
+// of an error with code 'deprecated_api_endpoint'.
+type ErrorDetailsDeprecatedAPIEndpoint struct {
+	Announcement string `json:"announcement"`
 }

--- a/hcloud/schema/error_test.go
+++ b/hcloud/schema/error_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 )
 
-func TestError(t *testing.T) {
+func TestInvalidInputError(t *testing.T) {
 	t.Run("UnmarshalJSON", func(t *testing.T) {
 		data := []byte(`{
 			"code": "invalid_input",
@@ -49,6 +49,35 @@ func TestError(t *testing.T) {
 		}
 		if d.Fields[0].Messages[0] != "is required" {
 			t.Errorf("unexpected Details.Fields[0].Messages[0]: %v", d.Fields[0].Messages[0])
+		}
+	})
+}
+
+func TestDeprecatedAPIEndpointError(t *testing.T) {
+	t.Run("UnmarshalJSON", func(t *testing.T) {
+		data := []byte(`{
+			"code": "deprecated_api_endpoint",
+			"message": "API functionality was removed",
+			"details": {
+				"announcement": "https://docs.hetzner.cloud/changelog#2023-07-20-foo-endpoint-is-deprecated"
+			}
+		}`)
+
+		e := &Error{}
+		err := json.Unmarshal(data, e)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if e.Details == nil {
+			t.Fatalf("unexpected Details: %v", e.Details)
+		}
+		d, ok := e.Details.(ErrorDetailsDeprecatedAPIEndpoint)
+		if !ok {
+			t.Fatalf("unexpected Details type (should be ErrorDetailsDeprecatedAPIEndpoint): %v", e.Details)
+		}
+		if d.Announcement != "https://docs.hetzner.cloud/changelog#2023-07-20-foo-endpoint-is-deprecated" {
+			t.Fatalf("unexpected Details.Announcement: %v", d.Announcement)
 		}
 	})
 }

--- a/hcloud/schema_gen.go
+++ b/hcloud/schema_gen.go
@@ -609,37 +609,48 @@ func intSecondsFromDuration(d time.Duration) int {
 }
 
 func errorDetailsFromSchema(d interface{}) interface{} {
-	if d, ok := d.(schema.ErrorDetailsInvalidInput); ok {
+	switch typed := d.(type) {
+	case schema.ErrorDetailsInvalidInput:
 		details := ErrorDetailsInvalidInput{
-			Fields: make([]ErrorDetailsInvalidInputField, len(d.Fields)),
+			Fields: make([]ErrorDetailsInvalidInputField, len(typed.Fields)),
 		}
-		for i, field := range d.Fields {
+		for i, field := range typed.Fields {
 			details.Fields[i] = ErrorDetailsInvalidInputField{
 				Name:     field.Name,
 				Messages: field.Messages,
 			}
 		}
 		return details
+
+	case schema.ErrorDetailsDeprecatedAPIEndpoint:
+		return ErrorDetailsDeprecatedAPIEndpoint{
+			Announcement: typed.Announcement,
+		}
 	}
 	return nil
 }
 
 func schemaFromErrorDetails(d interface{}) interface{} {
-	if d, ok := d.(ErrorDetailsInvalidInput); ok {
+	switch typed := d.(type) {
+	case ErrorDetailsInvalidInput:
 		details := schema.ErrorDetailsInvalidInput{
 			Fields: make([]struct {
 				Name     string   `json:"name"`
 				Messages []string `json:"messages"`
-			}, len(d.Fields)),
+			}, len(typed.Fields)),
 		}
-		for i, field := range d.Fields {
+		for i, field := range typed.Fields {
 			details.Fields[i] = struct {
 				Name     string   `json:"name"`
 				Messages []string `json:"messages"`
 			}{Name: field.Name, Messages: field.Messages}
 		}
 		return details
+
+	case ErrorDetailsDeprecatedAPIEndpoint:
+		return schema.ErrorDetailsDeprecatedAPIEndpoint{Announcement: typed.Announcement}
 	}
+
 	return nil
 }
 

--- a/hcloud/schema_test.go
+++ b/hcloud/schema_test.go
@@ -703,6 +703,11 @@ func TestErrorSchema(t *testing.T) {
 			"message": "invalid input",
 			"details": {"fields":[{"name":"broken_field","messages":["is required"]}]}
 		}`,
+		"deprecated_api_endpoint": `{
+			"code": "deprecated_api_endpoint",
+			"message": "API functionality was removed",
+			"details": {"announcement":"https://docs.hetzner.cloud/changelog#2023-07-20-foo-endpoint-is-deprecated"}
+		}`,
 	}
 
 	for name, data := range testCases {


### PR DESCRIPTION
This error code is returned when a user tries to access functionality that was removed from the API. It contains a link to the changelog announcement describing the removal.