### PR TITLE
feat: add running actions ids to done context error

### DIFF
--- a/hcloud/action_waiter.go
+++ b/hcloud/action_waiter.go
@@ -43,7 +43,7 @@ func (c *ActionClient) WaitForFunc(ctx context.Context, handleUpdate func(update
 
 		select {
 		case <-ctx.Done():
-			return ctx.Err()
+			return fmt.Errorf("%w: remaining running actions: %v", ctx.Err(), slices.Collect(maps.Keys(running)))
 		case <-time.After(c.action.client.pollBackoffFunc(retries)):
 			retries++
 		}

--- a/hcloud/action_waiter_test.go
+++ b/hcloud/action_waiter_test.go
@@ -76,8 +76,10 @@ func TestWaitFor(t *testing.T) {
 
 					ctx, cancelFunc := context.WithCancel(context.Background())
 					cancelFunc()
+					<-ctx.Done()
 					err := env.Client.Action.WaitFor(ctx, actions...)
-					assert.Error(t, err)
+					assert.EqualError(t, err, "context canceled: remaining running actions: [1509772237]")
+					assert.ErrorIs(t, err, context.Canceled)
 				},
 			},
 			{

--- a/hcloud/client_test.go
+++ b/hcloud/client_test.go
@@ -61,11 +61,11 @@ func newTestEnvWithServer(server *httptest.Server, mux *http.ServeMux) testEnv {
 		WithEndpoint(server.URL),
 		WithToken("token"),
 		WithRetryOpts(RetryOpts{
-			BackoffFunc: ConstantBackoff(0),
+			BackoffFunc: ConstantBackoff(time.Millisecond),
 			MaxRetries:  5,
 		}),
 		WithPollOpts(PollOpts{
-			BackoffFunc: ConstantBackoff(0),
+			BackoffFunc: ConstantBackoff(time.Millisecond),
 		}),
 		// This makes sure that our instrumentation does not cause any panics/errors
 		WithInstrumentation(prometheus.DefaultRegisterer),


### PR DESCRIPTION
```
context canceled: remaining running actions [1509772237]
```