### PR TITLE
refactor: use correct response schema

### DIFF
--- a/hcloud/network.go
+++ b/hcloud/network.go
@@ -370,7 +370,7 @@ func (c *NetworkClient) AddRoute(ctx context.Context, network *Network, opts Net
 		Gateway:     opts.Route.Gateway.String(),
 	}
 
-	respBody, resp, err := postRequest[schema.NetworkActionAddSubnetResponse](ctx, c.client, reqPath, reqBody)
+	respBody, resp, err := postRequest[schema.NetworkActionAddRouteResponse](ctx, c.client, reqPath, reqBody)
 	if err != nil {
 		return nil, resp, err
 	}
@@ -395,7 +395,7 @@ func (c *NetworkClient) DeleteRoute(ctx context.Context, network *Network, opts 
 		Gateway:     opts.Route.Gateway.String(),
 	}
 
-	respBody, resp, err := postRequest[schema.NetworkActionDeleteSubnetResponse](ctx, c.client, reqPath, reqBody)
+	respBody, resp, err := postRequest[schema.NetworkActionDeleteRouteResponse](ctx, c.client, reqPath, reqBody)
 	if err != nil {
 		return nil, resp, err
 	}

--- a/hcloud/server.go
+++ b/hcloud/server.go
@@ -984,7 +984,7 @@ func (c *ServerClient) ChangeAliasIPs(ctx context.Context, server *Server, opts 
 		reqBody.AliasIPs = append(reqBody.AliasIPs, aliasIP.String())
 	}
 
-	respBody, resp, err := postRequest[schema.ServerActionDetachFromNetworkResponse](ctx, c.client, reqPath, reqBody)
+	respBody, resp, err := postRequest[schema.ServerActionChangeAliasIPsResponse](ctx, c.client, reqPath, reqBody)
 	if err != nil {
 		return nil, resp, err
 	}


### PR DESCRIPTION
This does not include the fixes for the primary ip client, because those changes are more involved.

Related to the comments in #624 