### PR TITLE
refactor: use generic request for `GetByName` calls

### DIFF
--- a/hcloud/certificate.go
+++ b/hcloud/certificate.go
@@ -112,14 +112,9 @@ func (c *CertificateClient) GetByID(ctx context.Context, id int64) (*Certificate
 
 // GetByName retrieves a Certificate by its name. If the Certificate does not exist, nil is returned.
 func (c *CertificateClient) GetByName(ctx context.Context, name string) (*Certificate, *Response, error) {
-	if name == "" {
-		return nil, nil, nil
-	}
-	Certificate, response, err := c.List(ctx, CertificateListOpts{Name: name})
-	if len(Certificate) == 0 {
-		return nil, response, err
-	}
-	return Certificate[0], response, err
+	return firstByName(name, func() ([]*Certificate, *Response, error) {
+		return c.List(ctx, CertificateListOpts{Name: name})
+	})
 }
 
 // Get retrieves a Certificate by its ID if the input can be parsed as an integer, otherwise it

--- a/hcloud/client_helper.go
+++ b/hcloud/client_helper.go
@@ -30,3 +30,24 @@ func iterPages[T any](listFn func(int) ([]*T, *Response, error)) ([]*T, error) {
 		page = resp.Meta.Pagination.NextPage
 	}
 }
+
+// firstBy fetches a list of items using the list function, and returns the first item
+// of the list if present otherwise nil.
+func firstBy[T any](listFn func() ([]*T, *Response, error)) (*T, *Response, error) {
+	items, resp, err := listFn()
+	if len(items) == 0 {
+		return nil, resp, err
+	}
+
+	return items[0], resp, err
+}
+
+// firstByName is a wrapper around [firstBy], that checks if the provided name is not
+// empty.
+func firstByName[T any](name string, listFn func() ([]*T, *Response, error)) (*T, *Response, error) {
+	if name == "" {
+		return nil, nil, nil
+	}
+
+	return firstBy(listFn)
+}

--- a/hcloud/datacenter.go
+++ b/hcloud/datacenter.go
@@ -47,14 +47,9 @@ func (c *DatacenterClient) GetByID(ctx context.Context, id int64) (*Datacenter, 
 
 // GetByName retrieves a datacenter by its name. If the datacenter does not exist, nil is returned.
 func (c *DatacenterClient) GetByName(ctx context.Context, name string) (*Datacenter, *Response, error) {
-	if name == "" {
-		return nil, nil, nil
-	}
-	datacenters, response, err := c.List(ctx, DatacenterListOpts{Name: name})
-	if len(datacenters) == 0 {
-		return nil, response, err
-	}
-	return datacenters[0], response, err
+	return firstByName(name, func() ([]*Datacenter, *Response, error) {
+		return c.List(ctx, DatacenterListOpts{Name: name})
+	})
 }
 
 // Get retrieves a datacenter by its ID if the input can be parsed as an integer, otherwise it

--- a/hcloud/firewall.go
+++ b/hcloud/firewall.go
@@ -111,14 +111,9 @@ func (c *FirewallClient) GetByID(ctx context.Context, id int64) (*Firewall, *Res
 
 // GetByName retrieves a Firewall by its name. If the Firewall does not exist, nil is returned.
 func (c *FirewallClient) GetByName(ctx context.Context, name string) (*Firewall, *Response, error) {
-	if name == "" {
-		return nil, nil, nil
-	}
-	firewalls, response, err := c.List(ctx, FirewallListOpts{Name: name})
-	if len(firewalls) == 0 {
-		return nil, response, err
-	}
-	return firewalls[0], response, err
+	return firstByName(name, func() ([]*Firewall, *Response, error) {
+		return c.List(ctx, FirewallListOpts{Name: name})
+	})
 }
 
 // Get retrieves a Firewall by its ID if the input can be parsed as an integer, otherwise it

--- a/hcloud/floating_ip.go
+++ b/hcloud/floating_ip.go
@@ -112,14 +112,9 @@ func (c *FloatingIPClient) GetByID(ctx context.Context, id int64) (*FloatingIP, 
 
 // GetByName retrieves a Floating IP by its name. If the Floating IP does not exist, nil is returned.
 func (c *FloatingIPClient) GetByName(ctx context.Context, name string) (*FloatingIP, *Response, error) {
-	if name == "" {
-		return nil, nil, nil
-	}
-	floatingIPs, response, err := c.List(ctx, FloatingIPListOpts{Name: name})
-	if len(floatingIPs) == 0 {
-		return nil, response, err
-	}
-	return floatingIPs[0], response, err
+	return firstByName(name, func() ([]*FloatingIP, *Response, error) {
+		return c.List(ctx, FloatingIPListOpts{Name: name})
+	})
 }
 
 // Get retrieves a Floating IP by its ID if the input can be parsed as an integer, otherwise it

--- a/hcloud/image.go
+++ b/hcloud/image.go
@@ -100,14 +100,9 @@ func (c *ImageClient) GetByID(ctx context.Context, id int64) (*Image, *Response,
 //
 // Deprecated: Use [ImageClient.GetByNameAndArchitecture] instead.
 func (c *ImageClient) GetByName(ctx context.Context, name string) (*Image, *Response, error) {
-	if name == "" {
-		return nil, nil, nil
-	}
-	images, response, err := c.List(ctx, ImageListOpts{Name: name})
-	if len(images) == 0 {
-		return nil, response, err
-	}
-	return images[0], response, err
+	return firstByName(name, func() ([]*Image, *Response, error) {
+		return c.List(ctx, ImageListOpts{Name: name})
+	})
 }
 
 // GetByNameAndArchitecture retrieves an image by its name and architecture. If the image does not exist,
@@ -115,14 +110,9 @@ func (c *ImageClient) GetByName(ctx context.Context, name string) (*Image, *Resp
 // In contrast to [ImageClient.Get], this method also returns deprecated images. Depending on your needs you should
 // check for this in your calling method.
 func (c *ImageClient) GetByNameAndArchitecture(ctx context.Context, name string, architecture Architecture) (*Image, *Response, error) {
-	if name == "" {
-		return nil, nil, nil
-	}
-	images, response, err := c.List(ctx, ImageListOpts{Name: name, Architecture: []Architecture{architecture}, IncludeDeprecated: true})
-	if len(images) == 0 {
-		return nil, response, err
-	}
-	return images[0], response, err
+	return firstByName(name, func() ([]*Image, *Response, error) {
+		return c.List(ctx, ImageListOpts{Name: name, Architecture: []Architecture{architecture}, IncludeDeprecated: true})
+	})
 }
 
 // Get retrieves an image by its ID if the input can be parsed as an integer, otherwise it

--- a/hcloud/iso.go
+++ b/hcloud/iso.go
@@ -55,14 +55,9 @@ func (c *ISOClient) GetByID(ctx context.Context, id int64) (*ISO, *Response, err
 
 // GetByName retrieves an ISO by its name.
 func (c *ISOClient) GetByName(ctx context.Context, name string) (*ISO, *Response, error) {
-	if name == "" {
-		return nil, nil, nil
-	}
-	isos, response, err := c.List(ctx, ISOListOpts{Name: name})
-	if len(isos) == 0 {
-		return nil, response, err
-	}
-	return isos[0], response, err
+	return firstByName(name, func() ([]*ISO, *Response, error) {
+		return c.List(ctx, ISOListOpts{Name: name})
+	})
 }
 
 // Get retrieves an ISO by its ID if the input can be parsed as an integer, otherwise it retrieves an ISO by its name.

--- a/hcloud/load_balancer.go
+++ b/hcloud/load_balancer.go
@@ -258,14 +258,9 @@ func (c *LoadBalancerClient) GetByID(ctx context.Context, id int64) (*LoadBalanc
 
 // GetByName retrieves a Load Balancer by its name. If the Load Balancer does not exist, nil is returned.
 func (c *LoadBalancerClient) GetByName(ctx context.Context, name string) (*LoadBalancer, *Response, error) {
-	if name == "" {
-		return nil, nil, nil
-	}
-	LoadBalancer, response, err := c.List(ctx, LoadBalancerListOpts{Name: name})
-	if len(LoadBalancer) == 0 {
-		return nil, response, err
-	}
-	return LoadBalancer[0], response, err
+	return firstByName(name, func() ([]*LoadBalancer, *Response, error) {
+		return c.List(ctx, LoadBalancerListOpts{Name: name})
+	})
 }
 
 // Get retrieves a Load Balancer by its ID if the input can be parsed as an integer, otherwise it

--- a/hcloud/load_balancer_type.go
+++ b/hcloud/load_balancer_type.go
@@ -44,14 +44,9 @@ func (c *LoadBalancerTypeClient) GetByID(ctx context.Context, id int64) (*LoadBa
 
 // GetByName retrieves a Load Balancer type by its name. If the Load Balancer type does not exist, nil is returned.
 func (c *LoadBalancerTypeClient) GetByName(ctx context.Context, name string) (*LoadBalancerType, *Response, error) {
-	if name == "" {
-		return nil, nil, nil
-	}
-	LoadBalancerTypes, response, err := c.List(ctx, LoadBalancerTypeListOpts{Name: name})
-	if len(LoadBalancerTypes) == 0 {
-		return nil, response, err
-	}
-	return LoadBalancerTypes[0], response, err
+	return firstByName(name, func() ([]*LoadBalancerType, *Response, error) {
+		return c.List(ctx, LoadBalancerTypeListOpts{Name: name})
+	})
 }
 
 // Get retrieves a Load Balancer type by its ID if the input can be parsed as an integer, otherwise it

--- a/hcloud/location.go
+++ b/hcloud/location.go
@@ -43,14 +43,9 @@ func (c *LocationClient) GetByID(ctx context.Context, id int64) (*Location, *Res
 
 // GetByName retrieves an location by its name. If the location does not exist, nil is returned.
 func (c *LocationClient) GetByName(ctx context.Context, name string) (*Location, *Response, error) {
-	if name == "" {
-		return nil, nil, nil
-	}
-	locations, response, err := c.List(ctx, LocationListOpts{Name: name})
-	if len(locations) == 0 {
-		return nil, response, err
-	}
-	return locations[0], response, err
+	return firstByName(name, func() ([]*Location, *Response, error) {
+		return c.List(ctx, LocationListOpts{Name: name})
+	})
 }
 
 // Get retrieves a location by its ID if the input can be parsed as an integer, otherwise it

--- a/hcloud/network.go
+++ b/hcloud/network.go
@@ -102,14 +102,9 @@ func (c *NetworkClient) GetByID(ctx context.Context, id int64) (*Network, *Respo
 
 // GetByName retrieves a network by its name. If the network does not exist, nil is returned.
 func (c *NetworkClient) GetByName(ctx context.Context, name string) (*Network, *Response, error) {
-	if name == "" {
-		return nil, nil, nil
-	}
-	Networks, response, err := c.List(ctx, NetworkListOpts{Name: name})
-	if len(Networks) == 0 {
-		return nil, response, err
-	}
-	return Networks[0], response, err
+	return firstByName(name, func() ([]*Network, *Response, error) {
+		return c.List(ctx, NetworkListOpts{Name: name})
+	})
 }
 
 // Get retrieves a network by its ID if the input can be parsed as an integer, otherwise it

--- a/hcloud/placement_group.go
+++ b/hcloud/placement_group.go
@@ -53,14 +53,9 @@ func (c *PlacementGroupClient) GetByID(ctx context.Context, id int64) (*Placemen
 
 // GetByName retrieves a PlacementGroup by its name. If the PlacementGroup does not exist, nil is returned.
 func (c *PlacementGroupClient) GetByName(ctx context.Context, name string) (*PlacementGroup, *Response, error) {
-	if name == "" {
-		return nil, nil, nil
-	}
-	placementGroups, response, err := c.List(ctx, PlacementGroupListOpts{Name: name})
-	if len(placementGroups) == 0 {
-		return nil, response, err
-	}
-	return placementGroups[0], response, err
+	return firstByName(name, func() ([]*PlacementGroup, *Response, error) {
+		return c.List(ctx, PlacementGroupListOpts{Name: name})
+	})
 }
 
 // Get retrieves a PlacementGroup by its ID if the input can be parsed as an integer, otherwise it

--- a/hcloud/primary_ip.go
+++ b/hcloud/primary_ip.go
@@ -192,14 +192,9 @@ func (c *PrimaryIPClient) GetByIP(ctx context.Context, ip string) (*PrimaryIP, *
 
 // GetByName retrieves a Primary IP by its name. If the Primary IP does not exist, nil is returned.
 func (c *PrimaryIPClient) GetByName(ctx context.Context, name string) (*PrimaryIP, *Response, error) {
-	if name == "" {
-		return nil, nil, nil
-	}
-	primaryIPs, response, err := c.List(ctx, PrimaryIPListOpts{Name: name})
-	if len(primaryIPs) == 0 {
-		return nil, response, err
-	}
-	return primaryIPs[0], response, err
+	return firstByName(name, func() ([]*PrimaryIP, *Response, error) {
+		return c.List(ctx, PrimaryIPListOpts{Name: name})
+	})
 }
 
 // Get retrieves a Primary IP by its ID if the input can be parsed as an integer, otherwise it

--- a/hcloud/server.go
+++ b/hcloud/server.go
@@ -213,14 +213,9 @@ func (c *ServerClient) GetByID(ctx context.Context, id int64) (*Server, *Respons
 
 // GetByName retrieves a server by its name. If the server does not exist, nil is returned.
 func (c *ServerClient) GetByName(ctx context.Context, name string) (*Server, *Response, error) {
-	if name == "" {
-		return nil, nil, nil
-	}
-	servers, response, err := c.List(ctx, ServerListOpts{Name: name})
-	if len(servers) == 0 {
-		return nil, response, err
-	}
-	return servers[0], response, err
+	return firstByName(name, func() ([]*Server, *Response, error) {
+		return c.List(ctx, ServerListOpts{Name: name})
+	})
 }
 
 // Get retrieves a server by its ID if the input can be parsed as an integer, otherwise it

--- a/hcloud/server_type.go
+++ b/hcloud/server_type.go
@@ -72,14 +72,9 @@ func (c *ServerTypeClient) GetByID(ctx context.Context, id int64) (*ServerType, 
 
 // GetByName retrieves a server type by its name. If the server type does not exist, nil is returned.
 func (c *ServerTypeClient) GetByName(ctx context.Context, name string) (*ServerType, *Response, error) {
-	if name == "" {
-		return nil, nil, nil
-	}
-	serverTypes, response, err := c.List(ctx, ServerTypeListOpts{Name: name})
-	if len(serverTypes) == 0 {
-		return nil, response, err
-	}
-	return serverTypes[0], response, err
+	return firstByName(name, func() ([]*ServerType, *Response, error) {
+		return c.List(ctx, ServerTypeListOpts{Name: name})
+	})
 }
 
 // Get retrieves a server type by its ID if the input can be parsed as an integer, otherwise it

--- a/hcloud/ssh_key.go
+++ b/hcloud/ssh_key.go
@@ -45,23 +45,16 @@ func (c *SSHKeyClient) GetByID(ctx context.Context, id int64) (*SSHKey, *Respons
 
 // GetByName retrieves a SSH key by its name. If the SSH key does not exist, nil is returned.
 func (c *SSHKeyClient) GetByName(ctx context.Context, name string) (*SSHKey, *Response, error) {
-	if name == "" {
-		return nil, nil, nil
-	}
-	sshKeys, response, err := c.List(ctx, SSHKeyListOpts{Name: name})
-	if len(sshKeys) == 0 {
-		return nil, response, err
-	}
-	return sshKeys[0], response, err
+	return firstByName(name, func() ([]*SSHKey, *Response, error) {
+		return c.List(ctx, SSHKeyListOpts{Name: name})
+	})
 }
 
 // GetByFingerprint retreives a SSH key by its fingerprint. If the SSH key does not exist, nil is returned.
 func (c *SSHKeyClient) GetByFingerprint(ctx context.Context, fingerprint string) (*SSHKey, *Response, error) {
-	sshKeys, response, err := c.List(ctx, SSHKeyListOpts{Fingerprint: fingerprint})
-	if len(sshKeys) == 0 {
-		return nil, response, err
-	}
-	return sshKeys[0], response, err
+	return firstBy(func() ([]*SSHKey, *Response, error) {
+		return c.List(ctx, SSHKeyListOpts{Fingerprint: fingerprint})
+	})
 }
 
 // Get retrieves a SSH key by its ID if the input can be parsed as an integer, otherwise it

--- a/hcloud/volume.go
+++ b/hcloud/volume.go
@@ -72,14 +72,9 @@ func (c *VolumeClient) GetByID(ctx context.Context, id int64) (*Volume, *Respons
 
 // GetByName retrieves a volume by its name. If the volume does not exist, nil is returned.
 func (c *VolumeClient) GetByName(ctx context.Context, name string) (*Volume, *Response, error) {
-	if name == "" {
-		return nil, nil, nil
-	}
-	volumes, response, err := c.List(ctx, VolumeListOpts{Name: name})
-	if len(volumes) == 0 {
-		return nil, response, err
-	}
-	return volumes[0], response, err
+	return firstByName(name, func() ([]*Volume, *Response, error) {
+		return c.List(ctx, VolumeListOpts{Name: name})
+	})
 }
 
 // Get retrieves a volume by its ID if the input can be parsed as an integer, otherwise it


### PR DESCRIPTION
Uses the new generic requests function to reduce the code duplication for the `GetByName` calls (and others similar functions).
