### PR TITLE
fix: missing response from requests return values

### DIFF
--- a/hcloud/action.go
+++ b/hcloud/action.go
@@ -164,7 +164,7 @@ func (c *ResourceActionClient) GetByID(ctx context.Context, id int64) (*Action, 
 		if IsError(err, ErrorCodeNotFound) {
 			return nil, resp, nil
 		}
-		return nil, nil, err
+		return nil, resp, err
 	}
 	return ActionFromSchema(body.Action), resp, nil
 }
@@ -187,7 +187,7 @@ func (c *ResourceActionClient) List(ctx context.Context, opts ActionListOpts) ([
 	var body schema.ActionListResponse
 	resp, err := c.client.Do(req, &body)
 	if err != nil {
-		return nil, nil, err
+		return nil, resp, err
 	}
 	actions := make([]*Action, 0, len(body.Actions))
 	for _, i := range body.Actions {

--- a/hcloud/certificate.go
+++ b/hcloud/certificate.go
@@ -109,7 +109,7 @@ func (c *CertificateClient) GetByID(ctx context.Context, id int64) (*Certificate
 		if IsError(err, ErrorCodeNotFound) {
 			return nil, resp, nil
 		}
-		return nil, nil, err
+		return nil, resp, err
 	}
 	return CertificateFromSchema(body.Certificate), resp, nil
 }
@@ -170,7 +170,7 @@ func (c *CertificateClient) List(ctx context.Context, opts CertificateListOpts) 
 	var body schema.CertificateListResponse
 	resp, err := c.client.Do(req, &body)
 	if err != nil {
-		return nil, nil, err
+		return nil, resp, err
 	}
 	Certificates := make([]*Certificate, 0, len(body.Certificates))
 	for _, s := range body.Certificates {
@@ -366,7 +366,7 @@ func (c *CertificateClient) RetryIssuance(ctx context.Context, certificate *Cert
 	}
 	resp, err := c.client.Do(req, &respBody)
 	if err != nil {
-		return nil, nil, err
+		return nil, resp, err
 	}
 	action := ActionFromSchema(respBody.Action)
 	return action, resp, nil

--- a/hcloud/datacenter.go
+++ b/hcloud/datacenter.go
@@ -101,7 +101,7 @@ func (c *DatacenterClient) List(ctx context.Context, opts DatacenterListOpts) ([
 	var body schema.DatacenterListResponse
 	resp, err := c.client.Do(req, &body)
 	if err != nil {
-		return nil, nil, err
+		return nil, resp, err
 	}
 	datacenters := make([]*Datacenter, 0, len(body.Datacenters))
 	for _, i := range body.Datacenters {

--- a/hcloud/firewall.go
+++ b/hcloud/firewall.go
@@ -107,7 +107,7 @@ func (c *FirewallClient) GetByID(ctx context.Context, id int64) (*Firewall, *Res
 		if IsError(err, ErrorCodeNotFound) {
 			return nil, resp, nil
 		}
-		return nil, nil, err
+		return nil, resp, err
 	}
 	return FirewallFromSchema(body.Firewall), resp, nil
 }
@@ -168,7 +168,7 @@ func (c *FirewallClient) List(ctx context.Context, opts FirewallListOpts) ([]*Fi
 	var body schema.FirewallListResponse
 	resp, err := c.client.Do(req, &body)
 	if err != nil {
-		return nil, nil, err
+		return nil, resp, err
 	}
 	firewalls := make([]*Firewall, 0, len(body.Firewalls))
 	for _, s := range body.Firewalls {

--- a/hcloud/floating_ip.go
+++ b/hcloud/floating_ip.go
@@ -169,7 +169,7 @@ func (c *FloatingIPClient) List(ctx context.Context, opts FloatingIPListOpts) ([
 	var body schema.FloatingIPListResponse
 	resp, err := c.client.Do(req, &body)
 	if err != nil {
-		return nil, nil, err
+		return nil, resp, err
 	}
 	floatingIPs := make([]*FloatingIP, 0, len(body.FloatingIPs))
 	for _, s := range body.FloatingIPs {

--- a/hcloud/image.go
+++ b/hcloud/image.go
@@ -94,7 +94,7 @@ func (c *ImageClient) GetByID(ctx context.Context, id int64) (*Image, *Response,
 		if IsError(err, ErrorCodeNotFound) {
 			return nil, resp, nil
 		}
-		return nil, nil, err
+		return nil, resp, err
 	}
 	return ImageFromSchema(body.Image), resp, nil
 }
@@ -209,7 +209,7 @@ func (c *ImageClient) List(ctx context.Context, opts ImageListOpts) ([]*Image, *
 	var body schema.ImageListResponse
 	resp, err := c.client.Do(req, &body)
 	if err != nil {
-		return nil, nil, err
+		return nil, resp, err
 	}
 	images := make([]*Image, 0, len(body.Images))
 	for _, i := range body.Images {

--- a/hcloud/iso.go
+++ b/hcloud/iso.go
@@ -127,7 +127,7 @@ func (c *ISOClient) List(ctx context.Context, opts ISOListOpts) ([]*ISO, *Respon
 	var body schema.ISOListResponse
 	resp, err := c.client.Do(req, &body)
 	if err != nil {
-		return nil, nil, err
+		return nil, resp, err
 	}
 	isos := make([]*ISO, 0, len(body.ISOs))
 	for _, i := range body.ISOs {

--- a/hcloud/load_balancer.go
+++ b/hcloud/load_balancer.go
@@ -254,7 +254,7 @@ func (c *LoadBalancerClient) GetByID(ctx context.Context, id int64) (*LoadBalanc
 		if IsError(err, ErrorCodeNotFound) {
 			return nil, resp, nil
 		}
-		return nil, nil, err
+		return nil, resp, err
 	}
 	return LoadBalancerFromSchema(body.LoadBalancer), resp, nil
 }
@@ -315,7 +315,7 @@ func (c *LoadBalancerClient) List(ctx context.Context, opts LoadBalancerListOpts
 	var body schema.LoadBalancerListResponse
 	resp, err := c.client.Do(req, &body)
 	if err != nil {
-		return nil, nil, err
+		return nil, resp, err
 	}
 	LoadBalancers := make([]*LoadBalancer, 0, len(body.LoadBalancers))
 	for _, s := range body.LoadBalancers {
@@ -1043,7 +1043,7 @@ func (c *LoadBalancerClient) GetMetrics(
 	}
 	resp, err := c.client.Do(req, &respBody)
 	if err != nil {
-		return nil, nil, fmt.Errorf("get metrics: %v", err)
+		return nil, resp, fmt.Errorf("get metrics: %v", err)
 	}
 	ms, err := loadBalancerMetricsFromSchema(&respBody)
 	if err != nil {

--- a/hcloud/load_balancer_type.go
+++ b/hcloud/load_balancer_type.go
@@ -40,7 +40,7 @@ func (c *LoadBalancerTypeClient) GetByID(ctx context.Context, id int64) (*LoadBa
 		if IsError(err, ErrorCodeNotFound) {
 			return nil, resp, nil
 		}
-		return nil, nil, err
+		return nil, resp, err
 	}
 	return LoadBalancerTypeFromSchema(body.LoadBalancerType), resp, nil
 }
@@ -98,7 +98,7 @@ func (c *LoadBalancerTypeClient) List(ctx context.Context, opts LoadBalancerType
 	var body schema.LoadBalancerTypeListResponse
 	resp, err := c.client.Do(req, &body)
 	if err != nil {
-		return nil, nil, err
+		return nil, resp, err
 	}
 	LoadBalancerTypes := make([]*LoadBalancerType, 0, len(body.LoadBalancerTypes))
 	for _, s := range body.LoadBalancerTypes {

--- a/hcloud/location.go
+++ b/hcloud/location.go
@@ -97,7 +97,7 @@ func (c *LocationClient) List(ctx context.Context, opts LocationListOpts) ([]*Lo
 	var body schema.LocationListResponse
 	resp, err := c.client.Do(req, &body)
 	if err != nil {
-		return nil, nil, err
+		return nil, resp, err
 	}
 	locations := make([]*Location, 0, len(body.Locations))
 	for _, i := range body.Locations {

--- a/hcloud/network.go
+++ b/hcloud/network.go
@@ -98,7 +98,7 @@ func (c *NetworkClient) GetByID(ctx context.Context, id int64) (*Network, *Respo
 		if IsError(err, ErrorCodeNotFound) {
 			return nil, resp, nil
 		}
-		return nil, nil, err
+		return nil, resp, err
 	}
 	return NetworkFromSchema(body.Network), resp, nil
 }
@@ -159,7 +159,7 @@ func (c *NetworkClient) List(ctx context.Context, opts NetworkListOpts) ([]*Netw
 	var body schema.NetworkListResponse
 	resp, err := c.client.Do(req, &body)
 	if err != nil {
-		return nil, nil, err
+		return nil, resp, err
 	}
 	Networks := make([]*Network, 0, len(body.Networks))
 	for _, s := range body.Networks {

--- a/hcloud/placement_group.go
+++ b/hcloud/placement_group.go
@@ -49,7 +49,7 @@ func (c *PlacementGroupClient) GetByID(ctx context.Context, id int64) (*Placemen
 		if IsError(err, ErrorCodeNotFound) {
 			return nil, resp, nil
 		}
-		return nil, nil, err
+		return nil, resp, err
 	}
 	return PlacementGroupFromSchema(body.PlacementGroup), resp, nil
 }
@@ -114,7 +114,7 @@ func (c *PlacementGroupClient) List(ctx context.Context, opts PlacementGroupList
 	var body schema.PlacementGroupListResponse
 	resp, err := c.client.Do(req, &body)
 	if err != nil {
-		return nil, nil, err
+		return nil, resp, err
 	}
 	placementGroups := make([]*PlacementGroup, 0, len(body.PlacementGroups))
 	for _, g := range body.PlacementGroups {
@@ -193,7 +193,7 @@ func (c *PlacementGroupClient) Create(ctx context.Context, opts PlacementGroupCr
 	respBody := schema.PlacementGroupCreateResponse{}
 	resp, err := c.client.Do(req, &respBody)
 	if err != nil {
-		return PlacementGroupCreateResult{}, nil, err
+		return PlacementGroupCreateResult{}, resp, err
 	}
 	result := PlacementGroupCreateResult{
 		PlacementGroup: PlacementGroupFromSchema(respBody.PlacementGroup),

--- a/hcloud/pricing.go
+++ b/hcloud/pricing.go
@@ -144,7 +144,7 @@ func (c *PricingClient) Get(ctx context.Context) (Pricing, *Response, error) {
 	var body schema.PricingGetResponse
 	resp, err := c.client.Do(req, &body)
 	if err != nil {
-		return Pricing{}, nil, err
+		return Pricing{}, resp, err
 	}
 	return PricingFromSchema(body.Pricing), resp, nil
 }

--- a/hcloud/primary_ip.go
+++ b/hcloud/primary_ip.go
@@ -176,7 +176,7 @@ func (c *PrimaryIPClient) GetByID(ctx context.Context, id int64) (*PrimaryIP, *R
 		if IsError(err, ErrorCodeNotFound) {
 			return nil, resp, nil
 		}
-		return nil, nil, err
+		return nil, resp, err
 	}
 	return PrimaryIPFromSchema(body.PrimaryIP), resp, nil
 }
@@ -253,7 +253,7 @@ func (c *PrimaryIPClient) List(ctx context.Context, opts PrimaryIPListOpts) ([]*
 	var body schema.PrimaryIPListResult
 	resp, err := c.client.Do(req, &body)
 	if err != nil {
-		return nil, nil, err
+		return nil, resp, err
 	}
 	primaryIPs := make([]*PrimaryIP, 0, len(body.PrimaryIPs))
 	for _, s := range body.PrimaryIPs {

--- a/hcloud/server.go
+++ b/hcloud/server.go
@@ -209,7 +209,7 @@ func (c *ServerClient) GetByID(ctx context.Context, id int64) (*Server, *Respons
 		if IsError(err, ErrorCodeNotFound) {
 			return nil, resp, nil
 		}
-		return nil, nil, err
+		return nil, resp, err
 	}
 	return ServerFromSchema(body.Server), resp, nil
 }
@@ -274,7 +274,7 @@ func (c *ServerClient) List(ctx context.Context, opts ServerListOpts) ([]*Server
 	var body schema.ServerListResponse
 	resp, err := c.client.Do(req, &body)
 	if err != nil {
-		return nil, nil, err
+		return nil, resp, err
 	}
 	servers := make([]*Server, 0, len(body.Servers))
 	for _, s := range body.Servers {
@@ -1162,7 +1162,7 @@ func (c *ServerClient) GetMetrics(ctx context.Context, server *Server, opts Serv
 	}
 	resp, err := c.client.Do(req, &respBody)
 	if err != nil {
-		return nil, nil, fmt.Errorf("get metrics: %v", err)
+		return nil, resp, fmt.Errorf("get metrics: %v", err)
 	}
 	ms, err := serverMetricsFromSchema(&respBody)
 	if err != nil {

--- a/hcloud/server_type.go
+++ b/hcloud/server_type.go
@@ -68,7 +68,7 @@ func (c *ServerTypeClient) GetByID(ctx context.Context, id int64) (*ServerType, 
 		if IsError(err, ErrorCodeNotFound) {
 			return nil, resp, nil
 		}
-		return nil, nil, err
+		return nil, resp, err
 	}
 	return ServerTypeFromSchema(body.ServerType), resp, nil
 }
@@ -126,7 +126,7 @@ func (c *ServerTypeClient) List(ctx context.Context, opts ServerTypeListOpts) ([
 	var body schema.ServerTypeListResponse
 	resp, err := c.client.Do(req, &body)
 	if err != nil {
-		return nil, nil, err
+		return nil, resp, err
 	}
 	serverTypes := make([]*ServerType, 0, len(body.ServerTypes))
 	for _, s := range body.ServerTypes {

--- a/hcloud/ssh_key.go
+++ b/hcloud/ssh_key.go
@@ -41,7 +41,7 @@ func (c *SSHKeyClient) GetByID(ctx context.Context, id int64) (*SSHKey, *Respons
 		if IsError(err, ErrorCodeNotFound) {
 			return nil, resp, nil
 		}
-		return nil, nil, err
+		return nil, resp, err
 	}
 	return SSHKeyFromSchema(body.SSHKey), resp, nil
 }
@@ -115,7 +115,7 @@ func (c *SSHKeyClient) List(ctx context.Context, opts SSHKeyListOpts) ([]*SSHKey
 	var body schema.SSHKeyListResponse
 	resp, err := c.client.Do(req, &body)
 	if err != nil {
-		return nil, nil, err
+		return nil, resp, err
 	}
 	sshKeys := make([]*SSHKey, 0, len(body.SSHKeys))
 	for _, s := range body.SSHKeys {

--- a/hcloud/volume.go
+++ b/hcloud/volume.go
@@ -68,7 +68,7 @@ func (c *VolumeClient) GetByID(ctx context.Context, id int64) (*Volume, *Respons
 		if IsError(err, ErrorCodeNotFound) {
 			return nil, resp, nil
 		}
-		return nil, nil, err
+		return nil, resp, err
 	}
 	return VolumeFromSchema(body.Volume), resp, nil
 }
@@ -133,7 +133,7 @@ func (c *VolumeClient) List(ctx context.Context, opts VolumeListOpts) ([]*Volume
 	var body schema.VolumeListResponse
 	resp, err := c.client.Do(req, &body)
 	if err != nil {
-		return nil, nil, err
+		return nil, resp, err
 	}
 	volumes := make([]*Volume, 0, len(body.Volumes))
 	for _, s := range body.Volumes {


### PR DESCRIPTION
Consistently return the base response object even when errors occur.


Unless the return statement is before the `Do` function, all returns should include the response object.