### PR TITLE
docs: add links to api changelog

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,13 @@ Package hcloud is a library for the Hetzner Cloud API.
 The library’s documentation is available at [pkg.go.dev](https://godoc.org/github.com/hetznercloud/hcloud-go/v2/hcloud),
 the public API documentation is available at [docs.hetzner.cloud](https://docs.hetzner.cloud/).
 
+> [!IMPORTANT]
+> Make sure to follow our API changelog available at
+> [docs.hetzner.cloud/changelog](https://docs.hetzner.cloud/changelog) (or the RRS feed
+> available at
+> [docs.hetzner.cloud/changelog/feed.rss](https://docs.hetzner.cloud/changelog/feed.rss))
+> to be notified about additions, deprecations and removals.
+
 ## Installation
 
 ```sh

--- a/hcloud/hcloud.go
+++ b/hcloud/hcloud.go
@@ -3,6 +3,10 @@ Package hcloud is a library for the Hetzner Cloud API.
 
 The Hetzner Cloud API reference is available at https://docs.hetzner.cloud.
 
+Make sure to follow our API changelog available at https://docs.hetzner.cloud/changelog
+(or the RRS feed available at https://docs.hetzner.cloud/changelog/feed.rss) to be
+notified about additions, deprecations and removals.
+
 # Retry mechanism
 
 The [Client.Do] method will retry failed requests that match certain criteria. The


### PR DESCRIPTION
Users must subscribe to our changelog, or they might not be notified about additions, deprecations and removals.