### PR TITLE
fix(exp): remove dots from deprecation messages

### DIFF
--- a/hcloud/exp/deprecationutil/image.go
+++ b/hcloud/exp/deprecationutil/image.go
@@ -18,12 +18,12 @@ func ImageMessage(image *hcloud.Image) (string, bool) {
 
 		if time.Now().After(unavailableAfter) {
 			return fmt.Sprintf(
-				"Image %q is unavailable and can no longer be ordered.",
+				"Image %q is unavailable and can no longer be ordered",
 				image.Name,
 			), true
 		}
 		return fmt.Sprintf(
-			"Image %q is deprecated and will no longer be available for order as of %s.",
+			"Image %q is deprecated and will no longer be available for order as of %s",
 			image.Name,
 			unavailableAfter.Format(time.DateOnly),
 		), false

--- a/hcloud/exp/deprecationutil/image_test.go
+++ b/hcloud/exp/deprecationutil/image_test.go
@@ -25,7 +25,7 @@ func TestImageMessage(t *testing.T) {
 		o := &hcloud.Image{Name: "debian-13", Deprecated: deprecated}
 
 		message, isUnavailable := ImageMessage(o)
-		assert.Equal(t, fmt.Sprintf(`Image "debian-13" is deprecated and will no longer be available for order as of %s.`, deprecated.AddDate(0, 3, 0).Format(time.DateOnly)), message)
+		assert.Equal(t, fmt.Sprintf(`Image "debian-13" is deprecated and will no longer be available for order as of %s`, deprecated.AddDate(0, 3, 0).Format(time.DateOnly)), message)
 		assert.False(t, isUnavailable)
 	})
 
@@ -35,7 +35,7 @@ func TestImageMessage(t *testing.T) {
 		o := &hcloud.Image{Name: "debian-13", Deprecated: deprecated}
 
 		message, isUnavailable := ImageMessage(o)
-		assert.Equal(t, `Image "debian-13" is unavailable and can no longer be ordered.`, message)
+		assert.Equal(t, `Image "debian-13" is unavailable and can no longer be ordered`, message)
 		assert.True(t, isUnavailable)
 	})
 }

--- a/hcloud/exp/deprecationutil/server_type.go
+++ b/hcloud/exp/deprecationutil/server_type.go
@@ -18,12 +18,12 @@ func ServerTypeMessage(serverType *hcloud.ServerType, locationName string) (stri
 	if serverType.IsDeprecated() {
 		if time.Now().After(serverType.UnavailableAfter()) {
 			return fmt.Sprintf(
-				"Server Type %q is unavailable in all locations and can no longer be ordered.",
+				"Server Type %q is unavailable in all locations and can no longer be ordered",
 				serverType.Name,
 			), true
 		}
 		return fmt.Sprintf(
-			"Server Type %q is deprecated in all locations and will no longer be available for order as of %s.",
+			"Server Type %q is deprecated in all locations and will no longer be available for order as of %s",
 			serverType.Name,
 			serverType.UnavailableAfter().Format(time.DateOnly),
 		), false
@@ -58,13 +58,13 @@ func ServerTypeMessage(serverType *hcloud.ServerType, locationName string) (stri
 
 		if time.Now().After(deprecated[locationIndex].UnavailableAfter()) {
 			return fmt.Sprintf(
-				"Server Type %q is unavailable in %q and can no longer be ordered.",
+				"Server Type %q is unavailable in %q and can no longer be ordered",
 				serverType.Name,
 				deprecated[locationIndex].Location.Name,
 			), true
 		}
 		return fmt.Sprintf(
-			"Server Type %q is deprecated in %q and will no longer be available for order as of %s.",
+			"Server Type %q is deprecated in %q and will no longer be available for order as of %s",
 			serverType.Name,
 			deprecated[locationIndex].Location.Name,
 			deprecated[locationIndex].UnavailableAfter().Format(time.DateOnly),
@@ -83,14 +83,14 @@ func ServerTypeMessage(serverType *hcloud.ServerType, locationName string) (stri
 		if len(deprecated) == len(unavailable) {
 			// All are deprecated and all are unavailable
 			return fmt.Sprintf(
-				"Server Type %q is unavailable in all locations (%s) and can no longer be ordered.",
+				"Server Type %q is unavailable in all locations (%s) and can no longer be ordered",
 				serverType.Name,
 				strings.Join(unavailableNames, ","),
 			), true
 		}
 		// All are deprecated and some are unavailable
 		return fmt.Sprintf(
-			"Server Type %q is deprecated in all locations (%s) and can no longer be ordered some locations (%s).",
+			"Server Type %q is deprecated in all locations (%s) and can no longer be ordered some locations (%s)",
 			serverType.Name,
 			strings.Join(deprecatedNames, ","),
 			strings.Join(unavailableNames, ","),
@@ -98,7 +98,7 @@ func ServerTypeMessage(serverType *hcloud.ServerType, locationName string) (stri
 	}
 	// All are deprecated and none are unavailable
 	return fmt.Sprintf(
-		"Server Type %q is deprecated in all locations (%s) and will no longer be available for order.",
+		"Server Type %q is deprecated in all locations (%s) and will no longer be available for order",
 		serverType.Name,
 		strings.Join(deprecatedNames, ","),
 	), false

--- a/hcloud/exp/deprecationutil/server_type_test.go
+++ b/hcloud/exp/deprecationutil/server_type_test.go
@@ -38,7 +38,7 @@ func TestServerTypeMessage(t *testing.T) {
 		}
 
 		message, isUnavailable := ServerTypeMessage(o, "")
-		assert.Equal(t, fmt.Sprintf(`Server Type "cx22" is deprecated in all locations and will no longer be available for order as of %s.`, future.Format(time.DateOnly)), message)
+		assert.Equal(t, fmt.Sprintf(`Server Type "cx22" is deprecated in all locations and will no longer be available for order as of %s`, future.Format(time.DateOnly)), message)
 		assert.False(t, isUnavailable)
 	})
 
@@ -49,7 +49,7 @@ func TestServerTypeMessage(t *testing.T) {
 		}
 
 		message, isUnavailable := ServerTypeMessage(o, "")
-		assert.Equal(t, `Server Type "cx22" is unavailable in all locations and can no longer be ordered.`, message)
+		assert.Equal(t, `Server Type "cx22" is unavailable in all locations and can no longer be ordered`, message)
 		assert.True(t, isUnavailable)
 	})
 
@@ -86,7 +86,7 @@ func TestServerTypeMessage(t *testing.T) {
 		}
 
 		message, isUnavailable := ServerTypeMessage(o, "fsn1")
-		assert.Equal(t, fmt.Sprintf(`Server Type "cx22" is deprecated in "fsn1" and will no longer be available for order as of %s.`, future.Format(time.DateOnly)), message)
+		assert.Equal(t, fmt.Sprintf(`Server Type "cx22" is deprecated in "fsn1" and will no longer be available for order as of %s`, future.Format(time.DateOnly)), message)
 		assert.False(t, isUnavailable)
 	})
 
@@ -105,7 +105,7 @@ func TestServerTypeMessage(t *testing.T) {
 		}
 
 		deprecation, isUnavailable := ServerTypeMessage(o, "fsn1")
-		assert.Equal(t, `Server Type "cx22" is unavailable in "fsn1" and can no longer be ordered.`, deprecation)
+		assert.Equal(t, `Server Type "cx22" is unavailable in "fsn1" and can no longer be ordered`, deprecation)
 		assert.True(t, isUnavailable)
 	})
 
@@ -125,7 +125,7 @@ func TestServerTypeMessage(t *testing.T) {
 		}
 
 		message, isUnavailable := ServerTypeMessage(o, "fsn1")
-		assert.Equal(t, fmt.Sprintf(`Server Type "cx22" is deprecated in "fsn1" and will no longer be available for order as of %s.`, future.Format(time.DateOnly)), message)
+		assert.Equal(t, fmt.Sprintf(`Server Type "cx22" is deprecated in "fsn1" and will no longer be available for order as of %s`, future.Format(time.DateOnly)), message)
 		assert.False(t, isUnavailable)
 	})
 
@@ -184,7 +184,7 @@ func TestServerTypeMessage(t *testing.T) {
 		}
 
 		message, isUnavailable := ServerTypeMessage(o, "")
-		assert.Equal(t, `Server Type "cx22" is deprecated in all locations (fsn1,nbg1) and will no longer be available for order.`, message)
+		assert.Equal(t, `Server Type "cx22" is deprecated in all locations (fsn1,nbg1) and will no longer be available for order`, message)
 		assert.False(t, isUnavailable)
 	})
 
@@ -204,7 +204,7 @@ func TestServerTypeMessage(t *testing.T) {
 		}
 
 		message, isUnavailable := ServerTypeMessage(o, "")
-		assert.Equal(t, `Server Type "cx22" is deprecated in all locations (fsn1,nbg1) and can no longer be ordered some locations (nbg1).`, message)
+		assert.Equal(t, `Server Type "cx22" is deprecated in all locations (fsn1,nbg1) and can no longer be ordered some locations (nbg1)`, message)
 		assert.False(t, isUnavailable)
 	})
 
@@ -224,7 +224,7 @@ func TestServerTypeMessage(t *testing.T) {
 		}
 
 		message, isUnavailable := ServerTypeMessage(o, "")
-		assert.Equal(t, `Server Type "cx22" is unavailable in all locations (fsn1,nbg1) and can no longer be ordered.`, message)
+		assert.Equal(t, `Server Type "cx22" is unavailable in all locations (fsn1,nbg1) and can no longer be ordered`, message)
 		assert.True(t, isUnavailable)
 	})
 }


### PR DESCRIPTION
Makes it easier to embed in different messages format.

For example some structured logs message use a `:` between the messages and the attributes, having an extra dot in the middle is not pretty `.:` 