### PR TITLE
refactor: replace interface{} with any (Go 1.18+)

### DIFF
--- a/hcloud/schema/id_or_name.go
+++ b/hcloud/schema/id_or_name.go
@@ -25,7 +25,7 @@ func (o IDOrName) MarshalJSON() ([]byte, error) {
 		return json.Marshal(o.Name)
 	}
 
-	// We want to preserve the behavior of an empty interface{} to prevent breaking
+	// We want to preserve the behavior of an empty any to prevent breaking
 	// changes (marshaled to null when empty).
 	return json.Marshal(nil)
 }

--- a/hcloud/schema/id_or_name_test.go
+++ b/hcloud/schema/id_or_name_test.go
@@ -78,7 +78,7 @@ func TestIDOrNameUnMarshall(t *testing.T) {
 }
 
 func TestIDOrName(t *testing.T) {
-	// Make sure the behavior does not change from the use of an interface{}.
+	// Make sure the behavior does not change from the use of an any.
 	type FakeRequest struct {
 		Old any      `json:"old"`
 		New IDOrName `json:"new"`


### PR DESCRIPTION
Replace `interface{}` with `any` (the Go 1.18+ type alias) in comments for consistency with modern Go idioms.