### PR TITLE
refactor: use generic request for remaining get calls

### DIFF
--- a/hcloud/load_balancer_test.go
+++ b/hcloud/load_balancer_test.go
@@ -1155,7 +1155,7 @@ func TestLoadBalancerGetMetrics(t *testing.T) {
 				Start: mustParseTime(t, "2017-01-01T00:00:00Z"),
 				End:   mustParseTime(t, "2017-01-01T23:00:00Z"),
 			},
-			expectedErr: "add query params: no metric types specified",
+			expectedErr: "no metric types specified",
 		},
 		{
 			name: "no start time",
@@ -1164,7 +1164,7 @@ func TestLoadBalancerGetMetrics(t *testing.T) {
 				Types: []LoadBalancerMetricType{LoadBalancerMetricBandwidth},
 				End:   mustParseTime(t, "2017-01-01T23:00:00Z"),
 			},
-			expectedErr: "add query params: no start time specified",
+			expectedErr: "no start time specified",
 		},
 		{
 			name: "no end time",
@@ -1173,7 +1173,7 @@ func TestLoadBalancerGetMetrics(t *testing.T) {
 				Types: []LoadBalancerMetricType{LoadBalancerMetricBandwidth},
 				Start: mustParseTime(t, "2017-01-01T00:00:00Z"),
 			},
-			expectedErr: "add query params: no end time specified",
+			expectedErr: "no end time specified",
 		},
 		{
 			name: "call to backend API fails",
@@ -1184,7 +1184,7 @@ func TestLoadBalancerGetMetrics(t *testing.T) {
 				End:   mustParseTime(t, "2017-01-01T23:00:00Z"),
 			},
 			respStatus:  http.StatusInternalServerError,
-			expectedErr: "get metrics: hcloud: server responded with status code 500",
+			expectedErr: "hcloud: server responded with status code 500",
 		},
 		{
 			name: "no load balancer passed",

--- a/hcloud/pricing.go
+++ b/hcloud/pricing.go
@@ -136,15 +136,12 @@ type PricingClient struct {
 
 // Get retrieves pricing information.
 func (c *PricingClient) Get(ctx context.Context) (Pricing, *Response, error) {
-	req, err := c.client.NewRequest(ctx, "GET", "/pricing", nil)
-	if err != nil {
-		return Pricing{}, nil, err
-	}
+	reqPath := "/pricing"
 
-	var body schema.PricingGetResponse
-	resp, err := c.client.Do(req, &body)
+	respBody, resp, err := getRequest[schema.PricingGetResponse](ctx, c.client, reqPath)
 	if err != nil {
 		return Pricing{}, resp, err
 	}
-	return PricingFromSchema(body.Pricing), resp, nil
+
+	return PricingFromSchema(respBody.Pricing), resp, nil
 }

--- a/hcloud/server_test.go
+++ b/hcloud/server_test.go
@@ -2242,7 +2242,7 @@ func TestServerGetMetrics(t *testing.T) {
 				Start: mustParseTime(t, "2017-01-01T00:00:00Z"),
 				End:   mustParseTime(t, "2017-01-01T23:00:00Z"),
 			},
-			expectedErr: "add query params: no metric types specified",
+			expectedErr: "no metric types specified",
 		},
 		{
 			name:   "no start time",
@@ -2251,7 +2251,7 @@ func TestServerGetMetrics(t *testing.T) {
 				Types: []ServerMetricType{ServerMetricCPU},
 				End:   mustParseTime(t, "2017-01-01T23:00:00Z"),
 			},
-			expectedErr: "add query params: no start time specified",
+			expectedErr: "no start time specified",
 		},
 		{
 			name:   "no end time",
@@ -2260,7 +2260,7 @@ func TestServerGetMetrics(t *testing.T) {
 				Types: []ServerMetricType{ServerMetricCPU},
 				Start: mustParseTime(t, "2017-01-01T00:00:00Z"),
 			},
-			expectedErr: "add query params: no end time specified",
+			expectedErr: "no end time specified",
 		},
 		{
 			name:   "call to backend API fails",
@@ -2271,7 +2271,7 @@ func TestServerGetMetrics(t *testing.T) {
 				End:   mustParseTime(t, "2017-01-01T23:00:00Z"),
 			},
 			respStatus:  http.StatusInternalServerError,
-			expectedErr: "get metrics: hcloud: server responded with status code 500",
+			expectedErr: "hcloud: server responded with status code 500",
 		},
 		{
 			name: "no server passed",

--- a/hcloud/zz_load_balancer_client_iface.go
+++ b/hcloud/zz_load_balancer_client_iface.go
@@ -64,7 +64,7 @@ type ILoadBalancerClient interface {
 	// ChangeType changes a Load Balancer's type.
 	ChangeType(ctx context.Context, loadBalancer *LoadBalancer, opts LoadBalancerChangeTypeOpts) (*Action, *Response, error)
 	// GetMetrics obtains metrics for a Load Balancer.
-	GetMetrics(ctx context.Context, lb *LoadBalancer, opts LoadBalancerGetMetricsOpts) (*LoadBalancerMetrics, *Response, error)
+	GetMetrics(ctx context.Context, loadBalancer *LoadBalancer, opts LoadBalancerGetMetricsOpts) (*LoadBalancerMetrics, *Response, error)
 	// ChangeDNSPtr changes or resets the reverse DNS pointer for a Load Balancer.
 	// Pass a nil ptr to reset the reverse DNS pointer to its default value.
 	ChangeDNSPtr(ctx context.Context, lb *LoadBalancer, ip string, ptr *string) (*Action, *Response, error)


### PR DESCRIPTION
- Also split the metrics query parameter building into a `Validate() error` and a `values() url.Values` functions. 