### PR TITLE
fix: storage box type snapshot limits are nullable

### DIFF
--- a/hcloud/schema/storage_box_type.go
+++ b/hcloud/schema/storage_box_type.go
@@ -5,8 +5,8 @@ type StorageBoxType struct {
 	ID                     int64                 `json:"id"`
 	Name                   string                `json:"name"`
 	Description            string                `json:"description"`
-	SnapshotLimit          int                   `json:"snapshot_limit"`
-	AutomaticSnapshotLimit int                   `json:"automatic_snapshot_limit"`
+	SnapshotLimit          *int                  `json:"snapshot_limit"`
+	AutomaticSnapshotLimit *int                  `json:"automatic_snapshot_limit"`
 	SubaccountsLimit       int                   `json:"subaccounts_limit"`
 	Size                   int64                 `json:"size"`
 	Prices                 []StorageBoxTypePrice `json:"prices"`

--- a/hcloud/storage_box_type.go
+++ b/hcloud/storage_box_type.go
@@ -15,8 +15,8 @@ type StorageBoxType struct {
 	ID                     int64
 	Name                   string
 	Description            string
-	SnapshotLimit          int
-	AutomaticSnapshotLimit int
+	SnapshotLimit          *int
+	AutomaticSnapshotLimit *int
 	SubaccountsLimit       int
 	Size                   int64
 	Pricings               []StorageBoxTypeLocationPricing

--- a/hcloud/storage_box_type_test.go
+++ b/hcloud/storage_box_type_test.go
@@ -51,6 +51,39 @@ func TestStorageBoxTypeClientGetByID(t *testing.T) {
 		assert.Equal(t, "bx11", storageBoxType.Name, "unexpected storage box type name")
 	})
 
+	t.Run("GetByID (nullables)", func(t *testing.T) {
+		ctx, server, client := makeTestUtils(t)
+
+		server.Expect([]mockutil.Request{
+			{
+				Method: "GET", Path: "/storage_box_types/42",
+				Status: 200,
+				JSONRaw: `
+				{
+					"storage_box_type": {
+						"id": 42,
+						"name": "bx11",
+						"description": "BX11",
+						"snapshot_limit": null,
+						"automatic_snapshot_limit": null,
+						"subaccounts_limit": 200,
+						"size": 1073741824,
+						"prices": [],
+						"deprecation": null
+					}
+				}`,
+			},
+		})
+
+		storageBoxType, _, err := client.StorageBoxType.GetByID(ctx, 42)
+		require.NoError(t, err)
+		require.NotNil(t, storageBoxType, "no storage box type")
+		assert.Equal(t, int64(42), storageBoxType.ID, "unexpected storage box type ID")
+		assert.Nil(t, storageBoxType.SnapshotLimit, "expected nil snapshot limit")
+		assert.Nil(t, storageBoxType.AutomaticSnapshotLimit, "expected nil automatic snapshot limit")
+		assert.Nil(t, storageBoxType.Deprecation, "expected nil deprecation")
+	})
+
 	t.Run("GetByID (not found)", func(t *testing.T) {
 		ctx, server, client := makeTestUtils(t)
 


### PR DESCRIPTION
`snapshot_limit` and `automatic_snapshot_limit` are both nullable. We implemented them as required.