### PR TITLE
refactor: improve client generic requests

### DIFF
--- a/hcloud/client_generic.go
+++ b/hcloud/client_generic.go
@@ -4,76 +4,91 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"io"
 )
 
-func getRequest[Schema any](ctx context.Context, client *Client, url string) (*Schema, *Response, error) {
+func getRequest[Schema any](ctx context.Context, client *Client, url string) (Schema, *Response, error) {
+	var respBody Schema
+
 	req, err := client.NewRequest(ctx, "GET", url, nil)
 	if err != nil {
-		return nil, nil, err
+		return respBody, nil, err
 	}
 
-	var respBody Schema
 	resp, err := client.Do(req, &respBody)
 	if err != nil {
-		return nil, resp, err
+		return respBody, resp, err
 	}
 
-	return &respBody, resp, nil
+	return respBody, resp, nil
 }
 
-func postRequest[Schema any](ctx context.Context, client *Client, url string, reqBody any) (*Schema, *Response, error) {
-	reqBodyBytes, err := json.Marshal(reqBody)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	req, err := client.NewRequest(ctx, "POST", url, bytes.NewReader(reqBodyBytes))
-	if err != nil {
-		return nil, nil, err
-	}
-
+func postRequest[Schema any](ctx context.Context, client *Client, url string, reqBody any) (Schema, *Response, error) {
 	var respBody Schema
+
+	var reqBodyReader io.Reader
+	if reqBody != nil {
+		reqBodyBytes, err := json.Marshal(reqBody)
+		if err != nil {
+			return respBody, nil, err
+		}
+
+		reqBodyReader = bytes.NewReader(reqBodyBytes)
+	}
+
+	req, err := client.NewRequest(ctx, "POST", url, reqBodyReader)
+	if err != nil {
+		return respBody, nil, err
+	}
+
 	resp, err := client.Do(req, &respBody)
 	if err != nil {
-		return nil, resp, err
+		return respBody, resp, err
 	}
 
-	return &respBody, resp, nil
+	return respBody, resp, nil
 }
 
-func putRequest[Schema any](ctx context.Context, client *Client, url string, reqBody any) (*Schema, *Response, error) {
-	reqBodyBytes, err := json.Marshal(reqBody)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	req, err := client.NewRequest(ctx, "PUT", url, bytes.NewReader(reqBodyBytes))
-	if err != nil {
-		return nil, nil, err
-	}
-
+func putRequest[Schema any](ctx context.Context, client *Client, url string, reqBody any) (Schema, *Response, error) {
 	var respBody Schema
+
+	var reqBodyReader io.Reader
+	if reqBody != nil {
+		reqBodyBytes, err := json.Marshal(reqBody)
+		if err != nil {
+			return respBody, nil, err
+		}
+
+		reqBodyReader = bytes.NewReader(reqBodyBytes)
+	}
+
+	req, err := client.NewRequest(ctx, "PUT", url, reqBodyReader)
+	if err != nil {
+		return respBody, nil, err
+	}
+
 	resp, err := client.Do(req, &respBody)
 	if err != nil {
-		return nil, resp, err
+		return respBody, resp, err
 	}
 
-	return &respBody, resp, nil
+	return respBody, resp, nil
 }
 
-func deleteRequest[Schema any](ctx context.Context, client *Client, url string) (*Schema, *Response, error) {
+func deleteRequest[Schema any](ctx context.Context, client *Client, url string) (Schema, *Response, error) {
+	var respBody Schema
+
 	req, err := client.NewRequest(ctx, "DELETE", url, nil)
 	if err != nil {
-		return nil, nil, err
+		return respBody, nil, err
 	}
 
-	var respBody Schema
 	resp, err := client.Do(req, &respBody)
 	if err != nil {
-		return nil, resp, err
+		return respBody, resp, err
 	}
 
-	return &respBody, resp, nil
+	return respBody, resp, nil
 }
 
 func deleteRequestNoResult(ctx context.Context, client *Client, url string) (*Response, error) {

--- a/hcloud/client_generic_test.go
+++ b/hcloud/client_generic_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestGenericRequest(t *testing.T) {
-	t.Run("get", func(t *testing.T) {
+	t.Run("GET", func(t *testing.T) {
 		ctx, server, client := makeTestUtils(t)
 
 		server.Expect([]mockutil.Request{
@@ -31,7 +31,7 @@ func TestGenericRequest(t *testing.T) {
 		require.Equal(t, int64(1234), respBody.Action.ID)
 	})
 
-	t.Run("post", func(t *testing.T) {
+	t.Run("POST", func(t *testing.T) {
 		ctx, server, client := makeTestUtils(t)
 
 		server.Expect([]mockutil.Request{
@@ -55,7 +55,7 @@ func TestGenericRequest(t *testing.T) {
 		require.Equal(t, int64(1234), respBody.Action.ID)
 	})
 
-	t.Run("put", func(t *testing.T) {
+	t.Run("PUT", func(t *testing.T) {
 		ctx, server, client := makeTestUtils(t)
 
 		server.Expect([]mockutil.Request{
@@ -79,7 +79,7 @@ func TestGenericRequest(t *testing.T) {
 		require.Equal(t, int64(1234), respBody.Action.ID)
 	})
 
-	t.Run("delete", func(t *testing.T) {
+	t.Run("DELETE", func(t *testing.T) {
 		ctx, server, client := makeTestUtils(t)
 
 		server.Expect([]mockutil.Request{
@@ -98,7 +98,7 @@ func TestGenericRequest(t *testing.T) {
 		require.Equal(t, int64(1234), respBody.Action.ID)
 	})
 
-	t.Run("delete no result", func(t *testing.T) {
+	t.Run("DELETE no result", func(t *testing.T) {
 		ctx, server, client := makeTestUtils(t)
 
 		server.Expect([]mockutil.Request{


### PR DESCRIPTION
Those improvements were made after implementing the generics requests in the client.

- Allow passing nil request bodies
- Reduce nil checks on the caller side