### PR TITLE
fix: add arg name in missing or invalid argument errors

### DIFF
--- a/hcloud/error.go
+++ b/hcloud/error.go
@@ -166,8 +166,12 @@ func newArgumentErrorf(format string, args ...any) ArgumentError {
 	return ArgumentError(fmt.Sprintf(format, args...))
 }
 
-func missingArgument(obj any) error {
-	return newArgumentErrorf("missing argument [%T]", obj)
+func missingArgument(name string, obj any) error {
+	return newArgumentErrorf("missing argument '%s' [%T]", name, obj)
+}
+
+func invalidArgument(name string, obj any) error {
+	return newArgumentErrorf("invalid value '%v' for argument '%s' [%T]", obj, name, obj)
 }
 
 func missingField(obj any, field string) error {

--- a/hcloud/error_test.go
+++ b/hcloud/error_test.go
@@ -150,8 +150,12 @@ func TestArgumentError(t *testing.T) {
 		want string
 	}{
 		{
-			err:  missingArgument(something),
-			want: "missing argument [hcloud.Something]",
+			err:  missingArgument("something", something),
+			want: "missing argument 'something' [hcloud.Something]",
+		},
+		{
+			err:  invalidArgument("something", "hello"),
+			want: "invalid value 'hello' for argument 'something' [string]",
 		},
 		{
 			err:  missingField(something, "Name"),

--- a/hcloud/load_balancer.go
+++ b/hcloud/load_balancer.go
@@ -941,7 +941,7 @@ func (c *LoadBalancerClient) GetMetrics(
 	ctx = ctxutil.SetOpPath(ctx, opPath)
 
 	if loadBalancer == nil {
-		return nil, nil, missingArgument(loadBalancer)
+		return nil, nil, missingArgument("loadBalancer", loadBalancer)
 	}
 
 	if err := opts.Validate(); err != nil {

--- a/hcloud/load_balancer_test.go
+++ b/hcloud/load_balancer_test.go
@@ -1193,7 +1193,7 @@ func TestLoadBalancerGetMetrics(t *testing.T) {
 				Start: mustParseTime(t, "2017-01-01T00:00:00Z"),
 				End:   mustParseTime(t, "2017-01-01T23:00:00Z"),
 			},
-			expectedErr: "missing argument [*hcloud.LoadBalancer]",
+			expectedErr: "missing argument 'loadBalancer' [*hcloud.LoadBalancer]",
 		},
 	}
 

--- a/hcloud/server.go
+++ b/hcloud/server.go
@@ -1054,7 +1054,7 @@ func (c *ServerClient) GetMetrics(ctx context.Context, server *Server, opts Serv
 	ctx = ctxutil.SetOpPath(ctx, opPath)
 
 	if server == nil {
-		return nil, nil, missingArgument(server)
+		return nil, nil, missingArgument("server", server)
 	}
 
 	if err := opts.Validate(); err != nil {

--- a/hcloud/server_test.go
+++ b/hcloud/server_test.go
@@ -2280,7 +2280,7 @@ func TestServerGetMetrics(t *testing.T) {
 				Start: mustParseTime(t, "2017-01-01T00:00:00Z"),
 				End:   mustParseTime(t, "2017-01-01T23:00:00Z"),
 			},
-			expectedErr: "missing argument [*hcloud.Server]",
+			expectedErr: "missing argument 'server' [*hcloud.Server]",
 		},
 	}
 


### PR DESCRIPTION
Only printing the argument type might not always be enough to pin point where the problem is.

This ensure we print both the name and the type of the argument.