### PR TITLE
feat: add new ip_range param to LoadBalancerAttachToNetwork

### DIFF
--- a/hcloud/load_balancer.go
+++ b/hcloud/load_balancer.go
@@ -765,6 +765,7 @@ func (c *LoadBalancerClient) ChangeAlgorithm(ctx context.Context, loadBalancer *
 type LoadBalancerAttachToNetworkOpts struct {
 	Network *Network
 	IP      net.IP
+	IPRange *net.IPNet
 }
 
 // AttachToNetwork attaches a Load Balancer to a network.
@@ -779,6 +780,9 @@ func (c *LoadBalancerClient) AttachToNetwork(ctx context.Context, loadBalancer *
 	}
 	if opts.IP != nil {
 		reqBody.IP = Ptr(opts.IP.String())
+	}
+	if opts.IPRange != nil {
+		reqBody.IPRange = Ptr(opts.IPRange.String())
 	}
 
 	respBody, resp, err := postRequest[schema.LoadBalancerActionAttachToNetworkResponse](ctx, c.client, reqPath, reqBody)

--- a/hcloud/load_balancer_test.go
+++ b/hcloud/load_balancer_test.go
@@ -713,6 +713,7 @@ func TestLoadBalancerClientAttachToNetwork(t *testing.T) {
 		expectedReqBody := schema.LoadBalancerActionAttachToNetworkRequest{
 			Network: 1,
 			IP:      Ptr("10.0.1.1"),
+			IPRange: Ptr("10.0.1.0/24"),
 		}
 		if !cmp.Equal(expectedReqBody, reqBody) {
 			t.Log(cmp.Diff(expectedReqBody, reqBody))
@@ -731,9 +732,11 @@ func TestLoadBalancerClientAttachToNetwork(t *testing.T) {
 		network      = &Network{ID: 1}
 	)
 
+	_, ipRange, _ := net.ParseCIDR("10.0.1.0/24")
 	opts := LoadBalancerAttachToNetworkOpts{
 		Network: network,
 		IP:      net.ParseIP("10.0.1.1"),
+		IPRange: ipRange,
 	}
 	action, _, err := env.Client.LoadBalancer.AttachToNetwork(ctx, loadBalancer, opts)
 	if err != nil {

--- a/hcloud/schema/load_balancer.go
+++ b/hcloud/schema/load_balancer.go
@@ -353,6 +353,7 @@ type LoadBalancerActionChangeAlgorithmResponse struct {
 type LoadBalancerActionAttachToNetworkRequest struct {
 	Network int64   `json:"network"`
 	IP      *string `json:"ip,omitempty"`
+	IPRange *string `json:"ip_range,omitempty"`
 }
 
 type LoadBalancerActionAttachToNetworkResponse struct {


### PR DESCRIPTION
This pr adds the “ip_range” parameter to “LoadBalancerAttachToNetwork”, quiet similar to the pr which implements this feature for "ServerAttachToNetwork" from tloesch. (https://github.com/hetznercloud/hcloud-go/pull/723)

Hetzner now implemented this feature in their API.
Introduced by: https://docs.hetzner.cloud/changelog#2025-09-11-attach-to-network-support-ip-range