### PR TITLE
refactor: use generic `firstBy` for `GetByIP`

### DIFF
--- a/hcloud/primary_ip.go
+++ b/hcloud/primary_ip.go
@@ -170,11 +170,9 @@ func (c *PrimaryIPClient) GetByIP(ctx context.Context, ip string) (*PrimaryIP, *
 	if ip == "" {
 		return nil, nil, nil
 	}
-	primaryIPs, response, err := c.List(ctx, PrimaryIPListOpts{IP: ip})
-	if len(primaryIPs) == 0 {
-		return nil, response, err
-	}
-	return primaryIPs[0], response, err
+	return firstBy(func() ([]*PrimaryIP, *Response, error) {
+		return c.List(ctx, PrimaryIPListOpts{IP: ip})
+	})
 }
 
 // GetByName retrieves a Primary IP by its name. If the Primary IP does not exist, nil is returned.


### PR DESCRIPTION
Missing refactor from our past refactor patch series.