### PR TITLE
feat: Storage Box support no longer experimental

### DIFF
--- a/hcloud/storage_box.go
+++ b/hcloud/storage_box.go
@@ -83,8 +83,6 @@ const (
 // StorageBoxClient is a client for the Storage Box API.
 //
 // See https://docs.hetzner.cloud/reference/hetzner#storage-boxes
-//
-// Experimental: [StorageBoxClient] is experimental, breaking changes may occur within minor releases.
 type StorageBoxClient struct {
 	client *Client
 	Action *ResourceActionClient
@@ -93,8 +91,6 @@ type StorageBoxClient struct {
 // GetByID retrieves a [StorageBox] by its ID. If the [StorageBox] does not exist, nil is returned.
 //
 // See https://docs.hetzner.cloud/reference/hetzner#storage-boxes-get-a-storage-box
-//
-// Experimental: [StorageBoxClient] is experimental, breaking changes may occur within minor releases.
 func (c *StorageBoxClient) GetByID(ctx context.Context, id int64) (*StorageBox, *Response, error) {
 	const opPath = "/storage_boxes/%d"
 	ctx = ctxutil.SetOpPath(ctx, opPath)
@@ -115,8 +111,6 @@ func (c *StorageBoxClient) GetByID(ctx context.Context, id int64) (*StorageBox, 
 // GetByName retrieves a [StorageBox] by its name. If the [StorageBox] does not exist, nil is returned.
 //
 // See https://docs.hetzner.cloud/reference/hetzner#storage-boxes-list-storage-boxes
-//
-// Experimental: [StorageBoxClient] is experimental, breaking changes may occur within minor releases.
 func (c *StorageBoxClient) GetByName(ctx context.Context, name string) (*StorageBox, *Response, error) {
 	return firstByName(name, func() ([]*StorageBox, *Response, error) {
 		return c.List(ctx, StorageBoxListOpts{Name: name})
@@ -128,8 +122,6 @@ func (c *StorageBoxClient) GetByName(ctx context.Context, name string) (*Storage
 //
 // When fetching by ID, see https://docs.hetzner.cloud/reference/hetzner#storage-boxes-get-a-storage-box
 // When fetching by name, see https://docs.hetzner.cloud/reference/hetzner#storage-boxes-list-storage-boxes
-//
-// Experimental: [StorageBoxClient] is experimental, breaking changes may occur within minor releases.
 func (c *StorageBoxClient) Get(ctx context.Context, idOrName string) (*StorageBox, *Response, error) {
 	return getByIDOrName(ctx, c.GetByID, c.GetByName, idOrName)
 }
@@ -158,8 +150,6 @@ func (l StorageBoxListOpts) values() url.Values {
 // when their value corresponds to their zero value or when they are empty.
 //
 // See https://docs.hetzner.cloud/reference/hetzner#storage-boxes-list-storage-boxes
-//
-// Experimental: [StorageBoxClient] is experimental, breaking changes may occur within minor releases.
 func (c *StorageBoxClient) List(ctx context.Context, opts StorageBoxListOpts) ([]*StorageBox, *Response, error) {
 	const opPath = "/storage_boxes?%s"
 	ctx = ctxutil.SetOpPath(ctx, opPath)
@@ -177,8 +167,6 @@ func (c *StorageBoxClient) List(ctx context.Context, opts StorageBoxListOpts) ([
 // All returns all [StorageBox].
 //
 // See https://docs.hetzner.cloud/reference/hetzner#storage-boxes-list-storage-boxes
-//
-// Experimental: [StorageBoxClient] is experimental, breaking changes may occur within minor releases.
 func (c *StorageBoxClient) All(ctx context.Context) ([]*StorageBox, error) {
 	return c.AllWithOpts(ctx, StorageBoxListOpts{ListOpts: ListOpts{PerPage: 50}})
 }
@@ -186,8 +174,6 @@ func (c *StorageBoxClient) All(ctx context.Context) ([]*StorageBox, error) {
 // AllWithOpts returns all [StorageBox] with the given options.
 //
 // See https://docs.hetzner.cloud/reference/hetzner#storage-boxes-list-storage-boxes
-//
-// Experimental: [StorageBoxClient] is experimental, breaking changes may occur within minor releases.
 func (c *StorageBoxClient) AllWithOpts(ctx context.Context, opts StorageBoxListOpts) ([]*StorageBox, error) {
 	return iterPages(func(page int) ([]*StorageBox, *Response, error) {
 		opts.Page = page
@@ -239,8 +225,6 @@ type StorageBoxCreateResult struct {
 // is sent to the API. They are not addressable by ID or name.
 //
 // See https://docs.hetzner.cloud/reference/hetzner#storage-boxes-create-a-storage-box
-//
-// Experimental: [StorageBoxClient] is experimental, breaking changes may occur within minor releases.
 func (c *StorageBoxClient) Create(ctx context.Context, opts StorageBoxCreateOpts) (StorageBoxCreateResult, *Response, error) {
 	const opPath = "/storage_boxes"
 	ctx = ctxutil.SetOpPath(ctx, opPath)
@@ -273,8 +257,6 @@ type StorageBoxUpdateOpts struct {
 // Update updates a [StorageBox] with the given options.
 //
 // See https://docs.hetzner.cloud/reference/hetzner#storage-boxes-update-a-storage-box
-//
-// Experimental: [StorageBoxClient] is experimental, breaking changes may occur within minor releases.
 func (c *StorageBoxClient) Update(ctx context.Context, storageBox *StorageBox, opts StorageBoxUpdateOpts) (*StorageBox, *Response, error) {
 	const opPath = "/storage_boxes/%d"
 	ctx = ctxutil.SetOpPath(ctx, opPath)
@@ -298,8 +280,6 @@ type StorageBoxDeleteResult struct {
 // Delete deletes a [StorageBox].
 //
 // See https://docs.hetzner.cloud/reference/hetzner#storage-boxes-delete-a-storage-box
-//
-// Experimental: [StorageBoxClient] is experimental, breaking changes may occur within minor releases.
 func (c *StorageBoxClient) Delete(ctx context.Context, storageBox *StorageBox) (StorageBoxDeleteResult, *Response, error) {
 	const opPath = "/storage_boxes/%d"
 	ctx = ctxutil.SetOpPath(ctx, opPath)
@@ -337,8 +317,6 @@ func (o StorageBoxFoldersOpts) values() url.Values {
 // Folders lists folders in a [StorageBox].
 //
 // See https://docs.hetzner.cloud/reference/hetzner#storage-boxes-list-folders-of-a-storage-box
-//
-// Experimental: [StorageBoxClient] is experimental, breaking changes may occur within minor releases.
 func (c *StorageBoxClient) Folders(ctx context.Context, storageBox *StorageBox, opts StorageBoxFoldersOpts) (StorageBoxFoldersResult, *Response, error) {
 	const opPath = "/storage_boxes/%d/folders?%s"
 	ctx = ctxutil.SetOpPath(ctx, opPath)
@@ -365,8 +343,6 @@ type StorageBoxChangeProtectionOpts struct {
 // ChangeProtection changes the protection level of a [StorageBox].
 //
 // See https://docs.hetzner.cloud/reference/hetzner#storage-box-actions-change-protection
-//
-// Experimental: [StorageBoxClient] is experimental, breaking changes may occur within minor releases.
 func (c *StorageBoxClient) ChangeProtection(ctx context.Context, storageBox *StorageBox, opts StorageBoxChangeProtectionOpts) (*Action, *Response, error) {
 	const opPath = "/storage_boxes/%d/actions/change_protection"
 	ctx = ctxutil.SetOpPath(ctx, opPath)
@@ -390,8 +366,6 @@ type StorageBoxChangeTypeOpts struct {
 // ChangeType changes the type of a [StorageBox].
 //
 // See https://docs.hetzner.cloud/reference/hetzner#storage-box-actions-change-type
-//
-// Experimental: [StorageBoxClient] is experimental, breaking changes may occur within minor releases.
 func (c *StorageBoxClient) ChangeType(ctx context.Context, storageBox *StorageBox, opts StorageBoxChangeTypeOpts) (*Action, *Response, error) {
 	const opPath = "/storage_boxes/%d/actions/change_type"
 	ctx = ctxutil.SetOpPath(ctx, opPath)
@@ -415,8 +389,6 @@ type StorageBoxResetPasswordOpts struct {
 // ResetPassword resets the password of a [StorageBox].
 //
 // See https://docs.hetzner.cloud/reference/hetzner#storage-box-actions-reset-password
-//
-// Experimental: [StorageBoxClient] is experimental, breaking changes may occur within minor releases.
 func (c *StorageBoxClient) ResetPassword(ctx context.Context, storageBox *StorageBox, opts StorageBoxResetPasswordOpts) (*Action, *Response, error) {
 	const opPath = "/storage_boxes/%d/actions/reset_password"
 	ctx = ctxutil.SetOpPath(ctx, opPath)
@@ -444,8 +416,6 @@ type StorageBoxUpdateAccessSettingsOpts struct {
 // UpdateAccessSettings updates the [StorageBoxAccessSettings] of a [StorageBox].
 //
 // See https://docs.hetzner.cloud/reference/hetzner#storage-box-actions-update-access-settings
-//
-// Experimental: [StorageBoxClient] is experimental, breaking changes may occur within minor releases.
 func (c *StorageBoxClient) UpdateAccessSettings(ctx context.Context, storageBox *StorageBox, opts StorageBoxUpdateAccessSettingsOpts) (*Action, *Response, error) {
 	const opPath = "/storage_boxes/%d/actions/update_access_settings"
 	ctx = ctxutil.SetOpPath(ctx, opPath)
@@ -469,8 +439,6 @@ type StorageBoxRollbackSnapshotOpts struct {
 // RollbackSnapshot rolls back a [StorageBox] to a [StorageBoxSnapshot].
 //
 // See https://docs.hetzner.cloud/reference/hetzner#storage-box-actions-rollback-snapshot
-//
-// Experimental: [StorageBoxClient] is experimental, breaking changes may occur within minor releases.
 func (c *StorageBoxClient) RollbackSnapshot(
 	ctx context.Context,
 	storageBox *StorageBox,
@@ -509,8 +477,6 @@ type StorageBoxEnableSnapshotPlanOpts struct {
 // EnableSnapshotPlan enables a [StorageBoxSnapshotPlan] for a [StorageBox].
 //
 // See https://docs.hetzner.cloud/reference/hetzner#storage-box-actions-enable-snapshot-plan
-//
-// Experimental: [StorageBoxClient] is experimental, breaking changes may occur within minor releases.
 func (c *StorageBoxClient) EnableSnapshotPlan(
 	ctx context.Context,
 	storageBox *StorageBox,
@@ -533,8 +499,6 @@ func (c *StorageBoxClient) EnableSnapshotPlan(
 // DisableSnapshotPlan disables the [StorageBoxSnapshotPlan] for a [StorageBox].
 //
 // See https://docs.hetzner.cloud/reference/hetzner#storage-box-actions-disable-snapshot-plan
-//
-// Experimental: [StorageBoxClient] is experimental, breaking changes may occur within minor releases.
 func (c *StorageBoxClient) DisableSnapshotPlan(
 	ctx context.Context,
 	storageBox *StorageBox,

--- a/hcloud/storage_box_snapshot.go
+++ b/hcloud/storage_box_snapshot.go
@@ -33,8 +33,6 @@ type StorageBoxSnapshotStats struct {
 // GetSnapshotByID gets a [StorageBoxSnapshot] by its ID.
 //
 // See https://docs.hetzner.cloud/reference/hetzner#storage-box-snapshots-get-a-snapshot
-//
-// Experimental: [StorageBoxClient] is experimental, breaking changes may occur within minor releases.
 func (c *StorageBoxClient) GetSnapshotByID(ctx context.Context, storageBox *StorageBox, id int64) (*StorageBoxSnapshot, *Response, error) {
 	const optPath = "/storage_boxes/%d/snapshots/%d"
 	ctx = ctxutil.SetOpPath(ctx, optPath)
@@ -55,8 +53,6 @@ func (c *StorageBoxClient) GetSnapshotByID(ctx context.Context, storageBox *Stor
 // GetSnapshotByName gets a [StorageBoxSnapshot] by its name.
 //
 // See https://docs.hetzner.cloud/reference/hetzner#storage-box-snapshots-list-snapshots
-//
-// Experimental: [StorageBoxClient] is experimental, breaking changes may occur within minor releases.
 func (c *StorageBoxClient) GetSnapshotByName(
 	ctx context.Context,
 	storageBox *StorageBox,
@@ -72,8 +68,6 @@ func (c *StorageBoxClient) GetSnapshotByName(
 //
 // When fetching by ID, see https://docs.hetzner.cloud/reference/hetzner#storage-box-snapshots-get-a-snapshot
 // When fetching by name, see https://docs.hetzner.cloud/reference/hetzner#storage-box-snapshots-list-snapshots
-//
-// Experimental: [StorageBoxClient] is experimental, breaking changes may occur within minor releases.
 func (c *StorageBoxClient) GetSnapshot(
 	ctx context.Context,
 	storageBox *StorageBox,
@@ -121,8 +115,6 @@ func (o StorageBoxSnapshotListOpts) values() url.Values {
 // Pagination is not supported, so this will return all [StorageBoxSnapshot] at once.
 //
 // See https://docs.hetzner.cloud/reference/hetzner#storage-box-snapshots-list-snapshots
-//
-// Experimental: [StorageBoxClient] is experimental, breaking changes may occur within minor releases.
 func (c *StorageBoxClient) ListSnapshots(
 	ctx context.Context,
 	storageBox *StorageBox,
@@ -144,8 +136,6 @@ func (c *StorageBoxClient) ListSnapshots(
 // AllSnapshotsWithOpts lists all [StorageBoxSnapshot] of a [StorageBox] with the given options.
 //
 // See https://docs.hetzner.cloud/reference/hetzner#storage-box-snapshots-list-snapshots
-//
-// Experimental: [StorageBoxClient] is experimental, breaking changes may occur within minor releases.
 func (c *StorageBoxClient) AllSnapshotsWithOpts(
 	ctx context.Context,
 	storageBox *StorageBox,
@@ -158,8 +148,6 @@ func (c *StorageBoxClient) AllSnapshotsWithOpts(
 // AllSnapshots lists all [StorageBoxSnapshot] of a [StorageBox] without any options.
 //
 // See https://docs.hetzner.cloud/reference/hetzner#storage-box-snapshots-list-snapshots
-//
-// Experimental: [StorageBoxClient] is experimental, breaking changes may occur within minor releases.
 func (c *StorageBoxClient) AllSnapshots(
 	ctx context.Context,
 	storageBox *StorageBox,
@@ -184,8 +172,6 @@ type StorageBoxSnapshotCreateResult struct {
 // CreateSnapshot creates a new [StorageBoxSnapshot] for the given [StorageBox] with the provided options.
 //
 // See https://docs.hetzner.cloud/reference/hetzner#storage-box-snapshots-create-a-snapshot
-//
-// Experimental: [StorageBoxClient] is experimental, breaking changes may occur within minor releases.
 func (c *StorageBoxClient) CreateSnapshot(
 	ctx context.Context,
 	storageBox *StorageBox,
@@ -219,8 +205,6 @@ type StorageBoxSnapshotUpdateOpts struct {
 // UpdateSnapshot updates the given [StorageBoxSnapshot] of a [StorageBox] with the provided options.
 //
 // See https://docs.hetzner.cloud/reference/hetzner#storage-box-snapshots-update-a-snapshot
-//
-// Experimental: [StorageBoxClient] is experimental, breaking changes may occur within minor releases.
 func (c *StorageBoxClient) UpdateSnapshot(
 	ctx context.Context,
 	snapshot *StorageBoxSnapshot,
@@ -248,8 +232,6 @@ type StorageBoxSnapshotDeleteResult struct {
 // DeleteSnapshot deletes the given [StorageBoxSnapshot] of a [StorageBox].
 //
 // See https://docs.hetzner.cloud/reference/hetzner#storage-box-snapshots-delete-a-snapshot
-//
-// Experimental: [StorageBoxClient] is experimental, breaking changes may occur within minor releases.
 func (c *StorageBoxClient) DeleteSnapshot(
 	ctx context.Context,
 	snapshot *StorageBoxSnapshot,

--- a/hcloud/storage_box_subaccount.go
+++ b/hcloud/storage_box_subaccount.go
@@ -39,8 +39,6 @@ type StorageBoxSubaccountAccessSettings struct {
 //
 // When fetching by ID, see https://docs.hetzner.cloud/reference/hetzner#storage-box-subaccounts-get-a-subaccount
 // When fetching by name, see https://docs.hetzner.cloud/reference/hetzner#storage-box-subaccounts-list-subaccounts
-//
-// Experimental: [StorageBoxClient] is experimental, breaking changes may occur within minor releases.
 func (c *StorageBoxClient) GetSubaccount(
 	ctx context.Context,
 	storageBox *StorageBox,
@@ -61,8 +59,6 @@ func (c *StorageBoxClient) GetSubaccount(
 // GetSubaccountByID retrieves a [StorageBoxSubaccount] by its ID.
 //
 // See https://docs.hetzner.cloud/reference/hetzner#storage-box-subaccounts-get-a-subaccount
-//
-// Experimental: [StorageBoxClient] is experimental, breaking changes may occur within minor releases.
 func (c *StorageBoxClient) GetSubaccountByID(
 	ctx context.Context,
 	storageBox *StorageBox,
@@ -87,8 +83,6 @@ func (c *StorageBoxClient) GetSubaccountByID(
 // GetSubaccountByUsername retrieves a [StorageBoxSubaccount] by its username.
 //
 // See https://docs.hetzner.cloud/reference/hetzner#storage-box-subaccounts-list-subaccounts
-//
-// Experimental: [StorageBoxClient] is experimental, breaking changes may occur within minor releases.
 func (c *StorageBoxClient) GetSubaccountByUsername(
 	ctx context.Context,
 	storageBox *StorageBox,
@@ -125,8 +119,6 @@ func (o StorageBoxSubaccountListOpts) values() url.Values {
 // ListSubaccounts lists all [StorageBoxSubaccount] of a [StorageBox].
 //
 // See https://docs.hetzner.cloud/reference/hetzner#storage-box-subaccounts-list-subaccounts
-//
-// Experimental: [StorageBoxClient] is experimental, breaking changes may occur within minor releases.
 func (c *StorageBoxClient) ListSubaccounts(
 	ctx context.Context,
 	storageBox *StorageBox,
@@ -148,8 +140,6 @@ func (c *StorageBoxClient) ListSubaccounts(
 // AllSubaccountsWithOpts retrieves all [StorageBoxSubaccount] of a [StorageBox] with the given options.
 //
 // See https://docs.hetzner.cloud/reference/hetzner#storage-box-subaccounts-list-subaccounts
-//
-// Experimental: [StorageBoxClient] is experimental, breaking changes may occur within minor releases.
 func (c *StorageBoxClient) AllSubaccountsWithOpts(
 	ctx context.Context,
 	storageBox *StorageBox,
@@ -162,8 +152,6 @@ func (c *StorageBoxClient) AllSubaccountsWithOpts(
 // AllSubaccounts retrieves all [StorageBoxSubaccount] of a [StorageBox].
 //
 // See https://docs.hetzner.cloud/reference/hetzner#storage-box-subaccounts-list-subaccounts
-//
-// Experimental: [StorageBoxClient] is experimental, breaking changes may occur within minor releases.
 func (c *StorageBoxClient) AllSubaccounts(
 	ctx context.Context,
 	storageBox *StorageBox,
@@ -200,8 +188,6 @@ type StorageBoxSubaccountCreateResult struct {
 // CreateSubaccount creates a new [StorageBoxSubaccount] for a [StorageBox].
 //
 // See https://docs.hetzner.cloud/reference/hetzner#storage-box-subaccounts-create-a-subaccount
-//
-// Experimental: [StorageBoxClient] is experimental, breaking changes may occur within minor releases.
 func (c *StorageBoxClient) CreateSubaccount(
 	ctx context.Context,
 	storageBox *StorageBox,
@@ -235,8 +221,6 @@ type StorageBoxSubaccountUpdateOpts struct {
 // UpdateSubaccount updates a [StorageBoxSubaccount] of a [StorageBox].
 //
 // See https://docs.hetzner.cloud/reference/hetzner#storage-box-subaccounts-update-a-subaccount
-//
-// Experimental: [StorageBoxClient] is experimental, breaking changes may occur within minor releases.
 func (c *StorageBoxClient) UpdateSubaccount(
 	ctx context.Context,
 	subaccount *StorageBoxSubaccount,
@@ -264,8 +248,6 @@ type StorageBoxSubaccountDeleteResult struct {
 // DeleteSubaccount deletes a [StorageBoxSubaccount] from a [StorageBox].
 //
 // See https://docs.hetzner.cloud/reference/hetzner#storage-box-subaccounts-delete-a-subaccount
-//
-// Experimental: [StorageBoxClient] is experimental, breaking changes may occur within minor releases.
 func (c *StorageBoxClient) DeleteSubaccount(
 	ctx context.Context,
 	subaccount *StorageBoxSubaccount,
@@ -294,8 +276,6 @@ type StorageBoxSubaccountResetPasswordOpts struct {
 // ResetSubaccountPassword resets the password of a [StorageBoxSubaccount].
 //
 // See https://docs.hetzner.cloud/reference/hetzner#storage-box-subaccount-actions-reset-password
-//
-// Experimental: [StorageBoxClient] is experimental, breaking changes may occur within minor releases.
 func (c *StorageBoxClient) ResetSubaccountPassword(
 	ctx context.Context,
 	subaccount *StorageBoxSubaccount,
@@ -327,8 +307,6 @@ type StorageBoxSubaccountUpdateAccessSettingsOpts struct {
 // UpdateSubaccountAccessSettings updates the [StorageBoxSubaccountAccessSettings] of a [StorageBoxSubaccount].
 //
 // See https://docs.hetzner.cloud/reference/hetzner#storage-box-subaccount-actions-update-access-settings
-//
-// Experimental: [StorageBoxClient] is experimental, breaking changes may occur within minor releases.
 func (c *StorageBoxClient) UpdateSubaccountAccessSettings(
 	ctx context.Context,
 	subaccount *StorageBoxSubaccount,
@@ -353,11 +331,9 @@ type StorageBoxSubaccountChangeHomeDirectoryOpts struct {
 	HomeDirectory string
 }
 
-// UpdateSubaccountAccessSettings changes the home directory of a [StorageBoxSubaccount].
+// ChangeSubaccountHomeDirectory changes the home directory of a [StorageBoxSubaccount].
 //
 // See https://docs.hetzner.cloud/reference/hetzner#storage-box-subaccount-actions-change-home-directory
-//
-// Experimental: [StorageBoxClient] is experimental, breaking changes may occur within minor releases.
 func (c *StorageBoxClient) ChangeSubaccountHomeDirectory(
 	ctx context.Context,
 	subaccount *StorageBoxSubaccount,

--- a/hcloud/storage_box_type.go
+++ b/hcloud/storage_box_type.go
@@ -34,8 +34,6 @@ type StorageBoxTypeLocationPricing struct {
 // StorageBoxTypeClient provides access to Storage Box Types in the Hetzner API.
 //
 // See https://docs.hetzner.cloud/reference/hetzner#storage-box-types
-//
-// Experimental: [StorageBoxTypeClient] is experimental, breaking changes may occur within minor releases.
 type StorageBoxTypeClient struct {
 	client *Client
 }
@@ -57,8 +55,6 @@ func (l StorageBoxTypeListOpts) values() url.Values {
 // List returns a list of storage box types for a specific page.
 //
 // See https://docs.hetzner.cloud/reference/hetzner#storage-box-types-list-storage-box-types
-//
-// Experimental: [StorageBoxTypeClient] is experimental, breaking changes may occur within minor releases.
 func (c *StorageBoxTypeClient) List(ctx context.Context, opts StorageBoxTypeListOpts) ([]*StorageBoxType, *Response, error) {
 	const opPath = "/storage_box_types?%s"
 	ctx = ctxutil.SetOpPath(ctx, opPath)
@@ -76,8 +72,6 @@ func (c *StorageBoxTypeClient) List(ctx context.Context, opts StorageBoxTypeList
 // All returns all storage box types.
 //
 // See https://docs.hetzner.cloud/reference/hetzner#storage-box-types-list-storage-box-types
-//
-// Experimental: [StorageBoxTypeClient] is experimental, breaking changes may occur within minor releases.
 func (c *StorageBoxTypeClient) All(ctx context.Context) ([]*StorageBoxType, error) {
 	return c.AllWithOpts(ctx, StorageBoxTypeListOpts{ListOpts: ListOpts{PerPage: 50}})
 }
@@ -85,8 +79,6 @@ func (c *StorageBoxTypeClient) All(ctx context.Context) ([]*StorageBoxType, erro
 // AllWithOpts returns all storage box types for the given options.
 //
 // See https://docs.hetzner.cloud/reference/hetzner#storage-box-types-list-storage-box-types
-//
-// Experimental: [StorageBoxTypeClient] is experimental, breaking changes may occur within minor releases.
 func (c *StorageBoxTypeClient) AllWithOpts(ctx context.Context, opts StorageBoxTypeListOpts) ([]*StorageBoxType, error) {
 	return iterPages(func(page int) ([]*StorageBoxType, *Response, error) {
 		opts.Page = page
@@ -97,8 +89,6 @@ func (c *StorageBoxTypeClient) AllWithOpts(ctx context.Context, opts StorageBoxT
 // GetByID returns a specific Storage Box Type by ID.
 //
 // See https://docs.hetzner.cloud/reference/hetzner#storage-box-types-get-a-storage-box-type
-//
-// Experimental: [StorageBoxTypeClient] is experimental, breaking changes may occur within minor releases.
 func (c *StorageBoxTypeClient) GetByID(ctx context.Context, id int64) (*StorageBoxType, *Response, error) {
 	const opPath = "/storage_box_types/%d"
 	ctx = ctxutil.SetOpPath(ctx, opPath)
@@ -119,8 +109,6 @@ func (c *StorageBoxTypeClient) GetByID(ctx context.Context, id int64) (*StorageB
 // GetByName retrieves a Storage Box Type by its name. If the Storage Box Type does not exist, nil is returned.
 //
 // See https://docs.hetzner.cloud/reference/hetzner#storage-box-types-get-a-storage-box-type
-//
-// Experimental: [StorageBoxTypeClient] is experimental, breaking changes may occur within minor releases.
 func (c *StorageBoxTypeClient) GetByName(ctx context.Context, name string) (*StorageBoxType, *Response, error) {
 	return firstByName(name, func() ([]*StorageBoxType, *Response, error) {
 		return c.List(ctx, StorageBoxTypeListOpts{Name: name})
@@ -131,8 +119,6 @@ func (c *StorageBoxTypeClient) GetByName(ctx context.Context, name string) (*Sto
 // retrieves a Storage Box Type by its name. If the Storage Box Type does not exist, nil is returned.
 //
 // See https://docs.hetzner.cloud/reference/hetzner#storage-box-types-get-a-storage-box-type
-//
-// Experimental: [StorageBoxTypeClient] is experimental, breaking changes may occur within minor releases.
 func (c *StorageBoxTypeClient) Get(ctx context.Context, idOrName string) (*StorageBoxType, *Response, error) {
 	return getByIDOrName(ctx, c.GetByID, c.GetByName, idOrName)
 }

--- a/hcloud/zz_storage_box_client_iface.go
+++ b/hcloud/zz_storage_box_client_iface.go
@@ -11,22 +11,16 @@ type IStorageBoxClient interface {
 	// GetByID retrieves a [StorageBox] by its ID. If the [StorageBox] does not exist, nil is returned.
 	//
 	// See https://docs.hetzner.cloud/reference/hetzner#storage-boxes-get-a-storage-box
-	//
-	// Experimental: [StorageBoxClient] is experimental, breaking changes may occur within minor releases.
 	GetByID(ctx context.Context, id int64) (*StorageBox, *Response, error)
 	// GetByName retrieves a [StorageBox] by its name. If the [StorageBox] does not exist, nil is returned.
 	//
 	// See https://docs.hetzner.cloud/reference/hetzner#storage-boxes-list-storage-boxes
-	//
-	// Experimental: [StorageBoxClient] is experimental, breaking changes may occur within minor releases.
 	GetByName(ctx context.Context, name string) (*StorageBox, *Response, error)
 	// Get retrieves a [StorageBox] either by its ID or by its name, depending on whether
 	// the input can be parsed as an integer. If no matching [StorageBox] is found, it returns nil.
 	//
 	// When fetching by ID, see https://docs.hetzner.cloud/reference/hetzner#storage-boxes-get-a-storage-box
 	// When fetching by name, see https://docs.hetzner.cloud/reference/hetzner#storage-boxes-list-storage-boxes
-	//
-	// Experimental: [StorageBoxClient] is experimental, breaking changes may occur within minor releases.
 	Get(ctx context.Context, idOrName string) (*StorageBox, *Response, error)
 	// List returns a list of [StorageBox] for a specific page.
 	//
@@ -34,20 +28,14 @@ type IStorageBoxClient interface {
 	// when their value corresponds to their zero value or when they are empty.
 	//
 	// See https://docs.hetzner.cloud/reference/hetzner#storage-boxes-list-storage-boxes
-	//
-	// Experimental: [StorageBoxClient] is experimental, breaking changes may occur within minor releases.
 	List(ctx context.Context, opts StorageBoxListOpts) ([]*StorageBox, *Response, error)
 	// All returns all [StorageBox].
 	//
 	// See https://docs.hetzner.cloud/reference/hetzner#storage-boxes-list-storage-boxes
-	//
-	// Experimental: [StorageBoxClient] is experimental, breaking changes may occur within minor releases.
 	All(ctx context.Context) ([]*StorageBox, error)
 	// AllWithOpts returns all [StorageBox] with the given options.
 	//
 	// See https://docs.hetzner.cloud/reference/hetzner#storage-boxes-list-storage-boxes
-	//
-	// Experimental: [StorageBoxClient] is experimental, breaking changes may occur within minor releases.
 	AllWithOpts(ctx context.Context, opts StorageBoxListOpts) ([]*StorageBox, error)
 	// Create creates a new [StorageBox] with the given options.
 	//
@@ -56,199 +44,135 @@ type IStorageBoxClient interface {
 	// is sent to the API. They are not addressable by ID or name.
 	//
 	// See https://docs.hetzner.cloud/reference/hetzner#storage-boxes-create-a-storage-box
-	//
-	// Experimental: [StorageBoxClient] is experimental, breaking changes may occur within minor releases.
 	Create(ctx context.Context, opts StorageBoxCreateOpts) (StorageBoxCreateResult, *Response, error)
 	// Update updates a [StorageBox] with the given options.
 	//
 	// See https://docs.hetzner.cloud/reference/hetzner#storage-boxes-update-a-storage-box
-	//
-	// Experimental: [StorageBoxClient] is experimental, breaking changes may occur within minor releases.
 	Update(ctx context.Context, storageBox *StorageBox, opts StorageBoxUpdateOpts) (*StorageBox, *Response, error)
 	// Delete deletes a [StorageBox].
 	//
 	// See https://docs.hetzner.cloud/reference/hetzner#storage-boxes-delete-a-storage-box
-	//
-	// Experimental: [StorageBoxClient] is experimental, breaking changes may occur within minor releases.
 	Delete(ctx context.Context, storageBox *StorageBox) (StorageBoxDeleteResult, *Response, error)
 	// Folders lists folders in a [StorageBox].
 	//
 	// See https://docs.hetzner.cloud/reference/hetzner#storage-boxes-list-folders-of-a-storage-box
-	//
-	// Experimental: [StorageBoxClient] is experimental, breaking changes may occur within minor releases.
 	Folders(ctx context.Context, storageBox *StorageBox, opts StorageBoxFoldersOpts) (StorageBoxFoldersResult, *Response, error)
 	// ChangeProtection changes the protection level of a [StorageBox].
 	//
 	// See https://docs.hetzner.cloud/reference/hetzner#storage-box-actions-change-protection
-	//
-	// Experimental: [StorageBoxClient] is experimental, breaking changes may occur within minor releases.
 	ChangeProtection(ctx context.Context, storageBox *StorageBox, opts StorageBoxChangeProtectionOpts) (*Action, *Response, error)
 	// ChangeType changes the type of a [StorageBox].
 	//
 	// See https://docs.hetzner.cloud/reference/hetzner#storage-box-actions-change-type
-	//
-	// Experimental: [StorageBoxClient] is experimental, breaking changes may occur within minor releases.
 	ChangeType(ctx context.Context, storageBox *StorageBox, opts StorageBoxChangeTypeOpts) (*Action, *Response, error)
 	// ResetPassword resets the password of a [StorageBox].
 	//
 	// See https://docs.hetzner.cloud/reference/hetzner#storage-box-actions-reset-password
-	//
-	// Experimental: [StorageBoxClient] is experimental, breaking changes may occur within minor releases.
 	ResetPassword(ctx context.Context, storageBox *StorageBox, opts StorageBoxResetPasswordOpts) (*Action, *Response, error)
 	// UpdateAccessSettings updates the [StorageBoxAccessSettings] of a [StorageBox].
 	//
 	// See https://docs.hetzner.cloud/reference/hetzner#storage-box-actions-update-access-settings
-	//
-	// Experimental: [StorageBoxClient] is experimental, breaking changes may occur within minor releases.
 	UpdateAccessSettings(ctx context.Context, storageBox *StorageBox, opts StorageBoxUpdateAccessSettingsOpts) (*Action, *Response, error)
 	// RollbackSnapshot rolls back a [StorageBox] to a [StorageBoxSnapshot].
 	//
 	// See https://docs.hetzner.cloud/reference/hetzner#storage-box-actions-rollback-snapshot
-	//
-	// Experimental: [StorageBoxClient] is experimental, breaking changes may occur within minor releases.
 	RollbackSnapshot(ctx context.Context, storageBox *StorageBox, opts StorageBoxRollbackSnapshotOpts) (*Action, *Response, error)
 	// EnableSnapshotPlan enables a [StorageBoxSnapshotPlan] for a [StorageBox].
 	//
 	// See https://docs.hetzner.cloud/reference/hetzner#storage-box-actions-enable-snapshot-plan
-	//
-	// Experimental: [StorageBoxClient] is experimental, breaking changes may occur within minor releases.
 	EnableSnapshotPlan(ctx context.Context, storageBox *StorageBox, opts StorageBoxEnableSnapshotPlanOpts) (*Action, *Response, error)
 	// DisableSnapshotPlan disables the [StorageBoxSnapshotPlan] for a [StorageBox].
 	//
 	// See https://docs.hetzner.cloud/reference/hetzner#storage-box-actions-disable-snapshot-plan
-	//
-	// Experimental: [StorageBoxClient] is experimental, breaking changes may occur within minor releases.
 	DisableSnapshotPlan(ctx context.Context, storageBox *StorageBox) (*Action, *Response, error)
 	// GetSnapshotByID gets a [StorageBoxSnapshot] by its ID.
 	//
 	// See https://docs.hetzner.cloud/reference/hetzner#storage-box-snapshots-get-a-snapshot
-	//
-	// Experimental: [StorageBoxClient] is experimental, breaking changes may occur within minor releases.
 	GetSnapshotByID(ctx context.Context, storageBox *StorageBox, id int64) (*StorageBoxSnapshot, *Response, error)
 	// GetSnapshotByName gets a [StorageBoxSnapshot] by its name.
 	//
 	// See https://docs.hetzner.cloud/reference/hetzner#storage-box-snapshots-list-snapshots
-	//
-	// Experimental: [StorageBoxClient] is experimental, breaking changes may occur within minor releases.
 	GetSnapshotByName(ctx context.Context, storageBox *StorageBox, name string) (*StorageBoxSnapshot, *Response, error)
 	// GetSnapshot retrieves a [StorageBoxSnapshot] either by its ID or by its name, depending on whether
 	// the input can be parsed as an integer. If no matching [StorageBoxSnapshot] is found, it returns nil.
 	//
 	// When fetching by ID, see https://docs.hetzner.cloud/reference/hetzner#storage-box-snapshots-get-a-snapshot
 	// When fetching by name, see https://docs.hetzner.cloud/reference/hetzner#storage-box-snapshots-list-snapshots
-	//
-	// Experimental: [StorageBoxClient] is experimental, breaking changes may occur within minor releases.
 	GetSnapshot(ctx context.Context, storageBox *StorageBox, idOrName string) (*StorageBoxSnapshot, *Response, error)
 	// ListSnapshots lists all [StorageBoxSnapshot] of a [StorageBox] with the given options.
 	//
 	// Pagination is not supported, so this will return all [StorageBoxSnapshot] at once.
 	//
 	// See https://docs.hetzner.cloud/reference/hetzner#storage-box-snapshots-list-snapshots
-	//
-	// Experimental: [StorageBoxClient] is experimental, breaking changes may occur within minor releases.
 	ListSnapshots(ctx context.Context, storageBox *StorageBox, opts StorageBoxSnapshotListOpts) ([]*StorageBoxSnapshot, *Response, error)
 	// AllSnapshotsWithOpts lists all [StorageBoxSnapshot] of a [StorageBox] with the given options.
 	//
 	// See https://docs.hetzner.cloud/reference/hetzner#storage-box-snapshots-list-snapshots
-	//
-	// Experimental: [StorageBoxClient] is experimental, breaking changes may occur within minor releases.
 	AllSnapshotsWithOpts(ctx context.Context, storageBox *StorageBox, opts StorageBoxSnapshotListOpts) ([]*StorageBoxSnapshot, error)
 	// AllSnapshots lists all [StorageBoxSnapshot] of a [StorageBox] without any options.
 	//
 	// See https://docs.hetzner.cloud/reference/hetzner#storage-box-snapshots-list-snapshots
-	//
-	// Experimental: [StorageBoxClient] is experimental, breaking changes may occur within minor releases.
 	AllSnapshots(ctx context.Context, storageBox *StorageBox) ([]*StorageBoxSnapshot, error)
 	// CreateSnapshot creates a new [StorageBoxSnapshot] for the given [StorageBox] with the provided options.
 	//
 	// See https://docs.hetzner.cloud/reference/hetzner#storage-box-snapshots-create-a-snapshot
-	//
-	// Experimental: [StorageBoxClient] is experimental, breaking changes may occur within minor releases.
 	CreateSnapshot(ctx context.Context, storageBox *StorageBox, opts StorageBoxSnapshotCreateOpts) (StorageBoxSnapshotCreateResult, *Response, error)
 	// UpdateSnapshot updates the given [StorageBoxSnapshot] of a [StorageBox] with the provided options.
 	//
 	// See https://docs.hetzner.cloud/reference/hetzner#storage-box-snapshots-update-a-snapshot
-	//
-	// Experimental: [StorageBoxClient] is experimental, breaking changes may occur within minor releases.
 	UpdateSnapshot(ctx context.Context, snapshot *StorageBoxSnapshot, opts StorageBoxSnapshotUpdateOpts) (*StorageBoxSnapshot, *Response, error)
 	// DeleteSnapshot deletes the given [StorageBoxSnapshot] of a [StorageBox].
 	//
 	// See https://docs.hetzner.cloud/reference/hetzner#storage-box-snapshots-delete-a-snapshot
-	//
-	// Experimental: [StorageBoxClient] is experimental, breaking changes may occur within minor releases.
 	DeleteSnapshot(ctx context.Context, snapshot *StorageBoxSnapshot) (StorageBoxSnapshotDeleteResult, *Response, error)
 	// GetSubaccount retrieves a [StorageBoxSubaccount] either by its ID or by its username, depending on whether
 	// the input can be parsed as an integer. If no matching [StorageBoxSubaccount] is found, it returns nil.
 	//
 	// When fetching by ID, see https://docs.hetzner.cloud/reference/hetzner#storage-box-subaccounts-get-a-subaccount
 	// When fetching by name, see https://docs.hetzner.cloud/reference/hetzner#storage-box-subaccounts-list-subaccounts
-	//
-	// Experimental: [StorageBoxClient] is experimental, breaking changes may occur within minor releases.
 	GetSubaccount(ctx context.Context, storageBox *StorageBox, idOrUsername string) (*StorageBoxSubaccount, *Response, error)
 	// GetSubaccountByID retrieves a [StorageBoxSubaccount] by its ID.
 	//
 	// See https://docs.hetzner.cloud/reference/hetzner#storage-box-subaccounts-get-a-subaccount
-	//
-	// Experimental: [StorageBoxClient] is experimental, breaking changes may occur within minor releases.
 	GetSubaccountByID(ctx context.Context, storageBox *StorageBox, id int64) (*StorageBoxSubaccount, *Response, error)
 	// GetSubaccountByUsername retrieves a [StorageBoxSubaccount] by its username.
 	//
 	// See https://docs.hetzner.cloud/reference/hetzner#storage-box-subaccounts-list-subaccounts
-	//
-	// Experimental: [StorageBoxClient] is experimental, breaking changes may occur within minor releases.
 	GetSubaccountByUsername(ctx context.Context, storageBox *StorageBox, username string) (*StorageBoxSubaccount, *Response, error)
 	// ListSubaccounts lists all [StorageBoxSubaccount] of a [StorageBox].
 	//
 	// See https://docs.hetzner.cloud/reference/hetzner#storage-box-subaccounts-list-subaccounts
-	//
-	// Experimental: [StorageBoxClient] is experimental, breaking changes may occur within minor releases.
 	ListSubaccounts(ctx context.Context, storageBox *StorageBox, opts StorageBoxSubaccountListOpts) ([]*StorageBoxSubaccount, *Response, error)
 	// AllSubaccountsWithOpts retrieves all [StorageBoxSubaccount] of a [StorageBox] with the given options.
 	//
 	// See https://docs.hetzner.cloud/reference/hetzner#storage-box-subaccounts-list-subaccounts
-	//
-	// Experimental: [StorageBoxClient] is experimental, breaking changes may occur within minor releases.
 	AllSubaccountsWithOpts(ctx context.Context, storageBox *StorageBox, opts StorageBoxSubaccountListOpts) ([]*StorageBoxSubaccount, error)
 	// AllSubaccounts retrieves all [StorageBoxSubaccount] of a [StorageBox].
 	//
 	// See https://docs.hetzner.cloud/reference/hetzner#storage-box-subaccounts-list-subaccounts
-	//
-	// Experimental: [StorageBoxClient] is experimental, breaking changes may occur within minor releases.
 	AllSubaccounts(ctx context.Context, storageBox *StorageBox) ([]*StorageBoxSubaccount, error)
 	// CreateSubaccount creates a new [StorageBoxSubaccount] for a [StorageBox].
 	//
 	// See https://docs.hetzner.cloud/reference/hetzner#storage-box-subaccounts-create-a-subaccount
-	//
-	// Experimental: [StorageBoxClient] is experimental, breaking changes may occur within minor releases.
 	CreateSubaccount(ctx context.Context, storageBox *StorageBox, opts StorageBoxSubaccountCreateOpts) (StorageBoxSubaccountCreateResult, *Response, error)
 	// UpdateSubaccount updates a [StorageBoxSubaccount] of a [StorageBox].
 	//
 	// See https://docs.hetzner.cloud/reference/hetzner#storage-box-subaccounts-update-a-subaccount
-	//
-	// Experimental: [StorageBoxClient] is experimental, breaking changes may occur within minor releases.
 	UpdateSubaccount(ctx context.Context, subaccount *StorageBoxSubaccount, opts StorageBoxSubaccountUpdateOpts) (*StorageBoxSubaccount, *Response, error)
 	// DeleteSubaccount deletes a [StorageBoxSubaccount] from a [StorageBox].
 	//
 	// See https://docs.hetzner.cloud/reference/hetzner#storage-box-subaccounts-delete-a-subaccount
-	//
-	// Experimental: [StorageBoxClient] is experimental, breaking changes may occur within minor releases.
 	DeleteSubaccount(ctx context.Context, subaccount *StorageBoxSubaccount) (StorageBoxSubaccountDeleteResult, *Response, error)
 	// ResetSubaccountPassword resets the password of a [StorageBoxSubaccount].
 	//
 	// See https://docs.hetzner.cloud/reference/hetzner#storage-box-subaccount-actions-reset-password
-	//
-	// Experimental: [StorageBoxClient] is experimental, breaking changes may occur within minor releases.
 	ResetSubaccountPassword(ctx context.Context, subaccount *StorageBoxSubaccount, opts StorageBoxSubaccountResetPasswordOpts) (*Action, *Response, error)
 	// UpdateSubaccountAccessSettings updates the [StorageBoxSubaccountAccessSettings] of a [StorageBoxSubaccount].
 	//
 	// See https://docs.hetzner.cloud/reference/hetzner#storage-box-subaccount-actions-update-access-settings
-	//
-	// Experimental: [StorageBoxClient] is experimental, breaking changes may occur within minor releases.
 	UpdateSubaccountAccessSettings(ctx context.Context, subaccount *StorageBoxSubaccount, opts StorageBoxSubaccountUpdateAccessSettingsOpts) (*Action, *Response, error)
-	// UpdateSubaccountAccessSettings changes the home directory of a [StorageBoxSubaccount].
+	// ChangeSubaccountHomeDirectory changes the home directory of a [StorageBoxSubaccount].
 	//
 	// See https://docs.hetzner.cloud/reference/hetzner#storage-box-subaccount-actions-change-home-directory
-	//
-	// Experimental: [StorageBoxClient] is experimental, breaking changes may occur within minor releases.
 	ChangeSubaccountHomeDirectory(ctx context.Context, subaccount *StorageBoxSubaccount, opts StorageBoxSubaccountChangeHomeDirectoryOpts) (*Action, *Response, error)
 }

--- a/hcloud/zz_storage_box_type_client_iface.go
+++ b/hcloud/zz_storage_box_type_client_iface.go
@@ -11,38 +11,26 @@ type IStorageBoxTypeClient interface {
 	// List returns a list of storage box types for a specific page.
 	//
 	// See https://docs.hetzner.cloud/reference/hetzner#storage-box-types-list-storage-box-types
-	//
-	// Experimental: [StorageBoxTypeClient] is experimental, breaking changes may occur within minor releases.
 	List(ctx context.Context, opts StorageBoxTypeListOpts) ([]*StorageBoxType, *Response, error)
 	// All returns all storage box types.
 	//
 	// See https://docs.hetzner.cloud/reference/hetzner#storage-box-types-list-storage-box-types
-	//
-	// Experimental: [StorageBoxTypeClient] is experimental, breaking changes may occur within minor releases.
 	All(ctx context.Context) ([]*StorageBoxType, error)
 	// AllWithOpts returns all storage box types for the given options.
 	//
 	// See https://docs.hetzner.cloud/reference/hetzner#storage-box-types-list-storage-box-types
-	//
-	// Experimental: [StorageBoxTypeClient] is experimental, breaking changes may occur within minor releases.
 	AllWithOpts(ctx context.Context, opts StorageBoxTypeListOpts) ([]*StorageBoxType, error)
 	// GetByID returns a specific Storage Box Type by ID.
 	//
 	// See https://docs.hetzner.cloud/reference/hetzner#storage-box-types-get-a-storage-box-type
-	//
-	// Experimental: [StorageBoxTypeClient] is experimental, breaking changes may occur within minor releases.
 	GetByID(ctx context.Context, id int64) (*StorageBoxType, *Response, error)
 	// GetByName retrieves a Storage Box Type by its name. If the Storage Box Type does not exist, nil is returned.
 	//
 	// See https://docs.hetzner.cloud/reference/hetzner#storage-box-types-get-a-storage-box-type
-	//
-	// Experimental: [StorageBoxTypeClient] is experimental, breaking changes may occur within minor releases.
 	GetByName(ctx context.Context, name string) (*StorageBoxType, *Response, error)
 	// Get retrieves a Storage Box Type by its ID if the input can be parsed as an integer, otherwise it
 	// retrieves a Storage Box Type by its name. If the Storage Box Type does not exist, nil is returned.
 	//
 	// See https://docs.hetzner.cloud/reference/hetzner#storage-box-types-get-a-storage-box-type
-	//
-	// Experimental: [StorageBoxTypeClient] is experimental, breaking changes may occur within minor releases.
 	Get(ctx context.Context, idOrName string) (*StorageBoxType, *Response, error)
 }


### PR DESCRIPTION
This PR removes the `Experimental` annotations from the `StorageBoxClient` and `StorageBoxTypeClient`, making Storage Box support generally available.

```rp-commits
chore: Storage Box support no longer experimental
```