### PR TITLE
fix: panic when a request did not set the OpPath for instrumentation

### DIFF
--- a/hcloud/client_generic_test.go
+++ b/hcloud/client_generic_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/hetznercloud/hcloud-go/v2/hcloud/exp/ctxutil"
 	"github.com/hetznercloud/hcloud-go/v2/hcloud/exp/mockutil"
 	"github.com/hetznercloud/hcloud-go/v2/hcloud/schema"
 )
@@ -23,7 +24,10 @@ func TestGenericRequest(t *testing.T) {
 			},
 		})
 
-		respBody, resp, err := getRequest[schema.ActionGetResponse](ctx, client, "/resource")
+		const opPath = "/resource"
+		ctx = ctxutil.SetOpPath(ctx, opPath)
+
+		respBody, resp, err := getRequest[schema.ActionGetResponse](ctx, client, opPath)
 		require.NoError(t, err)
 		require.NotNil(t, resp)
 		require.NotNil(t, respBody)
@@ -47,7 +51,10 @@ func TestGenericRequest(t *testing.T) {
 			},
 		})
 
-		respBody, resp, err := postRequest[schema.ActionGetResponse](ctx, client, "/resource", map[string]string{"hello": "world"})
+		const opPath = "/resource"
+		ctx = ctxutil.SetOpPath(ctx, opPath)
+
+		respBody, resp, err := postRequest[schema.ActionGetResponse](ctx, client, opPath, map[string]string{"hello": "world"})
 		require.NoError(t, err)
 		require.NotNil(t, resp)
 		require.NotNil(t, respBody)
@@ -71,7 +78,10 @@ func TestGenericRequest(t *testing.T) {
 			},
 		})
 
-		respBody, resp, err := putRequest[schema.ActionGetResponse](ctx, client, "/resource", map[string]string{"hello": "world"})
+		const opPath = "/resource"
+		ctx = ctxutil.SetOpPath(ctx, opPath)
+
+		respBody, resp, err := putRequest[schema.ActionGetResponse](ctx, client, opPath, map[string]string{"hello": "world"})
 		require.NoError(t, err)
 		require.NotNil(t, resp)
 		require.NotNil(t, respBody)
@@ -90,7 +100,10 @@ func TestGenericRequest(t *testing.T) {
 			},
 		})
 
-		respBody, resp, err := deleteRequest[schema.ActionGetResponse](ctx, client, "/resource")
+		const opPath = "/resource"
+		ctx = ctxutil.SetOpPath(ctx, opPath)
+
+		respBody, resp, err := deleteRequest[schema.ActionGetResponse](ctx, client, opPath)
 		require.NoError(t, err)
 		require.NotNil(t, resp)
 		require.NotNil(t, respBody)
@@ -108,7 +121,10 @@ func TestGenericRequest(t *testing.T) {
 			},
 		})
 
-		resp, err := deleteRequestNoResult(ctx, client, "/resource")
+		const opPath = "/resource"
+		ctx = ctxutil.SetOpPath(ctx, opPath)
+
+		resp, err := deleteRequestNoResult(ctx, client, opPath)
 		require.NoError(t, err)
 		require.NotNil(t, resp)
 	})

--- a/hcloud/client_test.go
+++ b/hcloud/client_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -28,6 +29,8 @@ func makeTestUtils(t *testing.T) (context.Context, *mockutil.Server, *Client) {
 		WithEndpoint(server.URL),
 		WithRetryOpts(RetryOpts{BackoffFunc: ConstantBackoff(0), MaxRetries: 5}),
 		WithPollOpts(PollOpts{BackoffFunc: ConstantBackoff(0)}),
+		// This makes sure that our instrumentation does not cause any panics/errors
+		WithInstrumentation(prometheus.DefaultRegisterer),
 	)
 
 	return ctx, server, client
@@ -63,6 +66,8 @@ func newTestEnvWithServer(server *httptest.Server, mux *http.ServeMux) testEnv {
 		WithPollOpts(PollOpts{
 			BackoffFunc: ConstantBackoff(0),
 		}),
+		// This makes sure that our instrumentation does not cause any panics/errors
+		WithInstrumentation(prometheus.DefaultRegisterer),
 	)
 	return testEnv{
 		Server: server,

--- a/hcloud/exp/ctxutil/ctxutil.go
+++ b/hcloud/exp/ctxutil/ctxutil.go
@@ -11,6 +11,7 @@ type key struct{}
 // opPathKey is the key for operation path in Contexts.
 var opPathKey = key{}
 
+// SetOpPath processes the operation path and save it in the context before returning it.
 func SetOpPath(ctx context.Context, path string) context.Context {
 	path, _, _ = strings.Cut(path, "?")
 	path = strings.ReplaceAll(path, "%d", "-")
@@ -19,7 +20,11 @@ func SetOpPath(ctx context.Context, path string) context.Context {
 	return context.WithValue(ctx, opPathKey, path)
 }
 
+// OpPath returns the operation path from the context.
 func OpPath(ctx context.Context) string {
-	result := ctx.Value(opPathKey).(string)
+	result, ok := ctx.Value(opPathKey).(string)
+	if !ok {
+		return ""
+	}
 	return result
 }

--- a/hcloud/internal/instrumentation/metrics_test.go
+++ b/hcloud/internal/instrumentation/metrics_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestMultipleInstrumentedClients(t *testing.T) {
@@ -14,4 +15,25 @@ func TestMultipleInstrumentedClients(t *testing.T) {
 		New("test", reg).InstrumentedRoundTripper()
 		New("test", reg).InstrumentedRoundTripper()
 	})
+}
+
+func TestPreparePathForLabel(t *testing.T) {
+	tests := []struct {
+		path string
+		want string
+	}{
+		{
+			"/v1/volumes/123456",
+			"/volumes/-",
+		},
+		{
+			"/v1/volumes/123456/actions/attach",
+			"/volumes/-/actions/attach",
+		},
+	}
+	for _, tt := range tests {
+		t.Run("", func(t *testing.T) {
+			assert.Equal(t, tt.want, preparePathForLabel(tt.path))
+		})
+	}
 }

--- a/hcloud/metadata/client_test.go
+++ b/hcloud/metadata/client_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -27,6 +28,8 @@ func newTestEnv() testEnv {
 	server := httptest.NewServer(mux)
 	client := NewClient(
 		WithEndpoint(server.URL),
+		// This makes sure that our instrumentation does not cause any panics/errors
+		WithInstrumentation(prometheus.DefaultRegisterer),
 	)
 	return testEnv{
 		Server: server,


### PR DESCRIPTION
When an instrumented client (API or Metadata) made a request that did not explicitly specify the OpPath through `ctxutil.SetOpPath()` that instrumentation code caused a panic.

This is now handled by adding back a fallback if the explicit OpPath is not set. The fallback uses the same patterns to create the OpPath as our manual paths.

This only happened for the Metadata client and any custom clients/requests that users added besides the official endpoints implemented in hcloud-go.

Bug was introduced in #626, thanks to @lukasmetzner for finding and reporting.

Co-authored-by: Jonas Lammler <jonas.lammler@hetzner-cloud.de>