### PR TITLE
test: use golangci config presets

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,74 +1,48 @@
 ---
+linters:
+  presets:
+    - bugs
+    - error
+    - import
+    - metalinter
+    - module
+    - unused
+
+  enable:
+    - forbidigo
+    - testifylint
+
+  disable:
+    # preset error
+    - err113 # Very annoying to define static errors everywhere
+    - wrapcheck # Very annoying to wrap errors everywhere
+    # preset import
+    - depguard
+
 linters-settings:
-  exhaustive:
-    default-signifies-exhaustive: true
   gci:
     sections:
       - standard
       - default
       - prefix(github.com/hetznercloud)
-  gomodguard:
-    blocked:
-      modules:
-        - github.com/tj/assert:
-            recommendations:
-              - github.com/stretchr/testify/assert
-            reason: |
-              One assertion library is enough and we use testify/assert
-              everywhere.
-        - github.com/magiconair/properties:
-            recommendations:
-              - github.com/stretchr/testify/assert
-            reason: >
-              We do not currently need to parse properties files. At the same
-              time this module has an assert package which tends to get
-              imported by accident. It is therefore blocked.
-  forbidigo:
-    forbid:
-      - ^print.*$
-      - ^fmt\.Print.*$
-  misspell:
-    locale: "US"
 
-linters:
-  disable-all: true
-  enable:
-    - bodyclose
-    - errcheck
-    - errname
-    - exhaustive
-    - copyloopvar
-    - gci
-    - gocritic
-    - godot
-    - goimports
-    - gomodguard
-    - gosec
-    - gosimple
-    - govet
-    - ineffassign
-    - misspell
-    - prealloc
-    - revive
-    - staticcheck
-    - typecheck
-    - unparam
-    - unused
-    - whitespace
-    - forbidigo
+  exhaustive:
+    # Switch cases with a default case should be exhaustive.
+    default-signifies-exhaustive: true
 
 issues:
   exclude-rules:
     - path: _test\.go
       linters:
-        - gosec
         - errcheck
-    - path: hcloud/error.go
-      # False-positive in error codes
-      text: "G101: Potential hardcoded credentials" # gosec
+        - gosec
+        - noctx
 
     - path: _test\.go
       linters:
         - revive
-      # From "env.Mux.HandleFunc"
       text: "unused-parameter: parameter '(w|r)' seems to be unused, consider removing or renaming it as _"
+
+    - linters:
+        - testifylint
+      text: "require-error"

--- a/hcloud/action_waiter_test.go
+++ b/hcloud/action_waiter_test.go
@@ -201,7 +201,7 @@ func TestWaitForFunc(t *testing.T) {
 						return nil
 					}, actions...)
 
-					assert.Nil(t, err)
+					assert.NoError(t, err)
 					assert.Equal(t, []int{33, 46, 46, 53, 70, 83, 91, 100}, progress)
 				},
 			},

--- a/hcloud/action_watch_test.go
+++ b/hcloud/action_watch_test.go
@@ -3,12 +3,12 @@ package hcloud
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"net/http"
 	"reflect"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/hetznercloud/hcloud-go/v2/hcloud/schema"
 )
@@ -124,14 +124,11 @@ func TestActionClientWatchOverallProgress(t *testing.T) {
 
 	err := errs[0]
 
-	if e, ok := errors.Unwrap(err).(ActionError); !ok || e.Code != "action_failed" {
-		t.Fatalf("expected hcloud.Error, but got: %#v", err)
-	}
-
-	expectedProgressUpdates := []int{25, 62, 100}
-	if !reflect.DeepEqual(progressUpdates, expectedProgressUpdates) {
-		t.Fatalf("expected progresses %v but received %v", expectedProgressUpdates, progressUpdates)
-	}
+	require.Error(t, err)
+	var actionErr ActionError
+	require.ErrorAs(t, err, &actionErr)
+	require.Equal(t, "action_failed", actionErr.Code)
+	require.Equal(t, []int{25, 62, 100}, progressUpdates)
 }
 
 func TestActionClientWatchOverallProgressInvalidID(t *testing.T) {
@@ -274,15 +271,11 @@ loop:
 		}
 	}
 
-	if err == nil {
-		t.Fatal("expected an error")
-	}
-	if e, ok := err.(ActionError); !ok || e.Code != "action_failed" {
-		t.Fatalf("expected hcloud.Error, but got: %#v", err)
-	}
-	if len(progressUpdates) != 1 || progressUpdates[0] != 50 {
-		t.Fatalf("unexpected progress updates: %v", progressUpdates)
-	}
+	require.Error(t, err)
+	var actionErr ActionError
+	require.ErrorAs(t, err, &actionErr)
+	require.Equal(t, "action_failed", actionErr.Code)
+	require.Equal(t, []int{50}, progressUpdates)
 }
 
 func TestActionClientWatchProgressError(t *testing.T) {

--- a/hcloud/client_handler_error.go
+++ b/hcloud/client_handler_error.go
@@ -41,7 +41,7 @@ func errorFromBody(resp *Response) error {
 
 	var s schema.ErrorResponse
 	if err := json.Unmarshal(resp.body, &s); err != nil {
-		return nil
+		return nil // nolint: nilerr
 	}
 	if s.Error.Code == "" && s.Error.Message == "" {
 		return nil

--- a/hcloud/client_handler_parse_test.go
+++ b/hcloud/client_handler_parse_test.go
@@ -25,8 +25,8 @@ func TestParseHandler(t *testing.T) {
 			},
 			want: func(t *testing.T, v SomeStruct, resp *Response, err error) {
 				assert.NoError(t, err)
-				assert.Equal(t, v.Data, "Hello")
-				assert.Equal(t, resp.Meta.Pagination.Page, 1)
+				assert.Equal(t, "Hello", v.Data)
+				assert.Equal(t, 1, resp.Meta.Pagination.Page)
 			},
 		},
 		{
@@ -36,7 +36,7 @@ func TestParseHandler(t *testing.T) {
 			},
 			want: func(t *testing.T, v SomeStruct, resp *Response, err error) {
 				assert.EqualError(t, err, "any error")
-				assert.Equal(t, v.Data, "")
+				assert.Equal(t, "", v.Data)
 				assert.Nil(t, resp)
 			},
 		},

--- a/hcloud/client_handler_retry_test.go
+++ b/hcloud/client_handler_retry_test.go
@@ -39,7 +39,7 @@ func TestRetryHandler(t *testing.T) {
 			},
 			recover: true,
 			want: func(t *testing.T, err error, retryCount int) {
-				assert.Nil(t, err)
+				assert.NoError(t, err)
 				assert.Equal(t, 1, retryCount)
 			},
 		},
@@ -64,7 +64,7 @@ func TestRetryHandler(t *testing.T) {
 			},
 			recover: true,
 			want: func(t *testing.T, err error, retryCount int) {
-				assert.Nil(t, err)
+				assert.NoError(t, err)
 				assert.Equal(t, 1, retryCount)
 			},
 		},

--- a/hcloud/client_handler_test.go
+++ b/hcloud/client_handler_test.go
@@ -54,10 +54,10 @@ func TestCloneRequest(t *testing.T) {
 	assert.Equal(t, req.Context(), cloned.Context())
 
 	// Check headers
-	assert.Equal(t, req.Header.Get("Authorization"), "sensitive")
+	assert.Equal(t, "sensitive", req.Header.Get("Authorization"))
 
 	// Check body
 	reqBody, err := io.ReadAll(req.Body)
 	require.NoError(t, err)
-	assert.Equal(t, string(reqBody), "Hello")
+	assert.Equal(t, "Hello", string(reqBody))
 }

--- a/hcloud/exp/kit/sshutil/ssh_key_test.go
+++ b/hcloud/exp/kit/sshutil/ssh_key_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestGenerateKeyPair(t *testing.T) {
 	privBytes, pubBytes, err := GenerateKeyPair()
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	priv := string(privBytes)
 	pub := string(pubBytes)

--- a/hcloud/exp/mockutil/http.go
+++ b/hcloud/exp/mockutil/http.go
@@ -95,7 +95,7 @@ func (m *Server) handler(w http.ResponseWriter, r *http.Request) {
 		expectedCall += " " + expected.Path
 		foundCall += " " + r.RequestURI
 	}
-	require.Equal(m.t, expectedCall, foundCall)
+	require.Equal(m.t, expectedCall, foundCall) // nolint: testifylint
 
 	if expected.Want != nil {
 		expected.Want(m.t, r)

--- a/hcloud/exp/mockutil/http_test.go
+++ b/hcloud/exp/mockutil/http_test.go
@@ -46,14 +46,14 @@ func TestHandler(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, 200, resp.StatusCode)
 	assert.Equal(t, "application/json", resp.Header.Get("Content-Type"))
-	assert.Equal(t, `{"data":"Hello"}`, readBody(t, resp))
+	assert.JSONEq(t, `{"data":"Hello"}`, readBody(t, resp))
 
 	// Request 2
 	resp, err = http.Get(server.URL)
 	require.NoError(t, err)
 	assert.Equal(t, 400, resp.StatusCode)
 	assert.Equal(t, "application/json", resp.Header.Get("Content-Type"))
-	assert.Equal(t, `{"error": "failed"}`, readBody(t, resp))
+	assert.JSONEq(t, `{"error": "failed"}`, readBody(t, resp))
 
 	// Request 3
 	resp, err = http.Get(server.URL)

--- a/hcloud/metadata/client_test.go
+++ b/hcloud/metadata/client_test.go
@@ -231,5 +231,5 @@ func TestClient_PrivateNetworks(t *testing.T) {
   network: 192.168.0.0/16
   subnet: 192.168.0.0/24
   gateway: 192.168.0.1`
-	assert.Equal(t, privateNetworks, expectedNetworks)
+	assert.Equal(t, expectedNetworks, privateNetworks)
 }

--- a/hcloud/primary_ip_test.go
+++ b/hcloud/primary_ip_test.go
@@ -270,22 +270,11 @@ func TestPrimaryIPClient(t *testing.T) {
 
 		env.Mux.HandleFunc("/primary_ips", func(w http.ResponseWriter, r *http.Request) {
 			w.Header().Set("Content-Type", "application/json")
-			json.NewEncoder(w).Encode(struct {
-				PrimaryIPs []PrimaryIP `json:"primary_ips"`
-				Meta       schema.Meta `json:"meta"`
-			}{
-				PrimaryIPs: []PrimaryIP{
+			json.NewEncoder(w).Encode(schema.PrimaryIPListResponse{
+				PrimaryIPs: []schema.PrimaryIP{
 					{ID: 1},
 					{ID: 2},
 					{ID: 3},
-				},
-				Meta: schema.Meta{
-					Pagination: &schema.MetaPagination{
-						Page:         1,
-						LastPage:     1,
-						PerPage:      3,
-						TotalEntries: 3,
-					},
 				},
 			})
 		})

--- a/hcloud/schema/error.go
+++ b/hcloud/schema/error.go
@@ -7,7 +7,7 @@ type Error struct {
 	Code       string          `json:"code"`
 	Message    string          `json:"message"`
 	DetailsRaw json.RawMessage `json:"details"`
-	Details    interface{}
+	Details    any             `json:"-"`
 }
 
 // UnmarshalJSON overrides default json unmarshalling.

--- a/hcloud/schema/id_or_name_test.go
+++ b/hcloud/schema/id_or_name_test.go
@@ -80,26 +80,26 @@ func TestIDOrNameUnMarshall(t *testing.T) {
 func TestIDOrName(t *testing.T) {
 	// Make sure the behavior does not change from the use of an interface{}.
 	type FakeRequest struct {
-		Old interface{} `json:"old"`
-		New IDOrName    `json:"new"`
+		Old any      `json:"old"`
+		New IDOrName `json:"new"`
 	}
 
 	t.Run("null", func(t *testing.T) {
 		o := FakeRequest{}
 		body, err := json.Marshal(o)
 		require.NoError(t, err)
-		require.Equal(t, `{"old":null,"new":null}`, string(body))
+		require.JSONEq(t, `{"old":null,"new":null}`, string(body))
 	})
 	t.Run("id", func(t *testing.T) {
 		o := FakeRequest{Old: int64(1), New: IDOrName{ID: 1}}
 		body, err := json.Marshal(o)
 		require.NoError(t, err)
-		require.Equal(t, `{"old":1,"new":1}`, string(body))
+		require.JSONEq(t, `{"old":1,"new":1}`, string(body))
 	})
 	t.Run("name", func(t *testing.T) {
 		o := FakeRequest{Old: "name", New: IDOrName{Name: "name"}}
 		body, err := json.Marshal(o)
 		require.NoError(t, err)
-		require.Equal(t, `{"old":"name","new":"name"}`, string(body))
+		require.JSONEq(t, `{"old":"name","new":"name"}`, string(body))
 	})
 }

--- a/hcloud/schema_gen.go
+++ b/hcloud/schema_gen.go
@@ -946,7 +946,10 @@ func rawSchemaFromErrorDetails(v interface{}) json.RawMessage {
 	if v == nil {
 		return nil
 	}
-	msg, _ := json.Marshal(d)
+	msg, err := json.Marshal(d)
+	if err != nil {
+		return nil
+	}
 	return msg
 }
 

--- a/hcloud/schema_test.go
+++ b/hcloud/schema_test.go
@@ -284,7 +284,7 @@ func TestISOSchema(t *testing.T) {
 					t.Fatal(err)
 				}
 				assert.NotNil(t, v.Deprecation)
-				assert.Equal(t, v.Deprecated, expDeprecated)
+				assert.Equal(t, expDeprecated, v.Deprecated)
 			},
 		},
 	} {

--- a/hcloud/server.go
+++ b/hcloud/server.go
@@ -622,7 +622,7 @@ func (c *ServerClient) CreateImage(ctx context.Context, server *Server, opts *Se
 	reqBody := schema.ServerActionCreateImageRequest{}
 	if opts != nil {
 		if err := opts.Validate(); err != nil {
-			return result, nil, fmt.Errorf("invalid options: %s", err)
+			return result, nil, fmt.Errorf("invalid options: %w", err)
 		}
 		if opts.Description != nil {
 			reqBody.Description = opts.Description


### PR DESCRIPTION
- Updates the golangci config to use presets to use more linters.
- Make golangci lint happy. 