### PR TITLE
docs: do not mark DeprecatableResource as deprecated

### DIFF
--- a/hcloud/deprecation.go
+++ b/hcloud/deprecation.go
@@ -22,8 +22,8 @@ type DeprecationInfo struct {
 	UnavailableAfter time.Time
 }
 
-// DeprecatableResource implements the [Deprecatable] interface and can be embedded in structs for Resources that can be
-// deprecated.
+// DeprecatableResource implements the [Deprecatable] interface and can be embedded in structs for Resources that can
+// be deprecated.
 type DeprecatableResource struct {
 	Deprecation *DeprecationInfo
 }


### PR DESCRIPTION
Some tools (like JetBrains IDEs) scan comments for a line starting with `deprecated` to mark a type as deprecated. (See https://go.dev/wiki/Deprecated)
Since we do not want that here, we add a different line break so that the second line does not start with `deprecated` anymore.