### PR TITLE
fix: add Hetzner endpoint to test utils

### DIFF
--- a/hcloud/client_test.go
+++ b/hcloud/client_test.go
@@ -27,6 +27,7 @@ func makeTestUtils(t *testing.T) (context.Context, *mockutil.Server, *Client) {
 
 	client := NewClient(
 		WithEndpoint(server.URL),
+		WithHetznerEndpoint(server.URL),
 		WithRetryOpts(RetryOpts{BackoffFunc: ConstantBackoff(0), MaxRetries: 5}),
 		WithPollOpts(PollOpts{BackoffFunc: ConstantBackoff(0)}),
 		// This makes sure that our instrumentation does not cause any panics/errors


### PR DESCRIPTION
We can use the same API endpoint here, as this is a local server for testing, where we define the responses ourselves.