### PR TITLE
docs: drop support for the v1 releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - release-1.x
   pull_request:
 
 jobs:

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - release-1.x
 
 jobs:
   release-please:

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -4,8 +4,8 @@ This guide is intended for _maintainers_.
 
 ## Release Branches
 
-All development targets the `main` branch. New releases for the 2.x series are cut from this.
+All development targets the `main` branch. New releases for the latest major version series are cut from this branch.
 
-For the 1.x series which will be supported until at least September 1 2023 we also have a `release-1.x` branch where we try to backport all bug fixes.
+For the older major versions, we also have `release-<major>.x` branches where we try to backport all bug fixes.
 
-Backports are done by [tibdex/backport](https://github.com/tibdex/backport). Apply the label `backport release-1.x` to the PRs and once they are merged a new PR is opened.
+Backports are done by [tibdex/backport](https://github.com/tibdex/backport). Apply the label `backport release-<major>.x` to the PRs and once they are merged a new PR is opened.

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ func main() {
 ### Support
 
 - `v2` is actively maintained by Hetzner Cloud
-- `v1` is supported until September 1st 2023 and will continue to receive new features until then. See [#263](https://github.com/hetznercloud/hcloud-go/issues/263).
+- `v1` is unsupported since February 2025.
 
 ### From v1 to v2
 


### PR DESCRIPTION
Related to #263

This removes support for our v1 maintenance releases branch.