### PR TITLE
fix: subresources contain parent

### DIFF
--- a/hcloud/storage_box_snapshot.go
+++ b/hcloud/storage_box_snapshot.go
@@ -178,14 +178,13 @@ type StorageBoxSnapshotUpdateOpts struct {
 // UpdateSnapshot updates the given snapshot of a Storage Box with the provided options.
 func (c *StorageBoxClient) UpdateSnapshot(
 	ctx context.Context,
-	storageBox *StorageBox,
 	snapshot *StorageBoxSnapshot,
 	opts StorageBoxSnapshotUpdateOpts,
 ) (*StorageBoxSnapshot, *Response, error) {
 	const opPath = "/storage_boxes/%d/snapshots/%d"
 	ctx = ctxutil.SetOpPath(ctx, opPath)
 
-	reqPath := fmt.Sprintf(opPath, storageBox.ID, snapshot.ID)
+	reqPath := fmt.Sprintf(opPath, snapshot.StorageBox.ID, snapshot.ID)
 	reqBody := SchemaFromStorageBoxSnapshotUpdateOpts(opts)
 
 	respBody, resp, err := putRequest[schema.StorageBoxSnapshotUpdateResponse](ctx, c.client, reqPath, reqBody)
@@ -201,13 +200,12 @@ func (c *StorageBoxClient) UpdateSnapshot(
 // DeleteSnapshot deletes the given snapshot of a Storage Box.
 func (c *StorageBoxClient) DeleteSnapshot(
 	ctx context.Context,
-	storageBox *StorageBox,
 	snapshot *StorageBoxSnapshot,
 ) (*Action, *Response, error) {
 	const opPath = "/storage_boxes/%d/snapshots/%d"
 	ctx = ctxutil.SetOpPath(ctx, opPath)
 
-	reqPath := fmt.Sprintf(opPath, storageBox.ID, snapshot.ID)
+	reqPath := fmt.Sprintf(opPath, snapshot.StorageBox.ID, snapshot.ID)
 
 	respBody, resp, err := deleteRequest[schema.ActionGetResponse](ctx, c.client, reqPath)
 

--- a/hcloud/storage_box_snapshot_test.go
+++ b/hcloud/storage_box_snapshot_test.go
@@ -294,15 +294,19 @@ func TestStorageBoxClientUpdateSnapshot(t *testing.T) {
 		},
 	})
 
-	storageBox := &StorageBox{ID: 42}
-	storageBoxSnapshot := &StorageBoxSnapshot{ID: 13}
+	storageBoxSnapshot := &StorageBoxSnapshot{
+		ID: 13,
+		StorageBox: &StorageBox{
+			ID: 42,
+		},
+	}
 
 	opts := StorageBoxSnapshotUpdateOpts{
 		Labels: map[string]string{
 			"environment": "prod",
 		},
 	}
-	storageBoxSnapshot, _, err := client.StorageBox.UpdateSnapshot(ctx, storageBox, storageBoxSnapshot, opts)
+	storageBoxSnapshot, _, err := client.StorageBox.UpdateSnapshot(ctx, storageBoxSnapshot, opts)
 	require.NoError(t, err)
 	require.NotNil(t, storageBoxSnapshot)
 
@@ -320,10 +324,14 @@ func TestStorageBoxClientDeleteSnapshot(t *testing.T) {
 		},
 	})
 
-	storageBox := &StorageBox{ID: 42}
-	storageBoxSnapshot := &StorageBoxSnapshot{ID: 13}
+	storageBoxSnapshot := &StorageBoxSnapshot{
+		ID: 13,
+		StorageBox: &StorageBox{
+			ID: 42,
+		},
+	}
 
-	action, _, err := client.StorageBox.DeleteSnapshot(ctx, storageBox, storageBoxSnapshot)
+	action, _, err := client.StorageBox.DeleteSnapshot(ctx, storageBoxSnapshot)
 	require.NoError(t, err)
 	require.NotNil(t, action)
 }

--- a/hcloud/storage_box_subaccount.go
+++ b/hcloud/storage_box_subaccount.go
@@ -167,14 +167,13 @@ type StorageBoxSubaccountUpdateOpts struct {
 // UpdateSubaccount updates a subaccount of a Storage Box.
 func (c *StorageBoxClient) UpdateSubaccount(
 	ctx context.Context,
-	storageBox *StorageBox,
 	subaccount *StorageBoxSubaccount,
 	opts StorageBoxSubaccountUpdateOpts,
 ) (*StorageBoxSubaccount, *Response, error) {
 	const opPath = "/storage_boxes/%d/subaccounts/%d"
 	ctx = ctxutil.SetOpPath(ctx, opPath)
 
-	reqPath := fmt.Sprintf(opPath, storageBox.ID, subaccount.ID)
+	reqPath := fmt.Sprintf(opPath, subaccount.StorageBox.ID, subaccount.ID)
 	reqBody := SchemaFromStorageBoxSubaccountUpdateOpts(opts)
 
 	respBody, resp, err := putRequest[schema.StorageBoxSubaccountUpdateResponse](ctx, c.client, reqPath, reqBody)
@@ -190,13 +189,12 @@ func (c *StorageBoxClient) UpdateSubaccount(
 // DeleteSubaccount deletes a subaccount from a Storage Box.
 func (c *StorageBoxClient) DeleteSubaccount(
 	ctx context.Context,
-	storageBox *StorageBox,
 	subaccount *StorageBoxSubaccount,
 ) (*Action, *Response, error) {
 	const opPath = "/storage_boxes/%d/subaccounts/%d"
 	ctx = ctxutil.SetOpPath(ctx, opPath)
 
-	reqPath := fmt.Sprintf(opPath, storageBox.ID, subaccount.ID)
+	reqPath := fmt.Sprintf(opPath, subaccount.StorageBox.ID, subaccount.ID)
 
 	respBody, resp, err := deleteRequest[schema.ActionGetResponse](ctx, c.client, reqPath)
 	if err != nil {
@@ -216,14 +214,13 @@ type StorageBoxSubaccountResetPasswordOpts struct {
 // ResetSubaccountPassword resets the password of a Storage Box subaccount.
 func (c *StorageBoxClient) ResetSubaccountPassword(
 	ctx context.Context,
-	storageBox *StorageBox,
 	subaccount *StorageBoxSubaccount,
 	opts StorageBoxSubaccountResetPasswordOpts,
 ) (*Action, *Response, error) {
 	const opPath = "/storage_boxes/%d/subaccounts/%d/actions/reset_subaccount_password"
 	ctx = ctxutil.SetOpPath(ctx, opPath)
 
-	reqPath := fmt.Sprintf(opPath, storageBox.ID, subaccount.ID)
+	reqPath := fmt.Sprintf(opPath, subaccount.StorageBox.ID, subaccount.ID)
 	reqBody := SchemaFromStorageBoxSubaccountResetPasswordOpts(opts)
 
 	respBody, resp, err := postRequest[schema.ActionGetResponse](ctx, c.client, reqPath, reqBody)
@@ -247,14 +244,13 @@ type StorageBoxSubaccountAccessSettingsUpdateOpts struct {
 // UpdateSubaccountAccessSettings updates the access settings of a Storage Box subaccount.
 func (c *StorageBoxClient) UpdateSubaccountAccessSettings(
 	ctx context.Context,
-	storageBox *StorageBox,
 	subaccount *StorageBoxSubaccount,
 	opts StorageBoxSubaccountAccessSettingsUpdateOpts,
 ) (*Action, *Response, error) {
 	const opPath = "/storage_boxes/%d/subaccounts/%d/actions/update_access_settings"
 	ctx = ctxutil.SetOpPath(ctx, opPath)
 
-	reqPath := fmt.Sprintf(opPath, storageBox.ID, subaccount.ID)
+	reqPath := fmt.Sprintf(opPath, subaccount.StorageBox.ID, subaccount.ID)
 	reqBody := SchemaFromStorageBoxSubaccountUpdateAccessSettingsOpts(opts)
 
 	respBody, resp, err := postRequest[schema.ActionGetResponse](ctx, c.client, reqPath, reqBody)

--- a/hcloud/storage_box_subaccount_test.go
+++ b/hcloud/storage_box_subaccount_test.go
@@ -305,8 +305,12 @@ func TestStorageBoxClientUpdateSubaccount(t *testing.T) {
 			},
 		})
 
-		storageBox := &StorageBox{ID: 42}
-		subaccount := &StorageBoxSubaccount{ID: 13}
+		subaccount := &StorageBoxSubaccount{
+			ID: 13,
+			StorageBox: &StorageBox{
+				ID: 42,
+			},
+		}
 
 		opts := StorageBoxSubaccountUpdateOpts{
 			Description: Ptr("Updated description"),
@@ -317,7 +321,7 @@ func TestStorageBoxClientUpdateSubaccount(t *testing.T) {
 			},
 		}
 
-		result, _, err := client.StorageBox.UpdateSubaccount(ctx, storageBox, subaccount, opts)
+		result, _, err := client.StorageBox.UpdateSubaccount(ctx, subaccount, opts)
 
 		require.NoError(t, err)
 
@@ -337,10 +341,14 @@ func TestStorageBoxClientDeleteSubaccount(t *testing.T) {
 			},
 		})
 
-		storageBox := &StorageBox{ID: 42}
-		subaccount := &StorageBoxSubaccount{ID: 13}
+		subaccount := &StorageBoxSubaccount{
+			ID: 13,
+			StorageBox: &StorageBox{
+				ID: 42,
+			},
+		}
 
-		action, resp, err := client.StorageBox.DeleteSubaccount(ctx, storageBox, subaccount)
+		action, resp, err := client.StorageBox.DeleteSubaccount(ctx, subaccount)
 		require.NoError(t, err)
 		require.NotNil(t, resp)
 		require.NotNil(t, action)
@@ -364,13 +372,17 @@ func TestStorageBoxClientResetSubaccountPassword(t *testing.T) {
 		},
 	})
 
-	storageBox := &StorageBox{ID: 42}
-	subaccount := &StorageBoxSubaccount{ID: 13}
+	subaccount := &StorageBoxSubaccount{
+		ID: 13,
+		StorageBox: &StorageBox{
+			ID: 42,
+		},
+	}
 
 	opts := StorageBoxSubaccountResetPasswordOpts{
 		Password: "foobar",
 	}
-	action, resp, err := client.StorageBox.ResetSubaccountPassword(ctx, storageBox, subaccount, opts)
+	action, resp, err := client.StorageBox.ResetSubaccountPassword(ctx, subaccount, opts)
 	require.NoError(t, err)
 	require.NotNil(t, resp)
 	require.NotNil(t, action)
@@ -402,8 +414,12 @@ func TestStorageBoxSubbacountUpdateAccessSettings(t *testing.T) {
 		},
 	})
 
-	storageBox := &StorageBox{ID: 42}
-	subaccount := &StorageBoxSubaccount{ID: 13}
+	subaccount := &StorageBoxSubaccount{
+		ID: 13,
+		StorageBox: &StorageBox{
+			ID: 42,
+		},
+	}
 
 	opts := StorageBoxSubaccountAccessSettingsUpdateOpts{
 		HomeDirectory:       Ptr("/foobar"),
@@ -413,7 +429,7 @@ func TestStorageBoxSubbacountUpdateAccessSettings(t *testing.T) {
 		Readonly:            Ptr(false),
 		ReachableExternally: Ptr(true),
 	}
-	action, resp, err := client.StorageBox.UpdateSubaccountAccessSettings(ctx, storageBox, subaccount, opts)
+	action, resp, err := client.StorageBox.UpdateSubaccountAccessSettings(ctx, subaccount, opts)
 	require.NoError(t, err)
 	require.NotNil(t, resp)
 	require.NotNil(t, action)

--- a/hcloud/zz_storage_box_client_iface.go
+++ b/hcloud/zz_storage_box_client_iface.go
@@ -63,9 +63,9 @@ type IStorageBoxClient interface {
 	// CreateSnapshot creates a new snapshot for the given Storage Box with the provided options.
 	CreateSnapshot(ctx context.Context, storageBox *StorageBox, opts StorageBoxSnapshotCreateOpts) (StorageBoxSnapshotCreateResult, *Response, error)
 	// UpdateSnapshot updates the given snapshot of a Storage Box with the provided options.
-	UpdateSnapshot(ctx context.Context, storageBox *StorageBox, snapshot *StorageBoxSnapshot, opts StorageBoxSnapshotUpdateOpts) (*StorageBoxSnapshot, *Response, error)
+	UpdateSnapshot(ctx context.Context, snapshot *StorageBoxSnapshot, opts StorageBoxSnapshotUpdateOpts) (*StorageBoxSnapshot, *Response, error)
 	// DeleteSnapshot deletes the given snapshot of a Storage Box.
-	DeleteSnapshot(ctx context.Context, storageBox *StorageBox, snapshot *StorageBoxSnapshot) (*Action, *Response, error)
+	DeleteSnapshot(ctx context.Context, snapshot *StorageBoxSnapshot) (*Action, *Response, error)
 	// GetSubaccountByID retrieves a Storage Box subaccount by its ID.
 	GetSubaccountByID(ctx context.Context, storageBox *StorageBox, id int64) (*StorageBoxSubaccount, *Response, error)
 	// ListSubaccounts lists all subaccounts of a Storage Box.
@@ -77,11 +77,11 @@ type IStorageBoxClient interface {
 	// CreateSubaccount creates a new subaccount for a Storage Box.
 	CreateSubaccount(ctx context.Context, storageBox *StorageBox, opts StorageBoxSubaccountCreateOpts) (StorageBoxSubaccountCreateResult, *Response, error)
 	// UpdateSubaccount updates a subaccount of a Storage Box.
-	UpdateSubaccount(ctx context.Context, storageBox *StorageBox, subaccount *StorageBoxSubaccount, opts StorageBoxSubaccountUpdateOpts) (*StorageBoxSubaccount, *Response, error)
+	UpdateSubaccount(ctx context.Context, subaccount *StorageBoxSubaccount, opts StorageBoxSubaccountUpdateOpts) (*StorageBoxSubaccount, *Response, error)
 	// DeleteSubaccount deletes a subaccount from a Storage Box.
-	DeleteSubaccount(ctx context.Context, storageBox *StorageBox, subaccount *StorageBoxSubaccount) (*Action, *Response, error)
+	DeleteSubaccount(ctx context.Context, subaccount *StorageBoxSubaccount) (*Action, *Response, error)
 	// ResetSubaccountPassword resets the password of a Storage Box subaccount.
-	ResetSubaccountPassword(ctx context.Context, storageBox *StorageBox, subaccount *StorageBoxSubaccount, opts StorageBoxSubaccountResetPasswordOpts) (*Action, *Response, error)
+	ResetSubaccountPassword(ctx context.Context, subaccount *StorageBoxSubaccount, opts StorageBoxSubaccountResetPasswordOpts) (*Action, *Response, error)
 	// UpdateSubaccountAccessSettings updates the access settings of a Storage Box subaccount.
-	UpdateSubaccountAccessSettings(ctx context.Context, storageBox *StorageBox, subaccount *StorageBoxSubaccount, opts StorageBoxSubaccountAccessSettingsUpdateOpts) (*Action, *Response, error)
+	UpdateSubaccountAccessSettings(ctx context.Context, subaccount *StorageBoxSubaccount, opts StorageBoxSubaccountAccessSettingsUpdateOpts) (*Action, *Response, error)
 }


### PR DESCRIPTION
`hcloud.StorageBox` is part of `hcloud.StorageBoxSubaccount` and `hcloud.StorageBoxSnapshot`. Therefore, we can remove the storage box reference from the function parameters.