### PR TITLE
feat(metadata): add context-aware Client methods

### DIFF
--- a/hcloud/metadata/client.go
+++ b/hcloud/metadata/client.go
@@ -81,8 +81,8 @@ func NewClient(options ...ClientOption) *Client {
 }
 
 // get executes an HTTP request against the API.
-func (c *Client) get(path string) (string, error) {
-	ctx := ctxutil.SetOpPath(context.Background(), path)
+func (c *Client) get(ctx context.Context, path string) (string, error) {
+	ctx = ctxutil.SetOpPath(ctx, path)
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.endpoint+path, http.NoBody)
 	if err != nil {
@@ -110,25 +110,44 @@ func (c *Client) get(path string) (string, error) {
 
 // IsHcloudServer checks if the currently called server is a hcloud server by calling a metadata endpoint
 // if the endpoint answers with a non-empty value this method returns true, otherwise false.
+//
+// Deprecated: Use [Client.IsHcloudServerWithContext] instead so callers can control the request lifecycle.
 func (c *Client) IsHcloudServer() bool {
-	hostname, err := c.Hostname()
+	return c.IsHcloudServerWithContext(context.Background())
+}
+
+// IsHcloudServerWithContext checks if the currently called server is a hcloud server by calling a metadata
+// endpoint. If the endpoint answers with a non-empty value this method returns true, otherwise false.
+func (c *Client) IsHcloudServerWithContext(ctx context.Context) bool {
+	hostname, err := c.HostnameWithContext(ctx)
 	if err != nil {
 		return false
 	}
-	if len(hostname) > 0 {
-		return true
-	}
-	return false
+	return len(hostname) > 0
 }
 
 // Hostname returns the hostname of the server that did the request to the Metadata server.
+//
+// Deprecated: Use [Client.HostnameWithContext] instead so callers can control the request lifecycle.
 func (c *Client) Hostname() (string, error) {
-	return c.get("/hostname")
+	return c.HostnameWithContext(context.Background())
+}
+
+// HostnameWithContext returns the hostname of the server that did the request to the Metadata server.
+func (c *Client) HostnameWithContext(ctx context.Context) (string, error) {
+	return c.get(ctx, "/hostname")
 }
 
 // InstanceID returns the ID of the server that did the request to the Metadata server.
+//
+// Deprecated: Use [Client.InstanceIDWithContext] instead so callers can control the request lifecycle.
 func (c *Client) InstanceID() (int64, error) {
-	resp, err := c.get("/instance-id")
+	return c.InstanceIDWithContext(context.Background())
+}
+
+// InstanceIDWithContext returns the ID of the server that did the request to the Metadata server.
+func (c *Client) InstanceIDWithContext(ctx context.Context) (int64, error) {
+	resp, err := c.get(ctx, "/instance-id")
 	if err != nil {
 		return 0, err
 	}
@@ -136,8 +155,15 @@ func (c *Client) InstanceID() (int64, error) {
 }
 
 // PublicIPv4 returns the Public IPv4 of the server that did the request to the Metadata server.
+//
+// Deprecated: Use [Client.PublicIPv4WithContext] instead so callers can control the request lifecycle.
 func (c *Client) PublicIPv4() (net.IP, error) {
-	resp, err := c.get("/public-ipv4")
+	return c.PublicIPv4WithContext(context.Background())
+}
+
+// PublicIPv4WithContext returns the Public IPv4 of the server that did the request to the Metadata server.
+func (c *Client) PublicIPv4WithContext(ctx context.Context) (net.IP, error) {
+	resp, err := c.get(ctx, "/public-ipv4")
 	if err != nil {
 		return nil, err
 	}
@@ -145,17 +171,39 @@ func (c *Client) PublicIPv4() (net.IP, error) {
 }
 
 // Region returns the Network Zone of the server that did the request to the Metadata server.
+//
+// Deprecated: Use [Client.RegionWithContext] instead so callers can control the request lifecycle.
 func (c *Client) Region() (string, error) {
-	return c.get("/region")
+	return c.RegionWithContext(context.Background())
+}
+
+// RegionWithContext returns the Network Zone of the server that did the request to the Metadata server.
+func (c *Client) RegionWithContext(ctx context.Context) (string, error) {
+	return c.get(ctx, "/region")
 }
 
 // AvailabilityZone returns the datacenter of the server that did the request to the Metadata server.
+//
+// Deprecated: Use [Client.AvailabilityZoneWithContext] instead so callers can control the request lifecycle.
 func (c *Client) AvailabilityZone() (string, error) {
-	return c.get("/availability-zone")
+	return c.AvailabilityZoneWithContext(context.Background())
+}
+
+// AvailabilityZoneWithContext returns the datacenter of the server that did the request to the Metadata server.
+func (c *Client) AvailabilityZoneWithContext(ctx context.Context) (string, error) {
+	return c.get(ctx, "/availability-zone")
 }
 
 // PrivateNetworks returns details about the private networks the server is attached to.
 // Returns YAML (unparsed).
+//
+// Deprecated: Use [Client.PrivateNetworksWithContext] instead so callers can control the request lifecycle.
 func (c *Client) PrivateNetworks() (string, error) {
-	return c.get("/private-networks")
+	return c.PrivateNetworksWithContext(context.Background())
+}
+
+// PrivateNetworksWithContext returns details about the private networks the server is attached to.
+// Returns YAML (unparsed).
+func (c *Client) PrivateNetworksWithContext(ctx context.Context) (string, error) {
+	return c.get(ctx, "/private-networks")
 }

--- a/hcloud/metadata/client_test.go
+++ b/hcloud/metadata/client_test.go
@@ -2,7 +2,6 @@ package metadata
 
 import (
 	"context"
-	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -88,7 +87,7 @@ func TestClient_GetRespectsContext(t *testing.T) {
 
 	_, err := env.Client.get(ctx, "/blocks")
 	require.Error(t, err)
-	assert.True(t, errors.Is(err, context.Canceled), "got %v", err)
+	assert.ErrorIs(t, err, context.Canceled)
 }
 
 func TestClient_HostnameWithContext(t *testing.T) {
@@ -118,7 +117,7 @@ func TestClient_HostnameWithContext_Cancelled(t *testing.T) {
 
 	_, err := env.Client.HostnameWithContext(ctx)
 	require.Error(t, err)
-	assert.True(t, errors.Is(err, context.DeadlineExceeded), "got %v", err)
+	assert.ErrorIs(t, err, context.DeadlineExceeded)
 }
 
 func TestClient_IsHcloudServer(t *testing.T) {

--- a/hcloud/metadata/client_test.go
+++ b/hcloud/metadata/client_test.go
@@ -1,9 +1,12 @@
 package metadata
 
 import (
+	"context"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/assert"
@@ -54,18 +57,68 @@ func TestClient_Base(t *testing.T) {
 		w.Write([]byte("not found"))
 	})
 
-	if body, err := env.Client.get("/ok"); assert.NoError(t, err) {
+	ctx := context.Background()
+	if body, err := env.Client.get(ctx, "/ok"); assert.NoError(t, err) {
 		assert.Equal(t, "ok", body)
 	}
-	if body, err := env.Client.get("/sanitized"); assert.NoError(t, err) {
+	if body, err := env.Client.get(ctx, "/sanitized"); assert.NoError(t, err) {
 		assert.Equal(t, "sanitized", body)
 	}
-	if body, err := env.Client.get("/no-content"); assert.NoError(t, err) {
+	if body, err := env.Client.get(ctx, "/no-content"); assert.NoError(t, err) {
 		assert.Empty(t, body)
 	}
-	if body, err := env.Client.get("/not-found"); assert.EqualError(t, err, "response status was 404") {
+	if body, err := env.Client.get(ctx, "/not-found"); assert.EqualError(t, err, "response status was 404") {
 		assert.Equal(t, "not found", body)
 	}
+}
+
+func TestClient_GetRespectsContext(t *testing.T) {
+	env := newTestEnv()
+	blocked := make(chan struct{})
+	defer close(blocked)
+	env.Mux.HandleFunc("/blocks", func(_ http.ResponseWriter, r *http.Request) {
+		select {
+		case <-blocked:
+		case <-r.Context().Done():
+		}
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := env.Client.get(ctx, "/blocks")
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, context.Canceled), "got %v", err)
+}
+
+func TestClient_HostnameWithContext(t *testing.T) {
+	env := newTestEnv()
+	env.Mux.HandleFunc("/hostname", func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("my-server"))
+	})
+
+	hostname, err := env.Client.HostnameWithContext(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, "my-server", hostname)
+}
+
+func TestClient_HostnameWithContext_Cancelled(t *testing.T) {
+	env := newTestEnv()
+	blocked := make(chan struct{})
+	defer close(blocked)
+	env.Mux.HandleFunc("/hostname", func(_ http.ResponseWriter, r *http.Request) {
+		select {
+		case <-blocked:
+		case <-r.Context().Done():
+		}
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	_, err := env.Client.HostnameWithContext(ctx)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, context.DeadlineExceeded), "got %v", err)
 }
 
 func TestClient_IsHcloudServer(t *testing.T) {


### PR DESCRIPTION
The metadata `Client` methods build their HTTP requests with `context.Background()` internally, so callers can't propagate deadlines or cancellations. This came up while wiring the Hetzner detector in opentelemetry-go-contrib: `resource.Detector` receives a context and has no way to forward it, so the workaround in [open-telemetry/opentelemetry-go-contrib#8999](https://github.com/open-telemetry/opentelemetry-go-contrib/pull/8999) is a goroutine + `select` on `ctx.Done()`. The contrib maintainers said they'd rather wait for the fix to live here.

This adds `XxxWithContext` variants for each public method (`HostnameWithContext`, `InstanceIDWithContext`, `PublicIPv4WithContext`, `RegionWithContext`, `AvailabilityZoneWithContext`, `PrivateNetworksWithContext`, and `IsHcloudServerWithContext`) and threads a `ctx` parameter through the internal `get`. The original no-arg methods keep working, they just wrap the new ones with `context.Background()`. I marked them `Deprecated:` to nudge new code over, matching the style used in `action.go` and elsewhere, but happy to drop those if you'd rather keep the existing API undeprecated and revisit in a major version.

Tests cover the new happy path, a cancelled-context case on `get`, and a deadline-exceeded case on `HostnameWithContext`.

Closes #851.