### PR TITLE
refactor: do not copy loop var

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -37,7 +37,7 @@ linters:
     - errcheck
     - errname
     - exhaustive
-    # - copyloopvar TODO: re-enable once go is upgraded to 1.22
+    - copyloopvar
     - gci
     - gocritic
     - godot

--- a/hcloud/certificate_test.go
+++ b/hcloud/certificate_test.go
@@ -67,7 +67,6 @@ func TestCertificateCreateOptsValidate_Uploaded(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			err := tt.opts.Validate()
 			if tt.errMsg != "" {
@@ -112,7 +111,6 @@ func TestCertificateCreateOptsValidate_Managed(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			err := tt.opts.Validate()
 			if tt.errMsg != "" {

--- a/hcloud/load_balancer_test.go
+++ b/hcloud/load_balancer_test.go
@@ -1198,7 +1198,6 @@ func TestLoadBalancerGetMetrics(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			env := newTestEnv()
 			defer env.Teardown()

--- a/hcloud/schema_test.go
+++ b/hcloud/schema_test.go
@@ -1269,7 +1269,6 @@ func TestCertificateSchema(t *testing.T) {
 		},
 	}
 	for _, testCase := range testCases {
-		testCase := testCase
 		t.Run(testCase.name, func(t *testing.T) {
 			var s schema.Certificate
 			assert.NoError(t, json.Unmarshal([]byte(testCase.data), &s))
@@ -2062,7 +2061,6 @@ func TestServerMetricsFromSchema(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			resp := tt.respFn()
 			actual, err := serverMetricsFromSchema(resp)
@@ -2232,7 +2230,6 @@ func TestLoadBalancerMetricsFromSchema(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			resp := tt.respFn()
 			actual, err := loadBalancerMetricsFromSchema(resp)

--- a/hcloud/server_test.go
+++ b/hcloud/server_test.go
@@ -2285,7 +2285,6 @@ func TestServerGetMetrics(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			env := newTestEnv()
 			defer env.Teardown()


### PR DESCRIPTION
Since go1.22, loop vars do not need to be copied anymore.