### PR TITLE
ci: remove go 1.22 from test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,6 @@ jobs:
     strategy:
       matrix:
         go-version:
-          - "1.22"
           - "1.23"
           - "1.24"
 


### PR DESCRIPTION
Missing changes from when we dropped support for go v1.22 in #602

BEGIN_COMMIT_OVERRIDE
feat: drop go v1.22 (#602) (#621)
END_COMMIT_OVERRIDE