### PR TITLE
ci: set concurrency group for releaser-pleaser

### DIFF
--- a/.github/workflows/releaser-pleaser.yml
+++ b/.github/workflows/releaser-pleaser.yml
@@ -1,5 +1,9 @@
 name: Releaser-pleaser
 
+concurrency:
+  group: releaser-pleaser
+  cancel-in-progress: true
+
 on:
   push:
     branches: [main]


### PR DESCRIPTION
This PR updates our GitHub CI as described in the releaser-pleaser [Release notes](https://github.com/apricote/releaser-pleaser/releases/tag/v0.6.0).