### PR TITLE
fix: invalid property in network add_subnet request body

### DIFF
--- a/hcloud/schema/network.go
+++ b/hcloud/schema/network.go
@@ -95,7 +95,6 @@ type NetworkActionAddSubnetRequest struct {
 	Type        string `json:"type"`
 	IPRange     string `json:"ip_range,omitempty"`
 	NetworkZone string `json:"network_zone"`
-	Gateway     string `json:"gateway"`
 	VSwitchID   int64  `json:"vswitch_id,omitempty"`
 }
 


### PR DESCRIPTION
Remove invalid gateway property in `add_subnet` action request body.

https://docs.hetzner.cloud/reference/cloud#network-actions-add-a-subnet-to-a-network