### PR TITLE
fix: request in batches of 25 when waiting for actions

### DIFF
--- a/hcloud/action_waiter.go
+++ b/hcloud/action_waiter.go
@@ -51,18 +51,19 @@ func (c *ActionClient) WaitForFunc(ctx context.Context, handleUpdate func(update
 			retries++
 		}
 
-		opts := ActionListOpts{
-			Sort: []string{"status", "id"},
-			ID:   make([]int64, 0, len(running)),
-		}
-		for actionID := range running {
-			opts.ID = append(opts.ID, actionID)
-		}
-		slices.Sort(opts.ID)
+		updates := make([]*Action, 0, len(running))
+		for runningIDsChunk := range slices.Chunk(slices.Sorted(maps.Keys(running)), 25) {
+			opts := ActionListOpts{
+				Sort: []string{"status", "id"},
+				ID:   runningIDsChunk,
+			}
 
-		updates, err := c.AllWithOpts(ctx, opts)
-		if err != nil {
-			return err
+			updatesChunk, err := c.AllWithOpts(ctx, opts)
+			if err != nil {
+				return err
+			}
+
+			updates = append(updates, updatesChunk...)
 		}
 
 		if len(updates) != len(running) {


### PR DESCRIPTION
The `/actions?id=` endpoint should only be request at most 25 actions at once, or the extra actions might not be returned at all.