### PR TITLE
fix: http transport ignored when using instrumentation

### DIFF
--- a/hcloud/client.go
+++ b/hcloud/client.go
@@ -267,7 +267,7 @@ func NewClient(options ...ClientOption) *Client {
 	client.buildUserAgent()
 	if client.instrumentationRegistry != nil {
 		i := instrumentation.New("api", client.instrumentationRegistry)
-		client.httpClient.Transport = i.InstrumentedRoundTripper()
+		client.httpClient.Transport = i.InstrumentedRoundTripper(client.httpClient.Transport)
 	}
 
 	client.handler = assembleHandlerChain(client)

--- a/hcloud/internal/instrumentation/metrics_test.go
+++ b/hcloud/internal/instrumentation/metrics_test.go
@@ -1,6 +1,7 @@
 package instrumentation
 
 import (
+	"net/http"
 	"testing"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -12,8 +13,8 @@ func TestMultipleInstrumentedClients(t *testing.T) {
 
 	t.Run("should not panic", func(_ *testing.T) {
 		// Following code should run without panicking
-		New("test", reg).InstrumentedRoundTripper()
-		New("test", reg).InstrumentedRoundTripper()
+		New("test", reg).InstrumentedRoundTripper(http.DefaultTransport)
+		New("test", reg).InstrumentedRoundTripper(http.DefaultTransport)
 	})
 }
 

--- a/hcloud/metadata/client.go
+++ b/hcloud/metadata/client.go
@@ -75,7 +75,7 @@ func NewClient(options ...ClientOption) *Client {
 
 	if client.instrumentationRegistry != nil {
 		i := instrumentation.New("metadata", client.instrumentationRegistry)
-		client.httpClient.Transport = i.InstrumentedRoundTripper()
+		client.httpClient.Transport = i.InstrumentedRoundTripper(client.httpClient.Transport)
 	}
 	return client
 }


### PR DESCRIPTION
Configuration that set a custom HTTP client transport would be ignored. For example in this snippet, the `otelhttp.NewTransport` would not come into effect.

```go
httpClient := &http.Client{
	Transport: otelhttp.NewTransport(
		http.DefaultTransport,
	),
}

opts := []hcloud.ClientOption{
	hcloud.WithInstrumentation(reg),
	hcloud.WithHTTPClient(httpClient),
}

client := hcloud.NewClient(opts...)
```