### PR TITLE
chore: clarify go.mod version comment

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,8 @@ module github.com/hetznercloud/hcloud-go/v2
 // all dependends to update to the new version.
 // As long as we do not depend on any newer language feature this can be kept at the current value.
 // It should never be higher than the lowest currently supported version of Go.
+// Since golang.org/x dependencies always requires version 1.(N-1), this is effectively
+// the same version we will be using. (See http://go.dev/issue/69095)
 go 1.22.0
 
 // The toolchain version describes which Go version to use for testing, generating etc.


### PR DESCRIPTION
This comment clarifies the minimum go.mod version, since there were updates to golang.org/x dependencies: http://go.dev/issue/69095