### PR TITLE
feat: add support for Go 1.24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.23"
+          go-version: "1.24"
 
       - uses: golangci/golangci-lint-action@v6
         with:
@@ -23,9 +23,9 @@ jobs:
     strategy:
       matrix:
         go-version:
-          - "1.21"
           - "1.22"
           - "1.23"
+          - "1.24"
 
     runs-on: ubuntu-latest
     steps:
@@ -49,7 +49,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.23"
+          go-version: "1.24"
           cache: false
 
       - run: go generate ./...

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -22,7 +22,7 @@ cache:
 
 build:
   stage: build
-  image: golang:1.23
+  image: golang:1.24
   script:
     - go env
     - go mod download
@@ -35,7 +35,7 @@ test:lint:
 
 test:unit:
   stage: test
-  image: golang:1.23
+  image: golang:1.24
   script:
     - go test -v -race -coverprofile=coverage.txt -covermode=atomic ./...
     - go get github.com/boumenot/gocover-cobertura

--- a/go.mod
+++ b/go.mod
@@ -4,11 +4,11 @@ module github.com/hetznercloud/hcloud-go/v2
 // all dependends to update to the new version.
 // As long as we do not depend on any newer language feature this can be kept at the current value.
 // It should never be higher than the lowest currently supported version of Go.
-go 1.21
+go 1.22
 
 // The toolchain version describes which Go version to use for testing, generating etc.
 // It should always be the newest version.
-toolchain go1.23.7
+toolchain go1.24.1
 
 require (
 	github.com/google/go-cmp v0.7.0


### PR DESCRIPTION
This PR updates our Go tooling version to 1.24 while keeping the minimum required Go version for dependencies at Go 1.22.