### PR TITLE
feat(exp): add `sliceutil.Transform` function

### DIFF
--- a/hcloud/exp/kit/sliceutil/sliceutil.go
+++ b/hcloud/exp/kit/sliceutil/sliceutil.go
@@ -1,0 +1,12 @@
+package sliceutil
+
+// Transform each element of the given slice and returns a new slice with the result.
+//
+// Experimental: `exp` package is experimental, breaking changes may occur within minor releases.
+func Transform[Slice ~[]E, E any, R any](s Slice, fn func(e E) R) []R {
+	result := make([]R, 0, len(s))
+	for _, e := range s {
+		result = append(result, fn(e))
+	}
+	return result
+}

--- a/hcloud/exp/kit/sliceutil/sliceutil_test.go
+++ b/hcloud/exp/kit/sliceutil/sliceutil_test.go
@@ -1,0 +1,18 @@
+package sliceutil
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestTransform(t *testing.T) {
+	require.Equal(t,
+		[]string{"1", "2"},
+		Transform(
+			[]int{1, 2},
+			func(e int) string { return fmt.Sprint(e) },
+		),
+	)
+}


### PR DESCRIPTION
Helpers function to transform the items of a slice into another value and/or type.