### PR TITLE
feat(load-balancer): support `timeout_idle` http service field

### DIFF
--- a/hcloud/load_balancer.go
+++ b/hcloud/load_balancer.go
@@ -81,6 +81,7 @@ type LoadBalancerServiceHTTP struct {
 	Certificates   []*Certificate
 	RedirectHTTP   bool
 	StickySessions bool
+	TimeoutIdle    time.Duration
 }
 
 // LoadBalancerServiceHealthCheck stores configuration for a service health check.
@@ -427,6 +428,7 @@ type LoadBalancerCreateOptsServiceHTTP struct {
 	Certificates   []*Certificate
 	RedirectHTTP   *bool
 	StickySessions *bool
+	TimeoutIdle    *time.Duration
 }
 
 // LoadBalancerCreateOptsServiceHealthCheck holds options for specifying a service
@@ -620,6 +622,7 @@ type LoadBalancerAddServiceOptsHTTP struct {
 	Certificates   []*Certificate
 	RedirectHTTP   *bool
 	StickySessions *bool
+	TimeoutIdle    *time.Duration
 }
 
 // LoadBalancerAddServiceOptsHealthCheck holds options for specifying a health check
@@ -676,6 +679,7 @@ type LoadBalancerUpdateServiceOptsHTTP struct {
 	Certificates   []*Certificate
 	RedirectHTTP   *bool
 	StickySessions *bool
+	TimeoutIdle    *time.Duration
 }
 
 // LoadBalancerUpdateServiceOptsHealthCheck specifies options for updating

--- a/hcloud/load_balancer_test.go
+++ b/hcloud/load_balancer_test.go
@@ -476,6 +476,7 @@ func TestLoadBalancerAddService(t *testing.T) {
 				CookieLifetime: Ptr(5 * 60),
 				RedirectHTTP:   Ptr(false),
 				StickySessions: Ptr(true),
+				TimeoutIdle:    Ptr(60),
 			},
 			HealthCheck: &schema.LoadBalancerActionAddServiceRequestHealthCheck{
 				Protocol: "http",
@@ -514,6 +515,7 @@ func TestLoadBalancerAddService(t *testing.T) {
 			CookieLifetime: Ptr(5 * time.Minute),
 			RedirectHTTP:   Ptr(false),
 			StickySessions: Ptr(true),
+			TimeoutIdle:    Ptr(time.Minute),
 		},
 		HealthCheck: &LoadBalancerAddServiceOptsHealthCheck{
 			Protocol: "http",
@@ -557,6 +559,7 @@ func TestLoadBalancerUpdateService(t *testing.T) {
 				CookieLifetime: Ptr(5 * 60),
 				RedirectHTTP:   Ptr(false),
 				StickySessions: Ptr(true),
+				TimeoutIdle:    Ptr(60),
 			},
 			HealthCheck: &schema.LoadBalancerActionUpdateServiceRequestHealthCheck{
 				Protocol: Ptr(string(LoadBalancerServiceProtocolHTTP)),
@@ -594,6 +597,7 @@ func TestLoadBalancerUpdateService(t *testing.T) {
 			CookieLifetime: Ptr(5 * time.Minute),
 			RedirectHTTP:   Ptr(false),
 			StickySessions: Ptr(true),
+			TimeoutIdle:    Ptr(time.Minute),
 		},
 		HealthCheck: &LoadBalancerUpdateServiceOptsHealthCheck{
 			Protocol: LoadBalancerServiceProtocolHTTP,

--- a/hcloud/schema/load_balancer.go
+++ b/hcloud/schema/load_balancer.go
@@ -64,6 +64,7 @@ type LoadBalancerServiceHTTP struct {
 	Certificates   []int64 `json:"certificates"`
 	RedirectHTTP   bool    `json:"redirect_http"`
 	StickySessions bool    `json:"sticky_sessions"`
+	TimeoutIdle    int     `json:"timeout_idle"`
 }
 
 type LoadBalancerServiceHealthCheck struct {
@@ -180,6 +181,7 @@ type LoadBalancerActionAddServiceRequestHTTP struct {
 	Certificates   *[]int64 `json:"certificates,omitempty"`
 	RedirectHTTP   *bool    `json:"redirect_http,omitempty"`
 	StickySessions *bool    `json:"sticky_sessions,omitempty"`
+	TimeoutIdle    *int     `json:"timeout_idle,omitempty"`
 }
 
 type LoadBalancerActionAddServiceRequestHealthCheck struct {
@@ -218,6 +220,7 @@ type LoadBalancerActionUpdateServiceRequestHTTP struct {
 	Certificates   *[]int64 `json:"certificates,omitempty"`
 	RedirectHTTP   *bool    `json:"redirect_http,omitempty"`
 	StickySessions *bool    `json:"sticky_sessions,omitempty"`
+	TimeoutIdle    *int     `json:"timeout_idle,omitempty"`
 }
 
 type LoadBalancerActionUpdateServiceRequestHealthCheck struct {
@@ -301,6 +304,7 @@ type LoadBalancerCreateRequestServiceHTTP struct {
 	Certificates   *[]int64 `json:"certificates,omitempty"`
 	RedirectHTTP   *bool    `json:"redirect_http,omitempty"`
 	StickySessions *bool    `json:"sticky_sessions,omitempty"`
+	TimeoutIdle    *int     `json:"timeout_idle,omitempty"`
 }
 
 type LoadBalancerCreateRequestServiceHealthCheck struct {

--- a/hcloud/schema_test.go
+++ b/hcloud/schema_test.go
@@ -1057,7 +1057,8 @@ func TestLoadBalancerServiceSchema(t *testing.T) {
 				897
 			],
 			"redirect_http": true,
-			"sticky_sessions": true
+			"sticky_sessions": true,
+			"timeout_idle": 60
 		},
 		"health_check": {
 			"protocol": "http",

--- a/hcloud/zz_schema_converter.go
+++ b/hcloud/zz_schema_converter.go
@@ -1909,6 +1909,7 @@ func (c *converterImpl) hcloudLoadBalancerServiceHTTPToPSchemaLoadBalancerServic
 	}
 	schemaLoadBalancerServiceHTTP.RedirectHTTP = source.RedirectHTTP
 	schemaLoadBalancerServiceHTTP.StickySessions = source.StickySessions
+	schemaLoadBalancerServiceHTTP.TimeoutIdle = intSecondsFromDuration(source.TimeoutIdle)
 	return &schemaLoadBalancerServiceHTTP
 }
 func (c *converterImpl) hcloudNetworkProtectionToSchemaNetworkProtection(source NetworkProtection) schema.NetworkProtection {
@@ -2189,6 +2190,10 @@ func (c *converterImpl) pHcloudLoadBalancerAddServiceOptsHTTPToPSchemaLoadBalanc
 		schemaLoadBalancerActionAddServiceRequestHTTP.Certificates = int64SlicePtrFromCertificatePtrSlice((*source).Certificates)
 		schemaLoadBalancerActionAddServiceRequestHTTP.RedirectHTTP = (*source).RedirectHTTP
 		schemaLoadBalancerActionAddServiceRequestHTTP.StickySessions = (*source).StickySessions
+		if (*source).TimeoutIdle != nil {
+			xint2 := intSecondsFromDuration(*(*source).TimeoutIdle)
+			schemaLoadBalancerActionAddServiceRequestHTTP.TimeoutIdle = &xint2
+		}
 		pSchemaLoadBalancerActionAddServiceRequestHTTP = &schemaLoadBalancerActionAddServiceRequestHTTP
 	}
 	return pSchemaLoadBalancerActionAddServiceRequestHTTP
@@ -2247,6 +2252,10 @@ func (c *converterImpl) pHcloudLoadBalancerCreateOptsServiceHTTPToPSchemaLoadBal
 		schemaLoadBalancerCreateRequestServiceHTTP.Certificates = int64SlicePtrFromCertificatePtrSlice((*source).Certificates)
 		schemaLoadBalancerCreateRequestServiceHTTP.RedirectHTTP = (*source).RedirectHTTP
 		schemaLoadBalancerCreateRequestServiceHTTP.StickySessions = (*source).StickySessions
+		if (*source).TimeoutIdle != nil {
+			xint2 := intSecondsFromDuration(*(*source).TimeoutIdle)
+			schemaLoadBalancerCreateRequestServiceHTTP.TimeoutIdle = &xint2
+		}
 		pSchemaLoadBalancerCreateRequestServiceHTTP = &schemaLoadBalancerCreateRequestServiceHTTP
 	}
 	return pSchemaLoadBalancerCreateRequestServiceHTTP
@@ -2350,6 +2359,10 @@ func (c *converterImpl) pHcloudLoadBalancerUpdateServiceOptsHTTPToPSchemaLoadBal
 		schemaLoadBalancerActionUpdateServiceRequestHTTP.Certificates = int64SlicePtrFromCertificatePtrSlice((*source).Certificates)
 		schemaLoadBalancerActionUpdateServiceRequestHTTP.RedirectHTTP = (*source).RedirectHTTP
 		schemaLoadBalancerActionUpdateServiceRequestHTTP.StickySessions = (*source).StickySessions
+		if (*source).TimeoutIdle != nil {
+			xint2 := intSecondsFromDuration(*(*source).TimeoutIdle)
+			schemaLoadBalancerActionUpdateServiceRequestHTTP.TimeoutIdle = &xint2
+		}
 		pSchemaLoadBalancerActionUpdateServiceRequestHTTP = &schemaLoadBalancerActionUpdateServiceRequestHTTP
 	}
 	return pSchemaLoadBalancerActionUpdateServiceRequestHTTP
@@ -2678,6 +2691,7 @@ func (c *converterImpl) pSchemaLoadBalancerServiceHTTPToHcloudLoadBalancerServic
 		}
 		hcloudLoadBalancerServiceHTTP.RedirectHTTP = (*source).RedirectHTTP
 		hcloudLoadBalancerServiceHTTP.StickySessions = (*source).StickySessions
+		hcloudLoadBalancerServiceHTTP.TimeoutIdle = durationFromIntSeconds((*source).TimeoutIdle)
 	}
 	return hcloudLoadBalancerServiceHTTP
 }


### PR DESCRIPTION
`timeout_idle` controls the time a http connection is allowed to idle before the load balancer drops the connection.

See the [changelog](https://docs.hetzner.cloud/changelog#2026-04-30-load-balancers-http-idle-timeout-can-now-be-configured) for more information.