### PR TITLE
docs: add note about the schema package stability

### DIFF
--- a/hcloud/schema/README.md
+++ b/hcloud/schema/README.md
@@ -1,0 +1,6 @@
+# Schema
+
+The [`schema`](./) package holds API schemas for the `hcloud-go` library.
+
+> [!CAUTION]
+> Breaking changes may occur without notice. Do not use in production!

--- a/hcloud/schema/doc.go
+++ b/hcloud/schema/doc.go
@@ -1,0 +1,4 @@
+// The schema package holds API schemas for the `hcloud-go` library.
+
+// Breaking changes may occur without notice. Do not use in production!
+package schema


### PR DESCRIPTION
Since we introduce breaking changes in the schema package, we must make sure people do not expect stability from it. This adds a small note about the stability of the schema package.