### PR TITLE
feat: per locations server types

### DIFF
--- a/hcloud/exp/deprecationutil/server_type.go
+++ b/hcloud/exp/deprecationutil/server_type.go
@@ -1,0 +1,105 @@
+package deprecationutil
+
+import (
+	"fmt"
+	"slices"
+	"strings"
+	"time"
+
+	"github.com/hetznercloud/hcloud-go/v2/hcloud"
+	"github.com/hetznercloud/hcloud-go/v2/hcloud/exp/kit/sliceutil"
+)
+
+// ServerTypeWarning return a warning message when the given Server Type is
+// deprecated and whether the given Server Type is unavailable.
+//
+// Experimental: `exp` package is experimental, breaking changes may occur within minor releases.
+func ServerTypeWarning(serverType *hcloud.ServerType, locationName string) (string, bool) {
+	if serverType.IsDeprecated() {
+		if time.Now().After(serverType.UnavailableAfter()) {
+			return fmt.Sprintf(
+				"Server Type %q is unavailable in all locations and can no longer be ordered.",
+				serverType.Name,
+			), true
+		}
+		return fmt.Sprintf(
+			"Server Type %q is deprecated in all locations and will no longer be available for order as of %s.",
+			serverType.Name,
+			serverType.UnavailableAfter().Format(time.DateOnly),
+		), false
+	}
+
+	deprecated := make([]hcloud.ServerTypeLocation, 0, len(serverType.Locations))
+	unavailable := make([]hcloud.ServerTypeLocation, 0, len(serverType.Locations))
+
+	for _, o := range serverType.Locations {
+		if o.IsDeprecated() {
+			deprecated = append(deprecated, o)
+			if time.Now().After(o.UnavailableAfter()) {
+				unavailable = append(unavailable, o)
+			}
+		}
+	}
+
+	if len(deprecated) == 0 {
+		return "", false
+	}
+
+	// A location or a datacenter was provided
+	if locationName != "" {
+		locationIndex := slices.IndexFunc(deprecated, func(o hcloud.ServerTypeLocation) bool {
+			return o.Location.Name == locationName
+		})
+
+		// No deprecation for this location
+		if locationIndex < 0 {
+			return "", false
+		}
+
+		if time.Now().After(deprecated[locationIndex].UnavailableAfter()) {
+			return fmt.Sprintf(
+				"Server Type %q is unavailable in %q and can no longer be ordered.",
+				serverType.Name,
+				deprecated[locationIndex].Location.Name,
+			), true
+		}
+		return fmt.Sprintf(
+			"Server Type %q is deprecated in %q and will no longer be available for order as of %s.",
+			serverType.Name,
+			deprecated[locationIndex].Location.Name,
+			deprecated[locationIndex].UnavailableAfter().Format(time.DateOnly),
+		), false
+	}
+
+	// Only print a warning when all locations are deprecated
+	if len(serverType.Locations) != len(deprecated) {
+		return "", false
+	}
+
+	deprecatedNames := sliceutil.Transform(deprecated, func(e hcloud.ServerTypeLocation) string { return e.Location.Name })
+	unavailableNames := sliceutil.Transform(unavailable, func(e hcloud.ServerTypeLocation) string { return e.Location.Name })
+
+	if len(unavailable) > 0 {
+		if len(deprecated) == len(unavailable) {
+			// All are deprecated and all are unavailable
+			return fmt.Sprintf(
+				"Server Type %q is unavailable in all locations (%s) and can no longer be ordered.",
+				serverType.Name,
+				strings.Join(unavailableNames, ","),
+			), true
+		}
+		// All are deprecated and some are unavailable
+		return fmt.Sprintf(
+			"Server Type %q is deprecated in all locations (%s) and can no longer be ordered some locations (%s).",
+			serverType.Name,
+			strings.Join(deprecatedNames, ","),
+			strings.Join(unavailableNames, ","),
+		), false
+	}
+	// All are deprecated and none are unavailable
+	return fmt.Sprintf(
+		"Server Type %q is deprecated in all locations (%s) and will no longer be available for order.",
+		serverType.Name,
+		strings.Join(deprecatedNames, ","),
+	), false
+}

--- a/hcloud/exp/deprecationutil/server_type_test.go
+++ b/hcloud/exp/deprecationutil/server_type_test.go
@@ -1,0 +1,232 @@
+package deprecationutil
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/hetznercloud/hcloud-go/v2/hcloud"
+)
+
+func TestServerTypeWarning(t *testing.T) {
+	day := 24 * time.Hour
+
+	past := time.Now().Add(-14 * day).UTC()
+	future := time.Now().Add(14 * day).UTC()
+
+	Deprecated := hcloud.DeprecatableResource{Deprecation: &hcloud.DeprecationInfo{
+		Announced:        past,
+		UnavailableAfter: future,
+	}}
+	Unavailable := hcloud.DeprecatableResource{Deprecation: &hcloud.DeprecationInfo{
+		Announced:        past,
+		UnavailableAfter: past,
+	}}
+
+	t.Run("not deprecated", func(t *testing.T) {
+		o := &hcloud.ServerType{Name: "cx22"}
+
+		warn, warnIsError := ServerTypeWarning(o, "")
+		assert.Equal(t, "", warn)
+		assert.False(t, warnIsError)
+	})
+
+	t.Run("deprecated backward compatible", func(t *testing.T) {
+		o := &hcloud.ServerType{
+			Name:                 "cx22",
+			DeprecatableResource: Deprecated,
+		}
+
+		warn, warnIsError := ServerTypeWarning(o, "")
+		assert.Equal(t, fmt.Sprintf(`Server Type "cx22" is deprecated in all locations and will no longer be available for order as of %s.`, future.Format(time.DateOnly)), warn)
+		assert.False(t, warnIsError)
+	})
+
+	t.Run("unavailable backward compatible", func(t *testing.T) {
+		o := &hcloud.ServerType{
+			Name:                 "cx22",
+			DeprecatableResource: Unavailable,
+		}
+
+		warn, warnIsError := ServerTypeWarning(o, "")
+		assert.Equal(t, `Server Type "cx22" is unavailable in all locations and can no longer be ordered.`, warn)
+		assert.True(t, warnIsError)
+	})
+
+	t.Run("not deprecated in any locations with given location", func(t *testing.T) {
+		o := &hcloud.ServerType{
+			Name: "cx22",
+			Locations: []hcloud.ServerTypeLocation{
+				{
+					Location: &hcloud.Location{Name: "fsn1"},
+				},
+				{
+					Location: &hcloud.Location{Name: "nbg1"},
+				},
+			},
+		}
+
+		warn, warnIsError := ServerTypeWarning(o, "fsn1")
+		assert.Equal(t, ``, warn)
+		assert.False(t, warnIsError)
+	})
+
+	t.Run("deprecated in some locations with given location", func(t *testing.T) {
+		o := &hcloud.ServerType{
+			Name: "cx22",
+			Locations: []hcloud.ServerTypeLocation{
+				{
+					Location:             &hcloud.Location{Name: "fsn1"},
+					DeprecatableResource: Deprecated,
+				},
+				{
+					Location: &hcloud.Location{Name: "nbg1"},
+				},
+			},
+		}
+
+		warn, warnIsError := ServerTypeWarning(o, "fsn1")
+		assert.Equal(t, fmt.Sprintf(`Server Type "cx22" is deprecated in "fsn1" and will no longer be available for order as of %s.`, future.Format(time.DateOnly)), warn)
+		assert.False(t, warnIsError)
+	})
+
+	t.Run("unavailable in some locations with given location", func(t *testing.T) {
+		o := &hcloud.ServerType{
+			Name: "cx22",
+			Locations: []hcloud.ServerTypeLocation{
+				{
+					Location:             &hcloud.Location{Name: "fsn1"},
+					DeprecatableResource: Unavailable,
+				},
+				{
+					Location: &hcloud.Location{Name: "nbg1"},
+				},
+			},
+		}
+
+		warn, warnIsError := ServerTypeWarning(o, "fsn1")
+		assert.Equal(t, `Server Type "cx22" is unavailable in "fsn1" and can no longer be ordered.`, warn)
+		assert.True(t, warnIsError)
+	})
+
+	t.Run("deprecated in all locations with given location", func(t *testing.T) {
+		o := &hcloud.ServerType{
+			Name: "cx22",
+			Locations: []hcloud.ServerTypeLocation{
+				{
+					Location:             &hcloud.Location{Name: "fsn1"},
+					DeprecatableResource: Deprecated,
+				},
+				{
+					Location:             &hcloud.Location{Name: "nbg1"},
+					DeprecatableResource: Deprecated,
+				},
+			},
+		}
+
+		warn, warnIsError := ServerTypeWarning(o, "fsn1")
+		assert.Equal(t, fmt.Sprintf(`Server Type "cx22" is deprecated in "fsn1" and will no longer be available for order as of %s.`, future.Format(time.DateOnly)), warn)
+		assert.False(t, warnIsError)
+	})
+
+	t.Run("deprecated in all locations with given unknown location", func(t *testing.T) {
+		o := &hcloud.ServerType{
+			Name: "cx22",
+			Locations: []hcloud.ServerTypeLocation{
+				{
+					Location:             &hcloud.Location{Name: "fsn1"},
+					DeprecatableResource: Deprecated,
+				},
+				{
+					Location:             &hcloud.Location{Name: "nbg1"},
+					DeprecatableResource: Deprecated,
+				},
+			},
+		}
+
+		warn, warnIsError := ServerTypeWarning(o, "hel1")
+		assert.Equal(t, "", warn)
+		assert.False(t, warnIsError)
+	})
+
+	t.Run("deprecated in some locations", func(t *testing.T) {
+		o := &hcloud.ServerType{
+			Name: "cx22",
+			Locations: []hcloud.ServerTypeLocation{
+				{
+					Location:             &hcloud.Location{Name: "fsn1"},
+					DeprecatableResource: Deprecated,
+				},
+				{
+					Location: &hcloud.Location{Name: "nbg1"},
+				},
+			},
+		}
+
+		warn, warnIsError := ServerTypeWarning(o, "")
+		assert.Equal(t, "", warn)
+		assert.False(t, warnIsError)
+	})
+
+	t.Run("deprecated in all locations", func(t *testing.T) {
+		o := &hcloud.ServerType{
+			Name: "cx22",
+			Locations: []hcloud.ServerTypeLocation{
+				{
+					Location:             &hcloud.Location{Name: "fsn1"},
+					DeprecatableResource: Deprecated,
+				},
+				{
+					Location:             &hcloud.Location{Name: "nbg1"},
+					DeprecatableResource: Deprecated,
+				},
+			},
+		}
+
+		warn, warnIsError := ServerTypeWarning(o, "")
+		assert.Equal(t, `Server Type "cx22" is deprecated in all locations (fsn1,nbg1) and will no longer be available for order.`, warn)
+		assert.False(t, warnIsError)
+	})
+
+	t.Run("deprecated in all locations and unavailable in some locations", func(t *testing.T) {
+		o := &hcloud.ServerType{
+			Name: "cx22",
+			Locations: []hcloud.ServerTypeLocation{
+				{
+					Location:             &hcloud.Location{Name: "fsn1"},
+					DeprecatableResource: Deprecated,
+				},
+				{
+					Location:             &hcloud.Location{Name: "nbg1"},
+					DeprecatableResource: Unavailable,
+				},
+			},
+		}
+
+		warn, warnIsError := ServerTypeWarning(o, "")
+		assert.Equal(t, `Server Type "cx22" is deprecated in all locations (fsn1,nbg1) and can no longer be ordered some locations (nbg1).`, warn)
+		assert.False(t, warnIsError)
+	})
+
+	t.Run("unavailable in all locations", func(t *testing.T) {
+		o := &hcloud.ServerType{
+			Name: "cx22",
+			Locations: []hcloud.ServerTypeLocation{
+				{
+					Location:             &hcloud.Location{Name: "fsn1"},
+					DeprecatableResource: Unavailable,
+				},
+				{
+					Location:             &hcloud.Location{Name: "nbg1"},
+					DeprecatableResource: Unavailable,
+				},
+			},
+		}
+
+		warn, warnIsError := ServerTypeWarning(o, "")
+		assert.Equal(t, `Server Type "cx22" is unavailable in all locations (fsn1,nbg1) and can no longer be ordered.`, warn)
+		assert.True(t, warnIsError)
+	})
+}

--- a/hcloud/schema/server_type.go
+++ b/hcloud/schema/server_type.go
@@ -17,7 +17,20 @@ type ServerType struct {
 	// Use [ServerType.Prices] instead to get the included traffic for each location.
 	IncludedTraffic int64                    `json:"included_traffic"`
 	Prices          []PricingServerTypePrice `json:"prices"`
-	Deprecated      bool                     `json:"deprecated"`
+
+	// Deprecated: [ServerType.Deprecated] is deprecated and will gradually be phased out starting 2025-09-24.
+	// To learn about deprecations affecting individual locations you can use [ServerType.Locations] instead.
+	Deprecated bool `json:"deprecated"`
+	// Deprecated: [ServerType.DeprecatableResource] is deprecated and will gradually be phased out starting 2025-09-24.
+	// To learn about deprecations affecting individual locations you can use [ServerType.Locations] instead.
+	DeprecatableResource
+
+	Locations []ServerTypeLocation `json:"locations"`
+}
+
+type ServerTypeLocation struct {
+	ID   int64  `json:"id"`
+	Name string `json:"name"`
 	DeprecatableResource
 }
 

--- a/hcloud/schema_gen.go
+++ b/hcloud/schema_gen.go
@@ -79,6 +79,7 @@ You can find a documentation of goverter here: https://goverter.jmattheis.de/
 // goverter:extend stringMapToStringMapPtr
 // goverter:extend int64SlicePtrFromCertificatePtrSlice
 // goverter:extend stringSlicePtrFromStringSlice
+// goverter:extend locationFromServerTypeLocationSchema
 type converter interface {
 
 	// goverter:map Error.Code ErrorCode
@@ -162,9 +163,16 @@ type converter interface {
 	// goverter:map Prices Pricings
 	ServerTypeFromSchema(schema.ServerType) *ServerType
 
+	// goverter:map . Location
+	serverTypeLocationFromSchema(schema.ServerTypeLocation) ServerTypeLocation
+
 	// goverter:map Pricings Prices
 	// goverter:map DeprecatableResource.Deprecation Deprecated | isDeprecationNotNil
 	SchemaFromServerType(*ServerType) schema.ServerType
+
+	// goverter:map Location.ID ID
+	// goverter:map Location.Name Name
+	schemaFromServerTypeLocation(location ServerTypeLocation) schema.ServerTypeLocation
 
 	ImageFromSchema(schema.Image) *Image
 
@@ -981,4 +989,11 @@ func stringSlicePtrFromStringSlice(s []string) *[]string {
 		return nil
 	}
 	return &s
+}
+
+func locationFromServerTypeLocationSchema(serverTypeLocation schema.ServerTypeLocation) *Location {
+	return &Location{
+		ID:   serverTypeLocation.ID,
+		Name: serverTypeLocation.Name,
+	}
 }

--- a/hcloud/schema_test.go
+++ b/hcloud/schema_test.go
@@ -621,6 +621,16 @@ func TestServerTypeSchema(t *testing.T) {
 					"gross": "1.19"
 				}
 			}
+		],
+		"locations": [
+			{
+				"id": 1,
+				"name": "fsn1",
+				"deprecation": {
+					"announced": "2025-01-01T00:00:00Z",
+					"unavailable_after": "2025-04-01T00:00:00Z"
+				}
+			}
 		]
 	}`)
 

--- a/hcloud/server_type.go
+++ b/hcloud/server_type.go
@@ -27,7 +27,12 @@ type ServerType struct {
 	// Use [ServerType.Pricings] instead to get the included traffic for each location.
 	IncludedTraffic int64
 	Pricings        []ServerTypeLocationPricing
+
+	// Deprecated: [ServerType.DeprecatableResource] is deprecated and will gradually be phased out starting 2025-09-24.
+	// To learn about deprecations affecting individual locations you can use [ServerType.Locations] instead.
 	DeprecatableResource
+
+	Locations []ServerTypeLocation
 }
 
 // StorageType specifies the type of storage.
@@ -51,6 +56,11 @@ const (
 	// CPUTypeDedicated is the type for dedicated CPU.
 	CPUTypeDedicated CPUType = "dedicated"
 )
+
+type ServerTypeLocation struct {
+	Location *Location
+	DeprecatableResource
+}
 
 // ServerTypeClient is a client for the server types API.
 type ServerTypeClient struct {

--- a/hcloud/zz_schema.go
+++ b/hcloud/zz_schema.go
@@ -1120,6 +1120,12 @@ func (c *converterImpl) SchemaFromServerType(source *ServerType) schema.ServerTy
 		}
 		schemaServerType.Deprecated = isDeprecationNotNil((*source).DeprecatableResource.Deprecation)
 		schemaServerType.DeprecatableResource = c.hcloudDeprecatableResourceToSchemaDeprecatableResource((*source).DeprecatableResource)
+		if (*source).Locations != nil {
+			schemaServerType.Locations = make([]schema.ServerTypeLocation, len((*source).Locations))
+			for j := 0; j < len((*source).Locations); j++ {
+				schemaServerType.Locations[j] = c.schemaFromServerTypeLocation((*source).Locations[j])
+			}
+		}
 	}
 	return schemaServerType
 }
@@ -1278,6 +1284,12 @@ func (c *converterImpl) ServerTypeFromSchema(source schema.ServerType) *ServerTy
 		}
 	}
 	hcloudServerType.DeprecatableResource = c.schemaDeprecatableResourceToHcloudDeprecatableResource(source.DeprecatableResource)
+	if source.Locations != nil {
+		hcloudServerType.Locations = make([]ServerTypeLocation, len(source.Locations))
+		for j := 0; j < len(source.Locations); j++ {
+			hcloudServerType.Locations[j] = c.serverTypeLocationFromSchema(source.Locations[j])
+		}
+	}
 	return &hcloudServerType
 }
 func (c *converterImpl) VolumeFromSchema(source schema.Volume) *Volume {
@@ -2199,6 +2211,25 @@ func (c *converterImpl) schemaFromPrimaryIPTypePricing(source PrimaryIPTypePrici
 	schemaPricingPrimaryIPTypePrice.PriceMonthly = c.hcloudPrimaryIPPriceToSchemaPrice(source.Monthly)
 	return schemaPricingPrimaryIPTypePrice
 }
+func (c *converterImpl) schemaFromServerTypeLocation(source ServerTypeLocation) schema.ServerTypeLocation {
+	var schemaServerTypeLocation schema.ServerTypeLocation
+	var pInt64 *int64
+	if source.Location != nil {
+		pInt64 = &source.Location.ID
+	}
+	if pInt64 != nil {
+		schemaServerTypeLocation.ID = *pInt64
+	}
+	var pString *string
+	if source.Location != nil {
+		pString = &source.Location.Name
+	}
+	if pString != nil {
+		schemaServerTypeLocation.Name = *pString
+	}
+	schemaServerTypeLocation.DeprecatableResource = c.hcloudDeprecatableResourceToSchemaDeprecatableResource(source.DeprecatableResource)
+	return schemaServerTypeLocation
+}
 func (c *converterImpl) schemaFromServerTypeLocationPricing(source ServerTypeLocationPricing) schema.PricingServerTypePrice {
 	var schemaPricingServerTypePrice schema.PricingServerTypePrice
 	schemaPricingServerTypePrice.Location = c.pHcloudLocationToString(source.Location)
@@ -2308,6 +2339,12 @@ func (c *converterImpl) schemaVolumeProtectionToHcloudVolumeProtection(source sc
 	var hcloudVolumeProtection VolumeProtection
 	hcloudVolumeProtection.Delete = source.Delete
 	return hcloudVolumeProtection
+}
+func (c *converterImpl) serverTypeLocationFromSchema(source schema.ServerTypeLocation) ServerTypeLocation {
+	var hcloudServerTypeLocation ServerTypeLocation
+	hcloudServerTypeLocation.Location = locationFromServerTypeLocationSchema(source)
+	hcloudServerTypeLocation.DeprecatableResource = c.schemaDeprecatableResourceToHcloudDeprecatableResource(source.DeprecatableResource)
+	return hcloudServerTypeLocation
 }
 func (c *converterImpl) serverTypePricingFromSchema(source schema.PricingServerTypePrice) ServerTypeLocationPricing {
 	var hcloudServerTypeLocationPricing ServerTypeLocationPricing


### PR DESCRIPTION
[Server Types](https://docs.hetzner.cloud/reference/cloud#server-types) now depend on [Locations](https://docs.hetzner.cloud/reference/cloud#locations).

- We added a new `locations` property to the [Server Types](https://docs.hetzner.cloud/reference/cloud#server-types) resource. The new property defines a list of supported [Locations](https://docs.hetzner.cloud/reference/cloud#locations) and additional per [Locations](https://docs.hetzner.cloud/reference/cloud#locations) details such as deprecations information.

- We deprecated the `deprecation` property from the [Server Types](https://docs.hetzner.cloud/reference/cloud#server-types) resource. The property will gradually be phased out as per [Locations](https://docs.hetzner.cloud/reference/cloud#locations) deprecations are being announced. Please use the new per [Locations](https://docs.hetzner.cloud/reference/cloud#locations) deprecation information instead.

See our [changelog](https://docs.hetzner.cloud/changelog#2025-09-24-per-location-server-types) for more details.

#### Upgrading

```go
// Before
func ValidateServerType(serverType *hcloud.ServerType) error {
	if serverType.IsDeprecated() {
		return fmt.Errorf("server type %s is deprecated", serverType.Name)
	}
	return nil
}
```

```go
// After
func ValidateServerType(serverType *hcloud.ServerType, location *hcloud.Location) error {
	serverTypeLocationIndex := slices.IndexFunc(serverType.Locations, func(e hcloud.ServerTypeLocation) bool {
		return e.Location.Name == location.Name
	})
	if serverTypeLocationIndex < 0 {
		return fmt.Errorf("server type %s is not supported in location %q", serverType.Name, location.Name)
	}

	if serverType.Locations[serverTypeLocationIndex].IsDeprecated() {
		return fmt.Errorf("server type %q is deprecated in location %q", serverType.Name, location.Name)
	}

	return nil
}
```