### PR TITLE
refactor: use generic request for all `List` calls

### DIFF
--- a/hcloud/action.go
+++ b/hcloud/action.go
@@ -174,26 +174,14 @@ func (c *ResourceActionClient) GetByID(ctx context.Context, id int64) (*Action, 
 // Please note that filters specified in opts are not taken into account
 // when their value corresponds to their zero value or when they are empty.
 func (c *ResourceActionClient) List(ctx context.Context, opts ActionListOpts) ([]*Action, *Response, error) {
-	req, err := c.client.NewRequest(
-		ctx,
-		"GET",
-		fmt.Sprintf("%s/actions?%s", c.getBaseURL(), opts.values().Encode()),
-		nil,
-	)
-	if err != nil {
-		return nil, nil, err
-	}
+	reqPath := fmt.Sprintf("%s/actions?%s", c.getBaseURL(), opts.values().Encode())
 
-	var body schema.ActionListResponse
-	resp, err := c.client.Do(req, &body)
+	respBody, resp, err := getRequest[schema.ActionListResponse](ctx, c.client, reqPath)
 	if err != nil {
 		return nil, resp, err
 	}
-	actions := make([]*Action, 0, len(body.Actions))
-	for _, i := range body.Actions {
-		actions = append(actions, ActionFromSchema(i))
-	}
-	return actions, resp, nil
+
+	return allFromSchemaFunc(respBody.Actions, ActionFromSchema), resp, nil
 }
 
 // All returns all actions for the given options.

--- a/hcloud/certificate.go
+++ b/hcloud/certificate.go
@@ -161,22 +161,14 @@ func (l CertificateListOpts) values() url.Values {
 // Please note that filters specified in opts are not taken into account
 // when their value corresponds to their zero value or when they are empty.
 func (c *CertificateClient) List(ctx context.Context, opts CertificateListOpts) ([]*Certificate, *Response, error) {
-	path := "/certificates?" + opts.values().Encode()
-	req, err := c.client.NewRequest(ctx, "GET", path, nil)
-	if err != nil {
-		return nil, nil, err
-	}
+	reqPath := fmt.Sprintf("/certificates?%s", opts.values().Encode())
 
-	var body schema.CertificateListResponse
-	resp, err := c.client.Do(req, &body)
+	respBody, resp, err := getRequest[schema.CertificateListResponse](ctx, c.client, reqPath)
 	if err != nil {
 		return nil, resp, err
 	}
-	Certificates := make([]*Certificate, 0, len(body.Certificates))
-	for _, s := range body.Certificates {
-		Certificates = append(Certificates, CertificateFromSchema(s))
-	}
-	return Certificates, resp, nil
+
+	return allFromSchemaFunc(respBody.Certificates, CertificateFromSchema), resp, nil
 }
 
 // All returns all Certificates.

--- a/hcloud/client_helper.go
+++ b/hcloud/client_helper.go
@@ -1,0 +1,12 @@
+package hcloud
+
+// allFromSchemaFunc transform each item in the list using the FromSchema function, and
+// returns the result.
+func allFromSchemaFunc[T, V any](all []T, fn func(T) V) []V {
+	result := make([]V, len(all))
+	for i, t := range all {
+		result[i] = fn(t)
+	}
+
+	return result
+}

--- a/hcloud/datacenter.go
+++ b/hcloud/datacenter.go
@@ -92,22 +92,14 @@ func (l DatacenterListOpts) values() url.Values {
 // Please note that filters specified in opts are not taken into account
 // when their value corresponds to their zero value or when they are empty.
 func (c *DatacenterClient) List(ctx context.Context, opts DatacenterListOpts) ([]*Datacenter, *Response, error) {
-	path := "/datacenters?" + opts.values().Encode()
-	req, err := c.client.NewRequest(ctx, "GET", path, nil)
-	if err != nil {
-		return nil, nil, err
-	}
+	reqPath := fmt.Sprintf("/datacenters?%s", opts.values().Encode())
 
-	var body schema.DatacenterListResponse
-	resp, err := c.client.Do(req, &body)
+	respBody, resp, err := getRequest[schema.DatacenterListResponse](ctx, c.client, reqPath)
 	if err != nil {
 		return nil, resp, err
 	}
-	datacenters := make([]*Datacenter, 0, len(body.Datacenters))
-	for _, i := range body.Datacenters {
-		datacenters = append(datacenters, DatacenterFromSchema(i))
-	}
-	return datacenters, resp, nil
+
+	return allFromSchemaFunc(respBody.Datacenters, DatacenterFromSchema), resp, nil
 }
 
 // All returns all datacenters.

--- a/hcloud/firewall.go
+++ b/hcloud/firewall.go
@@ -159,22 +159,14 @@ func (l FirewallListOpts) values() url.Values {
 // Please note that filters specified in opts are not taken into account
 // when their value corresponds to their zero value or when they are empty.
 func (c *FirewallClient) List(ctx context.Context, opts FirewallListOpts) ([]*Firewall, *Response, error) {
-	path := "/firewalls?" + opts.values().Encode()
-	req, err := c.client.NewRequest(ctx, "GET", path, nil)
-	if err != nil {
-		return nil, nil, err
-	}
+	reqPath := fmt.Sprintf("/firewalls?%s", opts.values().Encode())
 
-	var body schema.FirewallListResponse
-	resp, err := c.client.Do(req, &body)
+	respBody, resp, err := getRequest[schema.FirewallListResponse](ctx, c.client, reqPath)
 	if err != nil {
 		return nil, resp, err
 	}
-	firewalls := make([]*Firewall, 0, len(body.Firewalls))
-	for _, s := range body.Firewalls {
-		firewalls = append(firewalls, FirewallFromSchema(s))
-	}
-	return firewalls, resp, nil
+
+	return allFromSchemaFunc(respBody.Firewalls, FirewallFromSchema), resp, nil
 }
 
 // All returns all Firewalls.

--- a/hcloud/floating_ip.go
+++ b/hcloud/floating_ip.go
@@ -160,22 +160,14 @@ func (l FloatingIPListOpts) values() url.Values {
 // Please note that filters specified in opts are not taken into account
 // when their value corresponds to their zero value or when they are empty.
 func (c *FloatingIPClient) List(ctx context.Context, opts FloatingIPListOpts) ([]*FloatingIP, *Response, error) {
-	path := "/floating_ips?" + opts.values().Encode()
-	req, err := c.client.NewRequest(ctx, "GET", path, nil)
-	if err != nil {
-		return nil, nil, err
-	}
+	reqPath := fmt.Sprintf("/floating_ips?%s", opts.values().Encode())
 
-	var body schema.FloatingIPListResponse
-	resp, err := c.client.Do(req, &body)
+	respBody, resp, err := getRequest[schema.FloatingIPListResponse](ctx, c.client, reqPath)
 	if err != nil {
 		return nil, resp, err
 	}
-	floatingIPs := make([]*FloatingIP, 0, len(body.FloatingIPs))
-	for _, s := range body.FloatingIPs {
-		floatingIPs = append(floatingIPs, FloatingIPFromSchema(s))
-	}
-	return floatingIPs, resp, nil
+
+	return allFromSchemaFunc(respBody.FloatingIPs, FloatingIPFromSchema), resp, nil
 }
 
 // All returns all Floating IPs.

--- a/hcloud/image.go
+++ b/hcloud/image.go
@@ -200,22 +200,14 @@ func (l ImageListOpts) values() url.Values {
 // Please note that filters specified in opts are not taken into account
 // when their value corresponds to their zero value or when they are empty.
 func (c *ImageClient) List(ctx context.Context, opts ImageListOpts) ([]*Image, *Response, error) {
-	path := "/images?" + opts.values().Encode()
-	req, err := c.client.NewRequest(ctx, "GET", path, nil)
-	if err != nil {
-		return nil, nil, err
-	}
+	reqPath := fmt.Sprintf("/images?%s", opts.values().Encode())
 
-	var body schema.ImageListResponse
-	resp, err := c.client.Do(req, &body)
+	respBody, resp, err := getRequest[schema.ImageListResponse](ctx, c.client, reqPath)
 	if err != nil {
 		return nil, resp, err
 	}
-	images := make([]*Image, 0, len(body.Images))
-	for _, i := range body.Images {
-		images = append(images, ImageFromSchema(i))
-	}
-	return images, resp, nil
+
+	return allFromSchemaFunc(respBody.Images, ImageFromSchema), resp, nil
 }
 
 // All returns all images.

--- a/hcloud/iso.go
+++ b/hcloud/iso.go
@@ -118,22 +118,14 @@ func (l ISOListOpts) values() url.Values {
 // Please note that filters specified in opts are not taken into account
 // when their value corresponds to their zero value or when they are empty.
 func (c *ISOClient) List(ctx context.Context, opts ISOListOpts) ([]*ISO, *Response, error) {
-	path := "/isos?" + opts.values().Encode()
-	req, err := c.client.NewRequest(ctx, "GET", path, nil)
-	if err != nil {
-		return nil, nil, err
-	}
+	reqPath := fmt.Sprintf("/isos?%s", opts.values().Encode())
 
-	var body schema.ISOListResponse
-	resp, err := c.client.Do(req, &body)
+	respBody, resp, err := getRequest[schema.ISOListResponse](ctx, c.client, reqPath)
 	if err != nil {
 		return nil, resp, err
 	}
-	isos := make([]*ISO, 0, len(body.ISOs))
-	for _, i := range body.ISOs {
-		isos = append(isos, ISOFromSchema(i))
-	}
-	return isos, resp, nil
+
+	return allFromSchemaFunc(respBody.ISOs, ISOFromSchema), resp, nil
 }
 
 // All returns all ISOs.

--- a/hcloud/load_balancer.go
+++ b/hcloud/load_balancer.go
@@ -306,22 +306,14 @@ func (l LoadBalancerListOpts) values() url.Values {
 // Please note that filters specified in opts are not taken into account
 // when their value corresponds to their zero value or when they are empty.
 func (c *LoadBalancerClient) List(ctx context.Context, opts LoadBalancerListOpts) ([]*LoadBalancer, *Response, error) {
-	path := "/load_balancers?" + opts.values().Encode()
-	req, err := c.client.NewRequest(ctx, "GET", path, nil)
-	if err != nil {
-		return nil, nil, err
-	}
+	reqPath := fmt.Sprintf("/load_balancers?%s", opts.values().Encode())
 
-	var body schema.LoadBalancerListResponse
-	resp, err := c.client.Do(req, &body)
+	respBody, resp, err := getRequest[schema.LoadBalancerListResponse](ctx, c.client, reqPath)
 	if err != nil {
 		return nil, resp, err
 	}
-	LoadBalancers := make([]*LoadBalancer, 0, len(body.LoadBalancers))
-	for _, s := range body.LoadBalancers {
-		LoadBalancers = append(LoadBalancers, LoadBalancerFromSchema(s))
-	}
-	return LoadBalancers, resp, nil
+
+	return allFromSchemaFunc(respBody.LoadBalancers, LoadBalancerFromSchema), resp, nil
 }
 
 // All returns all Load Balancers.

--- a/hcloud/load_balancer_type.go
+++ b/hcloud/load_balancer_type.go
@@ -89,22 +89,14 @@ func (l LoadBalancerTypeListOpts) values() url.Values {
 // Please note that filters specified in opts are not taken into account
 // when their value corresponds to their zero value or when they are empty.
 func (c *LoadBalancerTypeClient) List(ctx context.Context, opts LoadBalancerTypeListOpts) ([]*LoadBalancerType, *Response, error) {
-	path := "/load_balancer_types?" + opts.values().Encode()
-	req, err := c.client.NewRequest(ctx, "GET", path, nil)
-	if err != nil {
-		return nil, nil, err
-	}
+	reqPath := fmt.Sprintf("/load_balancer_types?%s", opts.values().Encode())
 
-	var body schema.LoadBalancerTypeListResponse
-	resp, err := c.client.Do(req, &body)
+	respBody, resp, err := getRequest[schema.LoadBalancerTypeListResponse](ctx, c.client, reqPath)
 	if err != nil {
 		return nil, resp, err
 	}
-	LoadBalancerTypes := make([]*LoadBalancerType, 0, len(body.LoadBalancerTypes))
-	for _, s := range body.LoadBalancerTypes {
-		LoadBalancerTypes = append(LoadBalancerTypes, LoadBalancerTypeFromSchema(s))
-	}
-	return LoadBalancerTypes, resp, nil
+
+	return allFromSchemaFunc(respBody.LoadBalancerTypes, LoadBalancerTypeFromSchema), resp, nil
 }
 
 // All returns all Load Balancer types.

--- a/hcloud/location.go
+++ b/hcloud/location.go
@@ -88,22 +88,14 @@ func (l LocationListOpts) values() url.Values {
 // Please note that filters specified in opts are not taken into account
 // when their value corresponds to their zero value or when they are empty.
 func (c *LocationClient) List(ctx context.Context, opts LocationListOpts) ([]*Location, *Response, error) {
-	path := "/locations?" + opts.values().Encode()
-	req, err := c.client.NewRequest(ctx, "GET", path, nil)
-	if err != nil {
-		return nil, nil, err
-	}
+	reqPath := fmt.Sprintf("/locations?%s", opts.values().Encode())
 
-	var body schema.LocationListResponse
-	resp, err := c.client.Do(req, &body)
+	respBody, resp, err := getRequest[schema.LocationListResponse](ctx, c.client, reqPath)
 	if err != nil {
 		return nil, resp, err
 	}
-	locations := make([]*Location, 0, len(body.Locations))
-	for _, i := range body.Locations {
-		locations = append(locations, LocationFromSchema(i))
-	}
-	return locations, resp, nil
+
+	return allFromSchemaFunc(respBody.Locations, LocationFromSchema), resp, nil
 }
 
 // All returns all locations.

--- a/hcloud/network.go
+++ b/hcloud/network.go
@@ -150,22 +150,14 @@ func (l NetworkListOpts) values() url.Values {
 // Please note that filters specified in opts are not taken into account
 // when their value corresponds to their zero value or when they are empty.
 func (c *NetworkClient) List(ctx context.Context, opts NetworkListOpts) ([]*Network, *Response, error) {
-	path := "/networks?" + opts.values().Encode()
-	req, err := c.client.NewRequest(ctx, "GET", path, nil)
-	if err != nil {
-		return nil, nil, err
-	}
+	reqPath := fmt.Sprintf("/networks?%s", opts.values().Encode())
 
-	var body schema.NetworkListResponse
-	resp, err := c.client.Do(req, &body)
+	respBody, resp, err := getRequest[schema.NetworkListResponse](ctx, c.client, reqPath)
 	if err != nil {
 		return nil, resp, err
 	}
-	Networks := make([]*Network, 0, len(body.Networks))
-	for _, s := range body.Networks {
-		Networks = append(Networks, NetworkFromSchema(s))
-	}
-	return Networks, resp, nil
+
+	return allFromSchemaFunc(respBody.Networks, NetworkFromSchema), resp, nil
 }
 
 // All returns all networks.

--- a/hcloud/placement_group.go
+++ b/hcloud/placement_group.go
@@ -105,22 +105,14 @@ func (l PlacementGroupListOpts) values() url.Values {
 // Please note that filters specified in opts are not taken into account
 // when their value corresponds to their zero value or when they are empty.
 func (c *PlacementGroupClient) List(ctx context.Context, opts PlacementGroupListOpts) ([]*PlacementGroup, *Response, error) {
-	path := "/placement_groups?" + opts.values().Encode()
-	req, err := c.client.NewRequest(ctx, "GET", path, nil)
-	if err != nil {
-		return nil, nil, err
-	}
+	reqPath := fmt.Sprintf("/placement_groups?%s", opts.values().Encode())
 
-	var body schema.PlacementGroupListResponse
-	resp, err := c.client.Do(req, &body)
+	respBody, resp, err := getRequest[schema.PlacementGroupListResponse](ctx, c.client, reqPath)
 	if err != nil {
 		return nil, resp, err
 	}
-	placementGroups := make([]*PlacementGroup, 0, len(body.PlacementGroups))
-	for _, g := range body.PlacementGroups {
-		placementGroups = append(placementGroups, PlacementGroupFromSchema(g))
-	}
-	return placementGroups, resp, nil
+
+	return allFromSchemaFunc(respBody.PlacementGroups, PlacementGroupFromSchema), resp, nil
 }
 
 // All returns all PlacementGroups.

--- a/hcloud/primary_ip.go
+++ b/hcloud/primary_ip.go
@@ -244,22 +244,14 @@ func (l PrimaryIPListOpts) values() url.Values {
 // Please note that filters specified in opts are not taken into account
 // when their value corresponds to their zero value or when they are empty.
 func (c *PrimaryIPClient) List(ctx context.Context, opts PrimaryIPListOpts) ([]*PrimaryIP, *Response, error) {
-	path := "/primary_ips?" + opts.values().Encode()
-	req, err := c.client.NewRequest(ctx, "GET", path, nil)
-	if err != nil {
-		return nil, nil, err
-	}
+	reqPath := fmt.Sprintf("/primary_ips?%s", opts.values().Encode())
 
-	var body schema.PrimaryIPListResult
-	resp, err := c.client.Do(req, &body)
+	respBody, resp, err := getRequest[schema.PrimaryIPListResult](ctx, c.client, reqPath)
 	if err != nil {
 		return nil, resp, err
 	}
-	primaryIPs := make([]*PrimaryIP, 0, len(body.PrimaryIPs))
-	for _, s := range body.PrimaryIPs {
-		primaryIPs = append(primaryIPs, PrimaryIPFromSchema(s))
-	}
-	return primaryIPs, resp, nil
+
+	return allFromSchemaFunc(respBody.PrimaryIPs, PrimaryIPFromSchema), resp, nil
 }
 
 // All returns all Primary IPs.

--- a/hcloud/server.go
+++ b/hcloud/server.go
@@ -265,22 +265,14 @@ func (l ServerListOpts) values() url.Values {
 // Please note that filters specified in opts are not taken into account
 // when their value corresponds to their zero value or when they are empty.
 func (c *ServerClient) List(ctx context.Context, opts ServerListOpts) ([]*Server, *Response, error) {
-	path := "/servers?" + opts.values().Encode()
-	req, err := c.client.NewRequest(ctx, "GET", path, nil)
-	if err != nil {
-		return nil, nil, err
-	}
+	reqPath := fmt.Sprintf("/servers?%s", opts.values().Encode())
 
-	var body schema.ServerListResponse
-	resp, err := c.client.Do(req, &body)
+	respBody, resp, err := getRequest[schema.ServerListResponse](ctx, c.client, reqPath)
 	if err != nil {
 		return nil, resp, err
 	}
-	servers := make([]*Server, 0, len(body.Servers))
-	for _, s := range body.Servers {
-		servers = append(servers, ServerFromSchema(s))
-	}
-	return servers, resp, nil
+
+	return allFromSchemaFunc(respBody.Servers, ServerFromSchema), resp, nil
 }
 
 // All returns all servers.

--- a/hcloud/server_type.go
+++ b/hcloud/server_type.go
@@ -117,22 +117,14 @@ func (l ServerTypeListOpts) values() url.Values {
 // Please note that filters specified in opts are not taken into account
 // when their value corresponds to their zero value or when they are empty.
 func (c *ServerTypeClient) List(ctx context.Context, opts ServerTypeListOpts) ([]*ServerType, *Response, error) {
-	path := "/server_types?" + opts.values().Encode()
-	req, err := c.client.NewRequest(ctx, "GET", path, nil)
-	if err != nil {
-		return nil, nil, err
-	}
+	reqPath := fmt.Sprintf("/server_types?%s", opts.values().Encode())
 
-	var body schema.ServerTypeListResponse
-	resp, err := c.client.Do(req, &body)
+	respBody, resp, err := getRequest[schema.ServerTypeListResponse](ctx, c.client, reqPath)
 	if err != nil {
 		return nil, resp, err
 	}
-	serverTypes := make([]*ServerType, 0, len(body.ServerTypes))
-	for _, s := range body.ServerTypes {
-		serverTypes = append(serverTypes, ServerTypeFromSchema(s))
-	}
-	return serverTypes, resp, nil
+
+	return allFromSchemaFunc(respBody.ServerTypes, ServerTypeFromSchema), resp, nil
 }
 
 // All returns all server types.

--- a/hcloud/ssh_key.go
+++ b/hcloud/ssh_key.go
@@ -106,22 +106,14 @@ func (l SSHKeyListOpts) values() url.Values {
 // Please note that filters specified in opts are not taken into account
 // when their value corresponds to their zero value or when they are empty.
 func (c *SSHKeyClient) List(ctx context.Context, opts SSHKeyListOpts) ([]*SSHKey, *Response, error) {
-	path := "/ssh_keys?" + opts.values().Encode()
-	req, err := c.client.NewRequest(ctx, "GET", path, nil)
-	if err != nil {
-		return nil, nil, err
-	}
+	reqPath := fmt.Sprintf("/ssh_keys?%s", opts.values().Encode())
 
-	var body schema.SSHKeyListResponse
-	resp, err := c.client.Do(req, &body)
+	respBody, resp, err := getRequest[schema.SSHKeyListResponse](ctx, c.client, reqPath)
 	if err != nil {
 		return nil, resp, err
 	}
-	sshKeys := make([]*SSHKey, 0, len(body.SSHKeys))
-	for _, s := range body.SSHKeys {
-		sshKeys = append(sshKeys, SSHKeyFromSchema(s))
-	}
-	return sshKeys, resp, nil
+
+	return allFromSchemaFunc(respBody.SSHKeys, SSHKeyFromSchema), resp, nil
 }
 
 // All returns all SSH keys.

--- a/hcloud/volume.go
+++ b/hcloud/volume.go
@@ -124,22 +124,14 @@ func (l VolumeListOpts) values() url.Values {
 // Please note that filters specified in opts are not taken into account
 // when their value corresponds to their zero value or when they are empty.
 func (c *VolumeClient) List(ctx context.Context, opts VolumeListOpts) ([]*Volume, *Response, error) {
-	path := "/volumes?" + opts.values().Encode()
-	req, err := c.client.NewRequest(ctx, "GET", path, nil)
-	if err != nil {
-		return nil, nil, err
-	}
+	reqPath := fmt.Sprintf("/volumes?%s", opts.values().Encode())
 
-	var body schema.VolumeListResponse
-	resp, err := c.client.Do(req, &body)
+	respBody, resp, err := getRequest[schema.VolumeListResponse](ctx, c.client, reqPath)
 	if err != nil {
 		return nil, resp, err
 	}
-	volumes := make([]*Volume, 0, len(body.Volumes))
-	for _, s := range body.Volumes {
-		volumes = append(volumes, VolumeFromSchema(s))
-	}
-	return volumes, resp, nil
+
+	return allFromSchemaFunc(respBody.Volumes, VolumeFromSchema), resp, nil
 }
 
 // All returns all volumes.


### PR DESCRIPTION
Uses the new generic requests function to reduce the code duplication for the `List` calls.