### PR TITLE
feat: add new ip_range param to ServerAttachToNetwork

### DIFF
--- a/hcloud/schema/server.go
+++ b/hcloud/schema/server.go
@@ -362,6 +362,7 @@ type ServerActionAttachToNetworkRequest struct {
 	Network  int64     `json:"network"`
 	IP       *string   `json:"ip,omitempty"`
 	AliasIPs []*string `json:"alias_ips,omitempty"`
+	IPRange  *string   `json:"ip_range,omitempty"`
 }
 
 // ServerActionAttachToNetworkResponse defines the schema of the response when

--- a/hcloud/server.go
+++ b/hcloud/server.go
@@ -905,6 +905,7 @@ type ServerAttachToNetworkOpts struct {
 	Network  *Network
 	IP       net.IP
 	AliasIPs []net.IP
+	IPRange  *net.IPNet
 }
 
 // AttachToNetwork attaches a server to a network.
@@ -922,6 +923,10 @@ func (c *ServerClient) AttachToNetwork(ctx context.Context, server *Server, opts
 	}
 	for _, aliasIP := range opts.AliasIPs {
 		reqBody.AliasIPs = append(reqBody.AliasIPs, Ptr(aliasIP.String()))
+	}
+
+	if opts.IPRange != nil {
+		reqBody.IPRange = Ptr(opts.IPRange.String())
 	}
 
 	respBody, resp, err := postRequest[schema.ServerActionAttachToNetworkResponse](ctx, c.client, reqPath, reqBody)

--- a/hcloud/server_test.go
+++ b/hcloud/server_test.go
@@ -1998,6 +1998,9 @@ func TestServerClientAttachToNetwork(t *testing.T) {
 			if len(reqBody.AliasIPs) == 0 || *reqBody.AliasIPs[0] != "10.0.1.1" {
 				t.Errorf("unexpected AliasIPs: %v", *reqBody.IP)
 			}
+			if reqBody.IPRange != nil && *reqBody.IPRange != "10.0.1.0/24" {
+				t.Errorf("unexpected IPRange: %v", *reqBody.IPRange)
+			}
 			json.NewEncoder(w).Encode(schema.ServerActionAttachToNetworkResponse{
 				Action: schema.Action{
 					ID: 1,
@@ -2008,10 +2011,12 @@ func TestServerClientAttachToNetwork(t *testing.T) {
 		aliasIPs := []net.IP{
 			ip,
 		}
+		_, ipRange, _ := net.ParseCIDR("10.0.1.0/24")
 		opts := ServerAttachToNetworkOpts{
 			Network:  &Network{ID: 1},
 			IP:       ip,
 			AliasIPs: aliasIPs,
+			IPRange:  ipRange,
 		}
 		action, _, err := env.Client.Server.AttachToNetwork(ctx, server, opts)
 		if err != nil {


### PR DESCRIPTION
Adds the parameter `ip_range` to `ServerAttachToNetwork`.
Introduced by: https://docs.hetzner.cloud/changelog#2025-09-11-attach-to-network-support-ip-range


Required to change the following implementation:
https://github.com/kubernetes/autoscaler/pull/8334

@lukasmetzner  I'm only mentioning you because we already talked about this :)

Change for loadbalancers will follow soon...