### PR TITLE
feat(primary-ip): `assignee_type` is optional when creating a primary ip

### DIFF
--- a/hcloud/schema/primary_ip.go
+++ b/hcloud/schema/primary_ip.go
@@ -41,7 +41,7 @@ type PrimaryIPDNSPTR struct {
 type PrimaryIPCreateRequest struct {
 	Name         string             `json:"name"`
 	Type         string             `json:"type"`
-	AssigneeType string             `json:"assignee_type"`
+	AssigneeType string             `json:"assignee_type,omitempty"`
 	AssigneeID   *int64             `json:"assignee_id,omitempty"`
 	Labels       *map[string]string `json:"labels,omitempty"`
 	AutoDelete   *bool              `json:"auto_delete,omitempty"`


### PR DESCRIPTION
#### Primary IPs `assignee_type` behavior change

As of 1 August 2026, the behavior of the [Primary IP](https://pkg.go.dev/github.com/hetznercloud/hcloud-go/v2/hcloud#PrimaryIP) `assignee_type` property will change, and will return `unassigned` when the [Primary IP](https://pkg.go.dev/github.com/hetznercloud/hcloud-go/v2/hcloud#PrimaryIP) is not assigned (when `assignee_id` is `null`). The goal is to eventually assign Primary IPs to other resource types, not only to `server`.

See the [changelog](https://docs.hetzner.cloud/changelog#2026-04-27-primary-ips-will-return-unassigned) for more details.

In addition, the [Primary IP request body](https://pkg.go.dev/github.com/hetznercloud/hcloud-go/v2/hcloud#PrimaryIPCreateOpts) `assignee_type` property of the operation [`POST /v1/primary_ips`](https://docs.hetzner.cloud/reference/cloud#tag/primary-ips/create_primary_ip) is now optional. Primary IPs created without `assignee_type` return `server` until 1 August 2026, after this date, its value will be `unassigned`.

See the [changelog](https://docs.hetzner.cloud/changelog#2026-04-27-primary-ips-make-assignee_type-optional) for more details.
