### PR TITLE
fix: ignore empty string when setting endpoint

### DIFF
--- a/hcloud/client.go
+++ b/hcloud/client.go
@@ -124,7 +124,9 @@ type ClientOption func(*Client)
 // WithEndpoint configures a Client to use the specified API endpoint.
 func WithEndpoint(endpoint string) ClientOption {
 	return func(client *Client) {
-		client.endpoint = strings.TrimRight(endpoint, "/")
+		if endpoint != "" {
+			client.endpoint = strings.TrimRight(endpoint, "/")
+		}
 	}
 }
 


### PR DESCRIPTION
Since we cannot return an error, we should never accept an empty string as a valid endpoint.

The current behavior is difficult to debug, when we set the endpoint to an empty string, the client fails with the `unsupported protocol scheme` erorr. 

This might be a bit magic, but between having a panic and ignore the input string, I prefer the latter.

This is a great candidate for a potential v3 of the client, were we can validate options.