### PR TITLE
refactor: use generic request for `Get` calls

### DIFF
--- a/hcloud/certificate.go
+++ b/hcloud/certificate.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
-	"strconv"
 	"time"
 
 	"github.com/hetznercloud/hcloud-go/v2/hcloud/schema"
@@ -120,13 +119,7 @@ func (c *CertificateClient) GetByName(ctx context.Context, name string) (*Certif
 // Get retrieves a Certificate by its ID if the input can be parsed as an integer, otherwise it
 // retrieves a Certificate by its name. If the Certificate does not exist, nil is returned.
 func (c *CertificateClient) Get(ctx context.Context, idOrName string) (*Certificate, *Response, error) {
-	if id, err := strconv.ParseInt(idOrName, 10, 64); err == nil {
-		cert, res, err := c.GetByID(ctx, id)
-		if cert != nil || err != nil {
-			return cert, res, err
-		}
-	}
-	return c.GetByName(ctx, idOrName)
+	return getByIDOrName(ctx, c.GetByID, c.GetByName, idOrName)
 }
 
 // CertificateListOpts specifies options for listing Certificates.

--- a/hcloud/client_helper.go
+++ b/hcloud/client_helper.go
@@ -1,5 +1,10 @@
 package hcloud
 
+import (
+	"context"
+	"strconv"
+)
+
 // allFromSchemaFunc transform each item in the list using the FromSchema function, and
 // returns the result.
 func allFromSchemaFunc[T, V any](all []T, fn func(T) V) []V {
@@ -50,4 +55,29 @@ func firstByName[T any](name string, listFn func() ([]*T, *Response, error)) (*T
 	}
 
 	return firstBy(listFn)
+}
+
+// getByIDOrName fetches the resource by ID when the identifier is an integer, otherwise
+// by Name. To support resources that have a integer as Name, an additional attempt is
+// made to fetch the resource by Name using the ID.
+//
+// This function is only meaningful for resources created by users.
+func getByIDOrName[T any](
+	ctx context.Context,
+	getByIDFn func(ctx context.Context, id int64) (*T, *Response, error),
+	getByNameFn func(ctx context.Context, name string) (*T, *Response, error),
+	idOrName string,
+) (*T, *Response, error) {
+	if id, err := strconv.ParseInt(idOrName, 10, 64); err == nil {
+		result, resp, err := getByIDFn(ctx, id)
+		if err != nil {
+			return result, resp, err
+		}
+		if result != nil {
+			return result, resp, err
+		}
+		// Fallback to get by Name if the resource was not found
+	}
+
+	return getByNameFn(ctx, idOrName)
 }

--- a/hcloud/client_helper.go
+++ b/hcloud/client_helper.go
@@ -61,7 +61,9 @@ func firstByName[T any](name string, listFn func() ([]*T, *Response, error)) (*T
 // by Name. To support resources that have a integer as Name, an additional attempt is
 // made to fetch the resource by Name using the ID.
 //
-// This function is only meaningful for resources created by users.
+// Since API managed resources (locations, server types, ...) do not have integers as
+// names, this function is only meaningful for user managed resources (ssh keys,
+// servers).
 func getByIDOrName[T any](
 	ctx context.Context,
 	getByIDFn func(ctx context.Context, id int64) (*T, *Response, error),

--- a/hcloud/firewall.go
+++ b/hcloud/firewall.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"net"
 	"net/url"
-	"strconv"
 	"time"
 
 	"github.com/hetznercloud/hcloud-go/v2/hcloud/schema"
@@ -119,13 +118,7 @@ func (c *FirewallClient) GetByName(ctx context.Context, name string) (*Firewall,
 // Get retrieves a Firewall by its ID if the input can be parsed as an integer, otherwise it
 // retrieves a Firewall by its name. If the Firewall does not exist, nil is returned.
 func (c *FirewallClient) Get(ctx context.Context, idOrName string) (*Firewall, *Response, error) {
-	if id, err := strconv.ParseInt(idOrName, 10, 64); err == nil {
-		fw, res, err := c.GetByID(ctx, id)
-		if fw != nil || err != nil {
-			return fw, res, err
-		}
-	}
-	return c.GetByName(ctx, idOrName)
+	return getByIDOrName(ctx, c.GetByID, c.GetByName, idOrName)
 }
 
 // FirewallListOpts specifies options for listing Firewalls.

--- a/hcloud/floating_ip.go
+++ b/hcloud/floating_ip.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"net"
 	"net/url"
-	"strconv"
 	"time"
 
 	"github.com/hetznercloud/hcloud-go/v2/hcloud/schema"
@@ -120,13 +119,7 @@ func (c *FloatingIPClient) GetByName(ctx context.Context, name string) (*Floatin
 // Get retrieves a Floating IP by its ID if the input can be parsed as an integer, otherwise it
 // retrieves a Floating IP by its name. If the Floating IP does not exist, nil is returned.
 func (c *FloatingIPClient) Get(ctx context.Context, idOrName string) (*FloatingIP, *Response, error) {
-	if id, err := strconv.ParseInt(idOrName, 10, 64); err == nil {
-		ip, res, err := c.GetByID(ctx, id)
-		if ip != nil || err != nil {
-			return ip, res, err
-		}
-	}
-	return c.GetByName(ctx, idOrName)
+	return getByIDOrName(ctx, c.GetByID, c.GetByName, idOrName)
 }
 
 // FloatingIPListOpts specifies options for listing Floating IPs.

--- a/hcloud/image.go
+++ b/hcloud/image.go
@@ -120,13 +120,7 @@ func (c *ImageClient) GetByNameAndArchitecture(ctx context.Context, name string,
 //
 // Deprecated: Use [ImageClient.GetForArchitecture] instead.
 func (c *ImageClient) Get(ctx context.Context, idOrName string) (*Image, *Response, error) {
-	if id, err := strconv.ParseInt(idOrName, 10, 64); err == nil {
-		img, res, err := c.GetByID(ctx, id)
-		if img != nil {
-			return img, res, err
-		}
-	}
-	return c.GetByName(ctx, idOrName)
+	return getByIDOrName(ctx, c.GetByID, c.GetByName, idOrName)
 }
 
 // GetForArchitecture retrieves an image by its ID if the input can be parsed as an integer, otherwise it
@@ -135,13 +129,13 @@ func (c *ImageClient) Get(ctx context.Context, idOrName string) (*Image, *Respon
 // In contrast to [ImageClient.Get], this method also returns deprecated images. Depending on your needs you should
 // check for this in your calling method.
 func (c *ImageClient) GetForArchitecture(ctx context.Context, idOrName string, architecture Architecture) (*Image, *Response, error) {
-	if id, err := strconv.ParseInt(idOrName, 10, 64); err == nil {
-		img, res, err := c.GetByID(ctx, id)
-		if img != nil || err != nil {
-			return img, res, err
-		}
-	}
-	return c.GetByNameAndArchitecture(ctx, idOrName, architecture)
+	return getByIDOrName(ctx,
+		c.GetByID,
+		func(ctx context.Context, name string) (*Image, *Response, error) {
+			return c.GetByNameAndArchitecture(ctx, name, architecture)
+		},
+		idOrName,
+	)
 }
 
 // ImageListOpts specifies options for listing images.

--- a/hcloud/iso.go
+++ b/hcloud/iso.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"net/url"
-	"strconv"
 	"time"
 
 	"github.com/hetznercloud/hcloud-go/v2/hcloud/schema"
@@ -62,13 +61,7 @@ func (c *ISOClient) GetByName(ctx context.Context, name string) (*ISO, *Response
 
 // Get retrieves an ISO by its ID if the input can be parsed as an integer, otherwise it retrieves an ISO by its name.
 func (c *ISOClient) Get(ctx context.Context, idOrName string) (*ISO, *Response, error) {
-	if id, err := strconv.ParseInt(idOrName, 10, 64); err == nil {
-		iso, res, err := c.GetByID(ctx, id)
-		if iso != nil || err != nil {
-			return iso, res, err
-		}
-	}
-	return c.GetByName(ctx, idOrName)
+	return getByIDOrName(ctx, c.GetByID, c.GetByName, idOrName)
 }
 
 // ISOListOpts specifies options for listing isos.

--- a/hcloud/load_balancer.go
+++ b/hcloud/load_balancer.go
@@ -266,13 +266,7 @@ func (c *LoadBalancerClient) GetByName(ctx context.Context, name string) (*LoadB
 // Get retrieves a Load Balancer by its ID if the input can be parsed as an integer, otherwise it
 // retrieves a Load Balancer by its name. If the Load Balancer does not exist, nil is returned.
 func (c *LoadBalancerClient) Get(ctx context.Context, idOrName string) (*LoadBalancer, *Response, error) {
-	if id, err := strconv.ParseInt(idOrName, 10, 64); err == nil {
-		lb, res, err := c.GetByID(ctx, id)
-		if lb != nil || err != nil {
-			return lb, res, err
-		}
-	}
-	return c.GetByName(ctx, idOrName)
+	return getByIDOrName(ctx, c.GetByID, c.GetByName, idOrName)
 }
 
 // LoadBalancerListOpts specifies options for listing Load Balancers.

--- a/hcloud/network.go
+++ b/hcloud/network.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"net"
 	"net/url"
-	"strconv"
 	"time"
 
 	"github.com/hetznercloud/hcloud-go/v2/hcloud/schema"
@@ -110,13 +109,7 @@ func (c *NetworkClient) GetByName(ctx context.Context, name string) (*Network, *
 // Get retrieves a network by its ID if the input can be parsed as an integer, otherwise it
 // retrieves a network by its name. If the network does not exist, nil is returned.
 func (c *NetworkClient) Get(ctx context.Context, idOrName string) (*Network, *Response, error) {
-	if id, err := strconv.ParseInt(idOrName, 10, 64); err == nil {
-		n, res, err := c.GetByID(ctx, id)
-		if n != nil || err != nil {
-			return n, res, err
-		}
-	}
-	return c.GetByName(ctx, idOrName)
+	return getByIDOrName(ctx, c.GetByID, c.GetByName, idOrName)
 }
 
 // NetworkListOpts specifies options for listing networks.

--- a/hcloud/placement_group.go
+++ b/hcloud/placement_group.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
-	"strconv"
 	"time"
 
 	"github.com/hetznercloud/hcloud-go/v2/hcloud/schema"
@@ -61,13 +60,7 @@ func (c *PlacementGroupClient) GetByName(ctx context.Context, name string) (*Pla
 // Get retrieves a PlacementGroup by its ID if the input can be parsed as an integer, otherwise it
 // retrieves a PlacementGroup by its name. If the PlacementGroup does not exist, nil is returned.
 func (c *PlacementGroupClient) Get(ctx context.Context, idOrName string) (*PlacementGroup, *Response, error) {
-	if id, err := strconv.ParseInt(idOrName, 10, 64); err == nil {
-		pg, res, err := c.GetByID(ctx, id)
-		if pg != nil || err != nil {
-			return pg, res, err
-		}
-	}
-	return c.GetByName(ctx, idOrName)
+	return getByIDOrName(ctx, c.GetByID, c.GetByName, idOrName)
 }
 
 // PlacementGroupListOpts specifies options for listing PlacementGroup.

--- a/hcloud/primary_ip.go
+++ b/hcloud/primary_ip.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"net"
 	"net/url"
-	"strconv"
 	"time"
 
 	"github.com/hetznercloud/hcloud-go/v2/hcloud/schema"
@@ -200,13 +199,7 @@ func (c *PrimaryIPClient) GetByName(ctx context.Context, name string) (*PrimaryI
 // Get retrieves a Primary IP by its ID if the input can be parsed as an integer, otherwise it
 // retrieves a Primary IP by its name. If the Primary IP does not exist, nil is returned.
 func (c *PrimaryIPClient) Get(ctx context.Context, idOrName string) (*PrimaryIP, *Response, error) {
-	if id, err := strconv.ParseInt(idOrName, 10, 64); err == nil {
-		ip, res, err := c.GetByID(ctx, id)
-		if ip != nil || err != nil {
-			return ip, res, err
-		}
-	}
-	return c.GetByName(ctx, idOrName)
+	return getByIDOrName(ctx, c.GetByID, c.GetByName, idOrName)
 }
 
 // PrimaryIPListOpts specifies options for listing Primary IPs.

--- a/hcloud/server.go
+++ b/hcloud/server.go
@@ -221,13 +221,7 @@ func (c *ServerClient) GetByName(ctx context.Context, name string) (*Server, *Re
 // Get retrieves a server by its ID if the input can be parsed as an integer, otherwise it
 // retrieves a server by its name. If the server does not exist, nil is returned.
 func (c *ServerClient) Get(ctx context.Context, idOrName string) (*Server, *Response, error) {
-	if id, err := strconv.ParseInt(idOrName, 10, 64); err == nil {
-		srv, res, err := c.GetByID(ctx, id)
-		if srv != nil || err != nil {
-			return srv, res, err
-		}
-	}
-	return c.GetByName(ctx, idOrName)
+	return getByIDOrName(ctx, c.GetByID, c.GetByName, idOrName)
 }
 
 // ServerListOpts specifies options for listing servers.

--- a/hcloud/ssh_key.go
+++ b/hcloud/ssh_key.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
-	"strconv"
 	"time"
 
 	"github.com/hetznercloud/hcloud-go/v2/hcloud/schema"
@@ -60,13 +59,7 @@ func (c *SSHKeyClient) GetByFingerprint(ctx context.Context, fingerprint string)
 // Get retrieves a SSH key by its ID if the input can be parsed as an integer, otherwise it
 // retrieves a SSH key by its name. If the SSH key does not exist, nil is returned.
 func (c *SSHKeyClient) Get(ctx context.Context, idOrName string) (*SSHKey, *Response, error) {
-	if id, err := strconv.ParseInt(idOrName, 10, 64); err == nil {
-		sshKey, res, err := c.GetByID(ctx, id)
-		if sshKey != nil || err != nil {
-			return sshKey, res, err
-		}
-	}
-	return c.GetByName(ctx, idOrName)
+	return getByIDOrName(ctx, c.GetByID, c.GetByName, idOrName)
 }
 
 // SSHKeyListOpts specifies options for listing SSH keys.

--- a/hcloud/volume.go
+++ b/hcloud/volume.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
-	"strconv"
 	"time"
 
 	"github.com/hetznercloud/hcloud-go/v2/hcloud/schema"
@@ -80,13 +79,7 @@ func (c *VolumeClient) GetByName(ctx context.Context, name string) (*Volume, *Re
 // Get retrieves a volume by its ID if the input can be parsed as an integer, otherwise it
 // retrieves a volume by its name. If the volume does not exist, nil is returned.
 func (c *VolumeClient) Get(ctx context.Context, idOrName string) (*Volume, *Response, error) {
-	if id, err := strconv.ParseInt(idOrName, 10, 64); err == nil {
-		vol, res, err := c.GetByID(ctx, id)
-		if vol != nil || err != nil {
-			return vol, res, err
-		}
-	}
-	return c.GetByName(ctx, idOrName)
+	return getByIDOrName(ctx, c.GetByID, c.GetByName, idOrName)
 }
 
 // VolumeListOpts specifies options for listing volumes.


### PR DESCRIPTION
Uses the new generic requests function to reduce the code duplication for the `Get` calls.