### PR TITLE
docs: drop support for the v1 releases (#590)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - release-1.x
 
 jobs:
   build:

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - release-1.x
 
 jobs:
   release-please:

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -4,8 +4,8 @@ This guide is intended for _maintainers_.
 
 ## Release Branches
 
-All development targets the `main` branch. New releases for the 2.x series are cut from this.
+All development targets the `main` branch. New releases for the latest major version series are cut from this branch.
 
-For the 1.x series which will be supported until at least September 1 2023 we also have a `release-1.x` branch where we try to backport all bug fixes.
+For the older major versions, we also have `release-<major>.x` branches where we try to backport all bug fixes.
 
-Backports are done by [tibdex/backport](https://github.com/tibdex/backport). Apply the label `backport release-1.x` to the PRs and once they are merged a new PR is opened.
+Backports are done by [tibdex/backport](https://github.com/tibdex/backport). Apply the label `backport release-<major>.x` to the PRs and once they are merged a new PR is opened.

--- a/README.md
+++ b/README.md
@@ -8,6 +8,9 @@ Package hcloud is a library for the Hetzner Cloud API.
 The library’s documentation is available at [GoDoc](https://godoc.org/github.com/hetznercloud/hcloud-go/hcloud),
 the public API documentation is available at [docs.hetzner.cloud](https://docs.hetzner.cloud/).
 
+> [!IMPORTANT]
+> v1 is unsupported since February 2025.
+
 ## Example
 
 ```go


### PR DESCRIPTION
Related to #263

This removes support for our v1 maintenance releases branch.

(cherry picked from commit 54f73407625c693ee619d2ee15018e3da91e5187)