### PR TITLE
refactor: use and enforce `go fix`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -47,6 +47,12 @@ repos:
         entry: go generate ./...
         pass_filenames: false
 
+      - id: go-fix
+        name: go fix
+        language: golang
+        entry: go fix ./...
+        pass_filenames: false
+
   - repo: https://github.com/golangci/golangci-lint
     rev: v2.11.4
     hooks:

--- a/hcloud/client_handler_http.go
+++ b/hcloud/client_handler_http.go
@@ -12,7 +12,7 @@ type httpHandler struct {
 	httpClient *http.Client
 }
 
-func (h *httpHandler) Do(req *http.Request, _ interface{}) (*Response, error) {
+func (h *httpHandler) Do(req *http.Request, _ any) (*Response, error) {
 	httpResponse, err := h.httpClient.Do(req) //nolint: bodyclose
 	resp := &Response{Response: httpResponse}
 	if err != nil {

--- a/hcloud/client_handler_test.go
+++ b/hcloud/client_handler_test.go
@@ -16,7 +16,7 @@ type mockHandler struct {
 	f func(req *http.Request, v any) (resp *Response, err error)
 }
 
-func (h *mockHandler) Do(req *http.Request, v interface{}) (*Response, error) { return h.f(req, v) }
+func (h *mockHandler) Do(req *http.Request, v any) (*Response, error) { return h.f(req, v) }
 
 func fakeResponse(t *testing.T, statusCode int, body string, json bool) *Response {
 	t.Helper()

--- a/hcloud/client_test.go
+++ b/hcloud/client_test.go
@@ -255,7 +255,7 @@ func TestClientDoPost(t *testing.T) {
 
 		callCount++
 		w.Header().Set("Content-Type", "application/json")
-		var dat map[string]interface{}
+		var dat map[string]any
 		body, err := io.ReadAll(r.Body)
 		r.Body.Close()
 		if err != nil {

--- a/hcloud/error.go
+++ b/hcloud/error.go
@@ -113,7 +113,7 @@ const (
 type Error struct {
 	Code    ErrorCode
 	Message string
-	Details interface{}
+	Details any
 
 	response *Response
 }

--- a/hcloud/error_test.go
+++ b/hcloud/error_test.go
@@ -12,7 +12,7 @@ func TestError_Error(t *testing.T) {
 	type fields struct {
 		Code     ErrorCode
 		Message  string
-		Details  interface{}
+		Details  any
 		response *Response
 	}
 	tests := []struct {

--- a/hcloud/labels.go
+++ b/hcloud/labels.go
@@ -9,7 +9,7 @@ var keyRegexp = regexp.MustCompile(
 	`^([a-z0-9A-Z]((?:[\-_.]|[a-z0-9A-Z]){0,253}[a-z0-9A-Z])?/)?[a-z0-9A-Z]((?:[\-_.]|[a-z0-9A-Z]|){0,61}[a-z0-9A-Z])?$`)
 var valueRegexp = regexp.MustCompile(`^(([a-z0-9A-Z](?:[\-_.]|[a-z0-9A-Z]){0,61})?[a-z0-9A-Z]$|$)`)
 
-func ValidateResourceLabels(labels map[string]interface{}) (bool, error) {
+func ValidateResourceLabels(labels map[string]any) (bool, error) {
 	for k, v := range labels {
 		if match := keyRegexp.MatchString(k); !match {
 			return false, fmt.Errorf("label key '%s' is not correctly formatted", k)

--- a/hcloud/labels_test.go
+++ b/hcloud/labels_test.go
@@ -8,7 +8,7 @@ import (
 
 func TestCheckLabels(t *testing.T) {
 	t.Run("correct labels", func(t *testing.T) {
-		labelMap := map[string]interface{}{
+		labelMap := map[string]any{
 			"label1":                    "correct.de",
 			"label2.de/hallo":           "1correct2.de",
 			"label3-test.de/hallo.welt": "233344444443",
@@ -33,7 +33,7 @@ func TestCheckLabels(t *testing.T) {
 		}
 
 		for _, label := range incorrectLabels {
-			labelMap := map[string]interface{}{
+			labelMap := map[string]any{
 				"test1": "valid",
 				"test2": label,
 			}
@@ -60,7 +60,7 @@ func TestCheckLabels(t *testing.T) {
 		}
 
 		for _, label := range incorrectLabels {
-			labelMap := map[string]interface{}{
+			labelMap := map[string]any{
 				label: "cor-rect.de",
 			}
 			ok, err := ValidateResourceLabels(labelMap)

--- a/hcloud/load_balancer_test.go
+++ b/hcloud/load_balancer_test.go
@@ -1092,33 +1092,33 @@ func TestLoadBalancerGetMetrics(t *testing.T) {
 				resp.Metrics.End = mustParseTime(t, "2017-01-01T23:00:00Z")
 				resp.Metrics.TimeSeries = map[string]schema.LoadBalancerTimeSeriesVals{
 					"open_connections": {
-						Values: []interface{}{
-							[]interface{}{1435781470.622, "42"},
-							[]interface{}{1435781471.622, "43"},
+						Values: []any{
+							[]any{1435781470.622, "42"},
+							[]any{1435781471.622, "43"},
 						},
 					},
 					"connections_per_second": {
-						Values: []interface{}{
-							[]interface{}{1435781480.622, "100"},
-							[]interface{}{1435781481.622, "150"},
+						Values: []any{
+							[]any{1435781480.622, "100"},
+							[]any{1435781481.622, "150"},
 						},
 					},
 					"requests_per_second": {
-						Values: []interface{}{
-							[]interface{}{1435781480.622, "50"},
-							[]interface{}{1435781481.622, "55"},
+						Values: []any{
+							[]any{1435781480.622, "50"},
+							[]any{1435781481.622, "55"},
 						},
 					},
 					"bandwidth.in": {
-						Values: []interface{}{
-							[]interface{}{1435781490.622, "70"},
-							[]interface{}{1435781491.622, "75"},
+						Values: []any{
+							[]any{1435781490.622, "70"},
+							[]any{1435781491.622, "75"},
 						},
 					},
 					"bandwidth.out": {
-						Values: []interface{}{
-							[]interface{}{1435781590.622, "60"},
-							[]interface{}{1435781591.622, "65"},
+						Values: []any{
+							[]any{1435781590.622, "60"},
+							[]any{1435781591.622, "65"},
 						},
 					},
 				}

--- a/hcloud/rdns.go
+++ b/hcloud/rdns.go
@@ -29,14 +29,14 @@ func (c *RDNSClient) ChangeDNSPtr(ctx context.Context, rdns RDNSSupporter, ip ne
 }
 
 // SupportsRDNS checks if the object supports reverse dns functions.
-func SupportsRDNS(i interface{}) bool {
+func SupportsRDNS(i any) bool {
 	_, ok := i.(RDNSSupporter)
 	return ok
 }
 
 // RDNSLookup searches for the dns assigned to the given IP address.
 // It returns an error if the object does not support reverse dns or if there is no dns set for the given IP address.
-func RDNSLookup(i interface{}, ip net.IP) (string, error) {
+func RDNSLookup(i any, ip net.IP) (string, error) {
 	rdns, ok := i.(RDNSSupporter)
 	if !ok {
 		return "", fmt.Errorf("%+v does not support RDNS", i)

--- a/hcloud/schema/id_or_name.go
+++ b/hcloud/schema/id_or_name.go
@@ -53,14 +53,14 @@ func (o *IDOrName) UnmarshalJSON(data []byte) error {
 		if err != nil {
 			return &json.UnmarshalTypeError{
 				Value: string(data),
-				Type:  reflect.TypeOf(*o),
+				Type:  reflect.TypeFor[IDOrName](),
 			}
 		}
 		o.ID = id
 	default:
 		return &json.UnmarshalTypeError{
 			Value: string(data),
-			Type:  reflect.TypeOf(*o),
+			Type:  reflect.TypeFor[IDOrName](),
 		}
 	}
 

--- a/hcloud/schema/load_balancer.go
+++ b/hcloud/schema/load_balancer.go
@@ -402,7 +402,7 @@ type LoadBalancerGetMetricsResponse struct {
 // LoadBalancerTimeSeriesVals contains the values for a Load Balancer time
 // series.
 type LoadBalancerTimeSeriesVals struct {
-	Values []interface{} `json:"values"`
+	Values []any `json:"values"`
 }
 
 // LoadBalancerActionChangeDNSPtrRequest defines the schema for the request to

--- a/hcloud/schema/server.go
+++ b/hcloud/schema/server.go
@@ -419,7 +419,7 @@ type ServerGetMetricsResponse struct {
 
 // ServerTimeSeriesVals contains the values for a Server time series.
 type ServerTimeSeriesVals struct {
-	Values []interface{} `json:"values"`
+	Values []any `json:"values"`
 }
 
 // ServerActionAddToPlacementGroupRequest defines the schema for the request to

--- a/hcloud/schema_gen.go
+++ b/hcloud/schema_gen.go
@@ -717,7 +717,7 @@ func intSecondsFromDuration(d time.Duration) int {
 	return int(d.Seconds())
 }
 
-func errorDetailsFromSchema(d interface{}) interface{} {
+func errorDetailsFromSchema(d any) any {
 	switch typed := d.(type) {
 	case schema.ErrorDetailsInvalidInput:
 		details := ErrorDetailsInvalidInput{
@@ -739,7 +739,7 @@ func errorDetailsFromSchema(d interface{}) interface{} {
 	return nil
 }
 
-func schemaFromErrorDetails(d interface{}) interface{} {
+func schemaFromErrorDetails(d any) any {
 	switch typed := d.(type) {
 	case ErrorDetailsInvalidInput:
 		details := schema.ErrorDetailsInvalidInput{
@@ -933,7 +933,7 @@ func serverMetricsTimeSeriesFromSchema(s schema.ServerTimeSeriesVals) ([]ServerM
 	for i, rawVal := range s.Values {
 		var val ServerMetricsValue
 
-		tup, ok := rawVal.([]interface{})
+		tup, ok := rawVal.([]any)
 		if !ok {
 			return nil, fmt.Errorf("failed to convert value to tuple: %v", rawVal)
 		}
@@ -963,7 +963,7 @@ func loadBalancerMetricsTimeSeriesFromSchema(s schema.LoadBalancerTimeSeriesVals
 	for i, rawVal := range s.Values {
 		var val LoadBalancerMetricsValue
 
-		tup, ok := rawVal.([]interface{})
+		tup, ok := rawVal.([]any)
 		if !ok {
 			return nil, fmt.Errorf("failed to convert value to tuple: %v", rawVal)
 		}
@@ -1044,7 +1044,7 @@ func stringMapToStringMapPtr(m map[string]string) *map[string]string {
 	return &m
 }
 
-func rawSchemaFromErrorDetails(v interface{}) json.RawMessage {
+func rawSchemaFromErrorDetails(v any) json.RawMessage {
 	d := schemaFromErrorDetails(v)
 	if v == nil {
 		return nil

--- a/hcloud/schema_test.go
+++ b/hcloud/schema_test.go
@@ -1934,7 +1934,7 @@ func TestServerMetricsFromSchema(t *testing.T) {
 				resp.Metrics.End = mustParseTime(t, "2017-01-01T23:00:00Z")
 				resp.Metrics.TimeSeries = map[string]schema.ServerTimeSeriesVals{
 					"cpu": {
-						Values: []interface{}{"some value"},
+						Values: []any{"some value"},
 					},
 				}
 
@@ -1951,8 +1951,8 @@ func TestServerMetricsFromSchema(t *testing.T) {
 				resp.Metrics.End = mustParseTime(t, "2017-01-01T23:00:00Z")
 				resp.Metrics.TimeSeries = map[string]schema.ServerTimeSeriesVals{
 					"cpu": {
-						Values: []interface{}{
-							[]interface{}{1435781471.622, "43", "something else"},
+						Values: []any{
+							[]any{1435781471.622, "43", "something else"},
 						},
 					},
 				}
@@ -1970,8 +1970,8 @@ func TestServerMetricsFromSchema(t *testing.T) {
 				resp.Metrics.End = mustParseTime(t, "2017-01-01T23:00:00Z")
 				resp.Metrics.TimeSeries = map[string]schema.ServerTimeSeriesVals{
 					"cpu": {
-						Values: []interface{}{
-							[]interface{}{"1435781471.622", "43"},
+						Values: []any{
+							[]any{"1435781471.622", "43"},
 						},
 					},
 				}
@@ -1989,8 +1989,8 @@ func TestServerMetricsFromSchema(t *testing.T) {
 				resp.Metrics.End = mustParseTime(t, "2017-01-01T23:00:00Z")
 				resp.Metrics.TimeSeries = map[string]schema.ServerTimeSeriesVals{
 					"cpu": {
-						Values: []interface{}{
-							[]interface{}{1435781471.622, 43},
+						Values: []any{
+							[]any{1435781471.622, 43},
 						},
 					},
 				}
@@ -2008,33 +2008,33 @@ func TestServerMetricsFromSchema(t *testing.T) {
 				resp.Metrics.End = mustParseTime(t, "2017-01-01T23:00:00Z")
 				resp.Metrics.TimeSeries = map[string]schema.ServerTimeSeriesVals{
 					"cpu": {
-						Values: []interface{}{
-							[]interface{}{1435781470.622, "42"},
-							[]interface{}{1435781471.622, "43"},
+						Values: []any{
+							[]any{1435781470.622, "42"},
+							[]any{1435781471.622, "43"},
 						},
 					},
 					"disk.0.iops.read": {
-						Values: []interface{}{
-							[]interface{}{1435781480.622, "100"},
-							[]interface{}{1435781481.622, "150"},
+						Values: []any{
+							[]any{1435781480.622, "100"},
+							[]any{1435781481.622, "150"},
 						},
 					},
 					"disk.0.iops.write": {
-						Values: []interface{}{
-							[]interface{}{1435781480.622, "50"},
-							[]interface{}{1435781481.622, "55"},
+						Values: []any{
+							[]any{1435781480.622, "50"},
+							[]any{1435781481.622, "55"},
 						},
 					},
 					"network.0.pps.in": {
-						Values: []interface{}{
-							[]interface{}{1435781490.622, "70"},
-							[]interface{}{1435781491.622, "75"},
+						Values: []any{
+							[]any{1435781490.622, "70"},
+							[]any{1435781491.622, "75"},
 						},
 					},
 					"network.0.pps.out": {
-						Values: []interface{}{
-							[]interface{}{1435781590.622, "60"},
-							[]interface{}{1435781591.622, "65"},
+						Values: []any{
+							[]any{1435781590.622, "60"},
+							[]any{1435781591.622, "65"},
 						},
 					},
 				}
@@ -2103,7 +2103,7 @@ func TestLoadBalancerMetricsFromSchema(t *testing.T) {
 				resp.Metrics.End = mustParseTime(t, "2017-01-01T23:00:00Z")
 				resp.Metrics.TimeSeries = map[string]schema.LoadBalancerTimeSeriesVals{
 					"open_connections": {
-						Values: []interface{}{"some value"},
+						Values: []any{"some value"},
 					},
 				}
 
@@ -2120,8 +2120,8 @@ func TestLoadBalancerMetricsFromSchema(t *testing.T) {
 				resp.Metrics.End = mustParseTime(t, "2017-01-01T23:00:00Z")
 				resp.Metrics.TimeSeries = map[string]schema.LoadBalancerTimeSeriesVals{
 					"open_connections": {
-						Values: []interface{}{
-							[]interface{}{1435781471.622, "43", "something else"},
+						Values: []any{
+							[]any{1435781471.622, "43", "something else"},
 						},
 					},
 				}
@@ -2139,8 +2139,8 @@ func TestLoadBalancerMetricsFromSchema(t *testing.T) {
 				resp.Metrics.End = mustParseTime(t, "2017-01-01T23:00:00Z")
 				resp.Metrics.TimeSeries = map[string]schema.LoadBalancerTimeSeriesVals{
 					"open_connections": {
-						Values: []interface{}{
-							[]interface{}{"1435781471.622", "43"},
+						Values: []any{
+							[]any{"1435781471.622", "43"},
 						},
 					},
 				}
@@ -2158,8 +2158,8 @@ func TestLoadBalancerMetricsFromSchema(t *testing.T) {
 				resp.Metrics.End = mustParseTime(t, "2017-01-01T23:00:00Z")
 				resp.Metrics.TimeSeries = map[string]schema.LoadBalancerTimeSeriesVals{
 					"open_connections": {
-						Values: []interface{}{
-							[]interface{}{1435781471.622, 43},
+						Values: []any{
+							[]any{1435781471.622, 43},
 						},
 					},
 				}
@@ -2177,33 +2177,33 @@ func TestLoadBalancerMetricsFromSchema(t *testing.T) {
 				resp.Metrics.End = mustParseTime(t, "2017-01-01T23:00:00Z")
 				resp.Metrics.TimeSeries = map[string]schema.LoadBalancerTimeSeriesVals{
 					"open_connections": {
-						Values: []interface{}{
-							[]interface{}{1435781470.622, "42"},
-							[]interface{}{1435781471.622, "43"},
+						Values: []any{
+							[]any{1435781470.622, "42"},
+							[]any{1435781471.622, "43"},
 						},
 					},
 					"connections_per_second": {
-						Values: []interface{}{
-							[]interface{}{1435781480.622, "100"},
-							[]interface{}{1435781481.622, "150"},
+						Values: []any{
+							[]any{1435781480.622, "100"},
+							[]any{1435781481.622, "150"},
 						},
 					},
 					"requests_per_second": {
-						Values: []interface{}{
-							[]interface{}{1435781480.622, "50"},
-							[]interface{}{1435781481.622, "55"},
+						Values: []any{
+							[]any{1435781480.622, "50"},
+							[]any{1435781481.622, "55"},
 						},
 					},
 					"bandwidth.in": {
-						Values: []interface{}{
-							[]interface{}{1435781490.622, "70"},
-							[]interface{}{1435781491.622, "75"},
+						Values: []any{
+							[]any{1435781490.622, "70"},
+							[]any{1435781491.622, "75"},
 						},
 					},
 					"bandwidth.out": {
-						Values: []interface{}{
-							[]interface{}{1435781590.622, "60"},
-							[]interface{}{1435781591.622, "65"},
+						Values: []any{
+							[]any{1435781590.622, "60"},
+							[]any{1435781591.622, "65"},
 						},
 					},
 				}

--- a/hcloud/server_test.go
+++ b/hcloud/server_test.go
@@ -2358,9 +2358,9 @@ func TestServerGetMetrics(t *testing.T) {
 				resp.Metrics.End = mustParseTime(t, "2017-01-01T23:00:00Z")
 				resp.Metrics.TimeSeries = map[string]schema.ServerTimeSeriesVals{
 					"cpu": {
-						Values: []interface{}{
-							[]interface{}{1435781470.622, "42"},
-							[]interface{}{1435781471.622, "43"},
+						Values: []any{
+							[]any{1435781470.622, "42"},
+							[]any{1435781471.622, "43"},
 						},
 					},
 				}
@@ -2397,33 +2397,33 @@ func TestServerGetMetrics(t *testing.T) {
 				resp.Metrics.End = mustParseTime(t, "2017-01-01T23:00:00Z")
 				resp.Metrics.TimeSeries = map[string]schema.ServerTimeSeriesVals{
 					"cpu": {
-						Values: []interface{}{
-							[]interface{}{1435781470.622, "42"},
-							[]interface{}{1435781471.622, "43"},
+						Values: []any{
+							[]any{1435781470.622, "42"},
+							[]any{1435781471.622, "43"},
 						},
 					},
 					"disk.0.iops.read": {
-						Values: []interface{}{
-							[]interface{}{1435781480.622, "100"},
-							[]interface{}{1435781481.622, "150"},
+						Values: []any{
+							[]any{1435781480.622, "100"},
+							[]any{1435781481.622, "150"},
 						},
 					},
 					"disk.0.iops.write": {
-						Values: []interface{}{
-							[]interface{}{1435781480.622, "50"},
-							[]interface{}{1435781481.622, "55"},
+						Values: []any{
+							[]any{1435781480.622, "50"},
+							[]any{1435781481.622, "55"},
 						},
 					},
 					"network.0.pps.in": {
-						Values: []interface{}{
-							[]interface{}{1435781490.622, "70"},
-							[]interface{}{1435781491.622, "75"},
+						Values: []any{
+							[]any{1435781490.622, "70"},
+							[]any{1435781491.622, "75"},
 						},
 					},
 					"network.0.pps.out": {
-						Values: []interface{}{
-							[]interface{}{1435781590.622, "60"},
-							[]interface{}{1435781591.622, "65"},
+						Values: []any{
+							[]any{1435781590.622, "60"},
+							[]any{1435781591.622, "65"},
 						},
 					},
 				}


### PR DESCRIPTION
For a more detailed explanation of `go fix`, see https://go.dev/blog/gofix
Note: This replaces all uses of `interface{}` in our public API with `any`. This should not be a problem, since they are equivalent as per the Go docs: https://pkg.go.dev/builtin#any
Since we currently require Go 1.25 in `go.mod` and `any` has been available since Go 1.18, this does not force a Go upgrade for consumers.