### PR TITLE
refactor(storage-box): simplify tests

### DIFF
--- a/hcloud/storage_box_snapshot_test.go
+++ b/hcloud/storage_box_snapshot_test.go
@@ -65,7 +65,7 @@ func TestStorageBoxClientGetSnapshot(t *testing.T) {
 				Method: "GET", Path: "/storage_boxes/42/snapshots?name=my-resource",
 				Status: 200,
 				JSONRaw: `{
-				"snapshots": [{ "id": 42, "name": "my-resource" }]
+				"snapshots": [{ "id": 42 }]
 			}`,
 			},
 		})
@@ -77,7 +77,6 @@ func TestStorageBoxClientGetSnapshot(t *testing.T) {
 		require.NotNil(t, storageBox)
 
 		assert.Equal(t, int64(42), storageBoxSnapshot.ID)
-		assert.Equal(t, "my-resource", storageBoxSnapshot.Name)
 	})
 
 	t.Run("GetSnapshot (ByIDOrName)", func(t *testing.T) {
@@ -88,7 +87,7 @@ func TestStorageBoxClientGetSnapshot(t *testing.T) {
 				Method: "GET", Path: "/storage_boxes/42/snapshots?name=my-resource",
 				Status: 200,
 				JSONRaw: `{
-				"snapshots": [{ "id": 42, "name": "my-resource" }]
+				"snapshots": [{ "id": 42 }]
 			}`,
 			},
 		})
@@ -100,7 +99,6 @@ func TestStorageBoxClientGetSnapshot(t *testing.T) {
 		require.NotNil(t, storageBox)
 
 		assert.Equal(t, int64(42), storageBoxSnapshot.ID)
-		assert.Equal(t, "my-resource", storageBoxSnapshot.Name)
 	})
 
 	t.Run("GetSnapshot (NotFound)", func(t *testing.T) {
@@ -139,14 +137,7 @@ func TestStorageBoxClientListSnapshot(t *testing.T) {
 				Method: "GET", Path: "/storage_boxes/42/snapshots?is_automatic=true&label_selector=environment%3Dprod&name=my-resource&sort=id%3Aasc",
 				Status: 200,
 				JSONRaw: `{
-					"snapshots": [{
-						"id": 42,
-						"name": "my-resource",
-						"is_automatic": true,
-						"labels": {
-							"environment": "prod"
-						}
-					}]
+					"snapshots": [{ "id": 42 }]
 				}`,
 			},
 		})
@@ -163,7 +154,6 @@ func TestStorageBoxClientListSnapshot(t *testing.T) {
 		require.Len(t, snapshots, 1)
 
 		assert.Equal(t, int64(42), snapshots[0].ID)
-		assert.Equal(t, "my-resource", snapshots[0].Name)
 	})
 
 	t.Run("AllSnapshots", func(t *testing.T) {
@@ -174,7 +164,7 @@ func TestStorageBoxClientListSnapshot(t *testing.T) {
 				Method: "GET", Path: "/storage_boxes/42/snapshots?",
 				Status: 200,
 				JSONRaw: `{
-					"snapshots": [{ "id": 42, "name": "my-resource" }]
+					"snapshots": [{ "id": 42 }]
 				}`,
 			},
 		})
@@ -186,7 +176,6 @@ func TestStorageBoxClientListSnapshot(t *testing.T) {
 		require.Len(t, snapshots, 1)
 
 		assert.Equal(t, int64(42), snapshots[0].ID)
-		assert.Equal(t, "my-resource", snapshots[0].Name)
 	})
 }
 
@@ -205,7 +194,7 @@ func TestStorageBoxClientCreateSnapshot(t *testing.T) {
 					assert.JSONEq(t, `{ "description": "Test Snapshot", "labels": { "environment": "prod" } }`, string(body))
 				},
 				JSONRaw: `{
-				"snapshot": { "id": 14, "name": "my-resource" },
+				"snapshot": { "id": 14 },
 				"action": { "id": 13 }
 			}`,
 			},
@@ -221,6 +210,9 @@ func TestStorageBoxClientCreateSnapshot(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, result.Action)
 		require.NotNil(t, result.Snapshot)
+
+		assert.Equal(t, int64(13), result.Action.ID)
+		assert.Equal(t, int64(14), result.Snapshot.ID)
 	})
 
 	t.Run("CreateSnapshot (Without Description)", func(t *testing.T) {
@@ -237,7 +229,7 @@ func TestStorageBoxClientCreateSnapshot(t *testing.T) {
 					assert.JSONEq(t, `{}`, string(body))
 				},
 				JSONRaw: `{
-				"snapshot": { "id": 14, "storage_box": 42 },
+				"snapshot": { "id": 14 },
 				"action": { "id": 13 }
 			}`,
 			},
@@ -250,6 +242,9 @@ func TestStorageBoxClientCreateSnapshot(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, result.Action)
 		require.NotNil(t, result.Snapshot)
+
+		assert.Equal(t, int64(13), result.Action.ID)
+		assert.Equal(t, int64(14), result.Snapshot.ID)
 	})
 }
 
@@ -269,7 +264,6 @@ func TestStorageBoxClientUpdateSnapshot(t *testing.T) {
 			JSONRaw: `{
 				"snapshot": {
 					"id": 42,
-					"name": "my-resource",
 					"labels": {
 						"environment": "prod"
 					}
@@ -294,6 +288,7 @@ func TestStorageBoxClientUpdateSnapshot(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, storageBoxSnapshot)
 
+	assert.Equal(t, int64(42), storageBoxSnapshot.ID)
 	assert.Equal(t, "prod", storageBoxSnapshot.Labels["environment"])
 }
 

--- a/hcloud/storage_box_subaccount_test.go
+++ b/hcloud/storage_box_subaccount_test.go
@@ -100,7 +100,7 @@ func TestStorageBoxClientGetSubaccount(t *testing.T) {
 				Method: "GET", Path: "/storage_boxes/42/subaccounts?username=my-user",
 				Status: 200,
 				JSONRaw: `{
-					"subaccounts": [{ "id": 13, "username": "my-user" }]
+					"subaccounts": [{ "id": 13 }]
 				}`,
 			},
 		})
@@ -123,24 +123,14 @@ func TestStorageBoxClientGetSubaccount(t *testing.T) {
 				Method: "GET", Path: "/storage_boxes/42/subaccounts/13",
 				Status: 200,
 				JSONRaw: `{
-					"subaccount": {
-						"id": 13,
-						"username": "foobar",
-						"storage_box": 42
-					}
+					"subaccount": { "id": 13 }
 				}`,
 			},
 			{
 				Method: "GET", Path: "/storage_boxes/42/subaccounts?username=my-user",
 				Status: 200,
 				JSONRaw: `{
-					"subaccounts": [
-						{
-							"id": 14,
-							"username": "my-user",
-							"storage_box": 42
-						}
-					]
+					"subaccounts": [{ "id": 14 }]
 				}`,
 			},
 		})
@@ -153,7 +143,6 @@ func TestStorageBoxClientGetSubaccount(t *testing.T) {
 		require.NotNil(t, subaccount)
 
 		assert.Equal(t, int64(13), subaccount.ID)
-		assert.Equal(t, int64(42), subaccount.StorageBox.ID)
 
 		subaccount, resp, err = client.StorageBox.GetSubaccount(ctx, storageBox, "my-user")
 		require.NoError(t, err)
@@ -161,7 +150,6 @@ func TestStorageBoxClientGetSubaccount(t *testing.T) {
 		require.NotNil(t, subaccount)
 
 		assert.Equal(t, int64(14), subaccount.ID)
-		assert.Equal(t, int64(42), subaccount.StorageBox.ID)
 
 	})
 }
@@ -175,8 +163,8 @@ func TestStorageBoxClientListSubaccounts(t *testing.T) {
 			Status: 200,
 			JSONRaw: `{
 					"subaccounts": [
-						{ "id": 42, "username": "my-user" },
-						{ "id": 43, "username": "my-user-2" }
+						{ "id": 42 },
+						{ "id": 43 }
 					]
 				}`,
 		},
@@ -192,9 +180,8 @@ func TestStorageBoxClientListSubaccounts(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, subaccounts, 2)
 
-	subaccount := subaccounts[0]
-	assert.Equal(t, int64(42), subaccount.ID)
-	assert.Equal(t, "my-user", subaccount.Username)
+	assert.Equal(t, int64(42), subaccounts[0].ID)
+	assert.Equal(t, int64(43), subaccounts[1].ID)
 }
 
 func TestStorageBoxClientAllSubaccountsWithOpts(t *testing.T) {
@@ -205,9 +192,7 @@ func TestStorageBoxClientAllSubaccountsWithOpts(t *testing.T) {
 			Method: "GET", Path: "/storage_boxes/42/subaccounts?label_selector=environment%3Dprod",
 			Status: 200,
 			JSONRaw: `{
-				"subaccounts": [
-					{ "id": 42, "username": "my-user" }
-				]
+				"subaccounts": [{ "id": 42 }]
 			}`,
 		},
 	})
@@ -223,7 +208,6 @@ func TestStorageBoxClientAllSubaccountsWithOpts(t *testing.T) {
 
 	subaccount := subaccounts[0]
 	assert.Equal(t, int64(42), subaccount.ID)
-	assert.Equal(t, "my-user", subaccount.Username)
 }
 
 func TestStorageBoxClientCreateSubaccount(t *testing.T) {
@@ -256,10 +240,7 @@ func TestStorageBoxClientCreateSubaccount(t *testing.T) {
 					assert.JSONEq(t, expectedBody, string(body))
 				},
 				JSONRaw: `{
-					"subaccount": {
-						"id": 42,
-						"storage_box": 42
-					},
+					"subaccount": { "id": 42 },
 					"action": { "id": 12345 }
 				}`,
 			},
@@ -290,7 +271,6 @@ func TestStorageBoxClientCreateSubaccount(t *testing.T) {
 		require.NotNil(t, subaccount)
 
 		assert.Equal(t, int64(42), subaccount.ID)
-		assert.Equal(t, int64(42), subaccount.StorageBox.ID)
 	})
 }
 
@@ -317,27 +297,7 @@ func TestStorageBoxClientUpdateSubaccount(t *testing.T) {
 					assert.JSONEq(t, expectedBody, string(body))
 				},
 				JSONRaw: `{
-					"subaccount": {
-						"id": 13,
-						"username": "my-user",
-						"home_directory": "/home/my-user",
-						"server": "my-server",
-						"access_settings": {
-							"reachable_externally": true,
-							"readonly": false,
-							"samba_enabled": true,
-							"ssh_enabled": false,
-							"webdav_enabled": true
-						},
-						"description": "Updated description",
-						"labels": {
-							"environment": "prod",
-							"example.com/my": "label",
-							"just-a-key": ""
-						},
-						"created": "2025-08-21T00:00:00Z",
-						"storage_box": 42
-					}
+					"subaccount": { "id": 13 }
 				}`,
 			},
 		})
@@ -358,11 +318,11 @@ func TestStorageBoxClientUpdateSubaccount(t *testing.T) {
 			},
 		}
 
-		result, _, err := client.StorageBox.UpdateSubaccount(ctx, subaccount, opts)
-
+		subaccount, _, err := client.StorageBox.UpdateSubaccount(ctx, subaccount, opts)
 		require.NoError(t, err)
+		require.NotNil(t, subaccount)
 
-		assert.Equal(t, int64(13), result.ID)
+		assert.Equal(t, int64(13), subaccount.ID)
 	})
 }
 

--- a/hcloud/storage_box_test.go
+++ b/hcloud/storage_box_test.go
@@ -108,7 +108,7 @@ func TestStorageBoxClientGet(t *testing.T) {
 				Method: "GET", Path: "/storage_boxes?name=foobar",
 				Status: 200,
 				JSONRaw: `{
-					"storage_boxes": [{ "id": 1, "name": "foobar" }]
+					"storage_boxes": [{ "id": 1 }]
 				}`,
 			},
 		})
@@ -129,8 +129,8 @@ func TestStorageBoxClientList(t *testing.T) {
 			Status: 200,
 			JSONRaw: `{
 				"storage_boxes": [
-					{ "id": 1, "name": "storage-box-1" },
-					{ "id": 2, "name": "storage-box-2" }
+					{ "id": 1 },
+					{ "id": 2 }
 				]
 			}`,
 		},
@@ -142,8 +142,8 @@ func TestStorageBoxClientList(t *testing.T) {
 	storageBoxes, _, err := client.StorageBox.List(ctx, opts)
 	require.NoError(t, err)
 	assert.Len(t, storageBoxes, 2, "expected 2 storage boxes")
-	assert.Equal(t, "storage-box-1", storageBoxes[0].Name)
-	assert.Equal(t, "storage-box-2", storageBoxes[1].Name)
+	assert.Equal(t, int64(1), storageBoxes[0].ID)
+	assert.Equal(t, int64(2), storageBoxes[1].ID)
 }
 
 func TestStorageBoxClientAll(t *testing.T) {
@@ -155,8 +155,8 @@ func TestStorageBoxClientAll(t *testing.T) {
 			Status: 200,
 			JSONRaw: `{
 				"storage_boxes": [
-					{ "id": 1, "name": "storage-box-1" },
-					{ "id": 2, "name": "storage-box-2" }
+					{ "id": 1 },
+					{ "id": 2 }
 				],
 				"meta": {"pagination": {"page": 1, "last_page": 2, "per_page": 2, "next_page": 2, "previous_page": null, "total_entries": 3}}
 			}`,
@@ -166,7 +166,7 @@ func TestStorageBoxClientAll(t *testing.T) {
 			Status: 200,
 			JSONRaw: `{
 				"storage_boxes": [
-					{ "id": 3, "name": "storage-box-3" }
+					{ "id": 3 }
 				],
 				"meta": {"pagination": {"page": 2, "last_page": 2, "per_page": 2, "next_page": null, "previous_page": 1, "total_entries": 3}}
 			}`,
@@ -208,7 +208,7 @@ func TestStorageBoxClientCreate(t *testing.T) {
 			Status: 201,
 			JSONRaw: `{
 				"action": { "id": 1 },
-				"storage_box": { "id": 42, "name": "my-resource" }
+				"storage_box": { "id": 42 }
 			}`,
 		},
 	})
@@ -231,7 +231,10 @@ func TestStorageBoxClientCreate(t *testing.T) {
 	result, _, err := client.StorageBox.Create(ctx, opts)
 	require.NoError(t, err)
 	require.NotNil(t, result.Action, "no action returned")
+	require.NotNil(t, result.StorageBox, "no storage box returned")
+
 	assert.Equal(t, int64(1), result.Action.ID, "unexpected action ID")
+	assert.Equal(t, int64(42), result.StorageBox.ID, "unexpected storage box ID")
 }
 
 func TestStorageBoxClientUpdate(t *testing.T) {
@@ -250,7 +253,7 @@ func TestStorageBoxClientUpdate(t *testing.T) {
 			},
 			Status: 200,
 			JSONRaw: `{
-				"storage_box": { "id": 42, "name": "updated-storage-box" }
+				"storage_box": { "id": 42 }
 			}`,
 		},
 	})
@@ -265,7 +268,6 @@ func TestStorageBoxClientUpdate(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, updatedStorageBox, "no storage box returned")
 	assert.Equal(t, int64(42), updatedStorageBox.ID, "unexpected storage box ID")
-	assert.Equal(t, "updated-storage-box", updatedStorageBox.Name, "unexpected storage box name")
 }
 
 func TestStorageBoxClientDelete(t *testing.T) {
@@ -298,8 +300,8 @@ func TestStorageBoxClientFolders(t *testing.T) {
 				Method: "GET", Path: "/storage_boxes/42/folders",
 				Status: 200,
 				JSONRaw: `{
-				"folders": ["foo", "bar"]
-			}`,
+					"folders": ["foo", "bar"]
+				}`,
 			},
 		})
 


### PR DESCRIPTION
- remove redundant parsing of full storage box properties
- make tests more coherent between storage box and the subressources snapshot and subaccount