### PR TITLE
feat: export list opts Values() methods

### DIFF
--- a/hcloud/action.go
+++ b/hcloud/action.go
@@ -109,7 +109,7 @@ type ActionListOpts struct {
 	Sort   []string
 }
 
-func (l ActionListOpts) values() url.Values {
+func (l ActionListOpts) Values() url.Values {
 	vals := l.ListOpts.Values()
 	for _, id := range l.ID {
 		vals.Add("id", fmt.Sprintf("%d", id))
@@ -188,7 +188,7 @@ func (c *ResourceActionClient[R]) List(ctx context.Context, opts ActionListOpts)
 	opPath := c.getBaseURL() + "/actions?%s"
 	ctx = ctxutil.SetOpPath(ctx, opPath)
 
-	reqPath := fmt.Sprintf(opPath, opts.values().Encode())
+	reqPath := fmt.Sprintf(opPath, opts.Values().Encode())
 
 	respBody, resp, err := getRequest[schema.ActionListResponse](ctx, c.client, reqPath)
 	if err != nil {
@@ -232,7 +232,7 @@ func (c *ResourceActionClient[R]) ListFor(ctx context.Context, resource R, opts 
 		return nil, nil, invalidArgument("resource", resource, err)
 	}
 
-	reqPath := fmt.Sprintf(opPath, id, opts.values().Encode())
+	reqPath := fmt.Sprintf(opPath, id, opts.Values().Encode())
 
 	respBody, resp, err := getRequest[schema.ActionListResponse](ctx, c.client, reqPath)
 	if err != nil {

--- a/hcloud/certificate.go
+++ b/hcloud/certificate.go
@@ -134,7 +134,7 @@ type CertificateListOpts struct {
 	Sort []string
 }
 
-func (l CertificateListOpts) values() url.Values {
+func (l CertificateListOpts) Values() url.Values {
 	vals := l.ListOpts.Values()
 	if l.Name != "" {
 		vals.Add("name", l.Name)
@@ -153,7 +153,7 @@ func (c *CertificateClient) List(ctx context.Context, opts CertificateListOpts) 
 	const opPath = "/certificates?%s"
 	ctx = ctxutil.SetOpPath(ctx, opPath)
 
-	reqPath := fmt.Sprintf(opPath, opts.values().Encode())
+	reqPath := fmt.Sprintf(opPath, opts.Values().Encode())
 
 	respBody, resp, err := getRequest[schema.CertificateListResponse](ctx, c.client, reqPath)
 	if err != nil {

--- a/hcloud/datacenter.go
+++ b/hcloud/datacenter.go
@@ -78,7 +78,7 @@ type DatacenterListOpts struct {
 	Sort []string
 }
 
-func (l DatacenterListOpts) values() url.Values {
+func (l DatacenterListOpts) Values() url.Values {
 	vals := l.ListOpts.Values()
 	if l.Name != "" {
 		vals.Add("name", l.Name)
@@ -97,7 +97,7 @@ func (c *DatacenterClient) List(ctx context.Context, opts DatacenterListOpts) ([
 	const opPath = "/datacenters?%s"
 	ctx = ctxutil.SetOpPath(ctx, opPath)
 
-	reqPath := fmt.Sprintf(opPath, opts.values().Encode())
+	reqPath := fmt.Sprintf(opPath, opts.Values().Encode())
 
 	respBody, resp, err := getRequest[schema.DatacenterListResponse](ctx, c.client, reqPath)
 	if err != nil {

--- a/hcloud/firewall.go
+++ b/hcloud/firewall.go
@@ -140,7 +140,7 @@ type FirewallListOpts struct {
 	Sort []string
 }
 
-func (l FirewallListOpts) values() url.Values {
+func (l FirewallListOpts) Values() url.Values {
 	vals := l.ListOpts.Values()
 	if l.Name != "" {
 		vals.Add("name", l.Name)
@@ -159,7 +159,7 @@ func (c *FirewallClient) List(ctx context.Context, opts FirewallListOpts) ([]*Fi
 	const opPath = "/firewalls?%s"
 	ctx = ctxutil.SetOpPath(ctx, opPath)
 
-	reqPath := fmt.Sprintf(opPath, opts.values().Encode())
+	reqPath := fmt.Sprintf(opPath, opts.Values().Encode())
 
 	respBody, resp, err := getRequest[schema.FirewallListResponse](ctx, c.client, reqPath)
 	if err != nil {

--- a/hcloud/floating_ip.go
+++ b/hcloud/floating_ip.go
@@ -134,7 +134,7 @@ type FloatingIPListOpts struct {
 	Sort []string
 }
 
-func (l FloatingIPListOpts) values() url.Values {
+func (l FloatingIPListOpts) Values() url.Values {
 	vals := l.ListOpts.Values()
 	if l.Name != "" {
 		vals.Add("name", l.Name)
@@ -153,7 +153,7 @@ func (c *FloatingIPClient) List(ctx context.Context, opts FloatingIPListOpts) ([
 	const opPath = "/floating_ips?%s"
 	ctx = ctxutil.SetOpPath(ctx, opPath)
 
-	reqPath := fmt.Sprintf(opPath, opts.values().Encode())
+	reqPath := fmt.Sprintf(opPath, opts.Values().Encode())
 
 	respBody, resp, err := getRequest[schema.FloatingIPListResponse](ctx, c.client, reqPath)
 	if err != nil {

--- a/hcloud/image.go
+++ b/hcloud/image.go
@@ -159,7 +159,7 @@ type ImageListOpts struct {
 	Architecture      []Architecture
 }
 
-func (l ImageListOpts) values() url.Values {
+func (l ImageListOpts) Values() url.Values {
 	vals := l.ListOpts.Values()
 	for _, typ := range l.Type {
 		vals.Add("type", string(typ))
@@ -193,7 +193,7 @@ func (c *ImageClient) List(ctx context.Context, opts ImageListOpts) ([]*Image, *
 	const opPath = "/images?%s"
 	ctx = ctxutil.SetOpPath(ctx, opPath)
 
-	reqPath := fmt.Sprintf(opPath, opts.values().Encode())
+	reqPath := fmt.Sprintf(opPath, opts.Values().Encode())
 
 	respBody, resp, err := getRequest[schema.ImageListResponse](ctx, c.client, reqPath)
 	if err != nil {

--- a/hcloud/iso.go
+++ b/hcloud/iso.go
@@ -86,7 +86,7 @@ type ISOListOpts struct {
 	IncludeArchitectureWildcard bool
 }
 
-func (l ISOListOpts) values() url.Values {
+func (l ISOListOpts) Values() url.Values {
 	vals := l.ListOpts.Values()
 	if l.Name != "" {
 		vals.Add("name", l.Name)
@@ -111,7 +111,7 @@ func (c *ISOClient) List(ctx context.Context, opts ISOListOpts) ([]*ISO, *Respon
 	const opPath = "/isos?%s"
 	ctx = ctxutil.SetOpPath(ctx, opPath)
 
-	reqPath := fmt.Sprintf(opPath, opts.values().Encode())
+	reqPath := fmt.Sprintf(opPath, opts.Values().Encode())
 
 	respBody, resp, err := getRequest[schema.ISOListResponse](ctx, c.client, reqPath)
 	if err != nil {

--- a/hcloud/load_balancer.go
+++ b/hcloud/load_balancer.go
@@ -293,7 +293,7 @@ type LoadBalancerListOpts struct {
 	Sort []string
 }
 
-func (l LoadBalancerListOpts) values() url.Values {
+func (l LoadBalancerListOpts) Values() url.Values {
 	vals := l.ListOpts.Values()
 	if l.Name != "" {
 		vals.Add("name", l.Name)
@@ -312,7 +312,7 @@ func (c *LoadBalancerClient) List(ctx context.Context, opts LoadBalancerListOpts
 	const opPath = "/load_balancers?%s"
 	ctx = ctxutil.SetOpPath(ctx, opPath)
 
-	reqPath := fmt.Sprintf(opPath, opts.values().Encode())
+	reqPath := fmt.Sprintf(opPath, opts.Values().Encode())
 
 	respBody, resp, err := getRequest[schema.LoadBalancerListResponse](ctx, c.client, reqPath)
 	if err != nil {
@@ -933,7 +933,7 @@ func (o LoadBalancerGetMetricsOpts) Validate() error {
 	return nil
 }
 
-func (o LoadBalancerGetMetricsOpts) values() url.Values {
+func (o LoadBalancerGetMetricsOpts) Values() url.Values {
 	query := url.Values{}
 
 	for _, typ := range o.Types {
@@ -979,7 +979,7 @@ func (c *LoadBalancerClient) GetMetrics(
 		return nil, nil, err
 	}
 
-	reqPath := fmt.Sprintf(opPath, loadBalancer.ID, opts.values().Encode())
+	reqPath := fmt.Sprintf(opPath, loadBalancer.ID, opts.Values().Encode())
 
 	respBody, resp, err := getRequest[schema.LoadBalancerGetMetricsResponse](ctx, c.client, reqPath)
 	if err != nil {

--- a/hcloud/load_balancer_type.go
+++ b/hcloud/load_balancer_type.go
@@ -69,7 +69,7 @@ type LoadBalancerTypeListOpts struct {
 	Sort []string
 }
 
-func (l LoadBalancerTypeListOpts) values() url.Values {
+func (l LoadBalancerTypeListOpts) Values() url.Values {
 	vals := l.ListOpts.Values()
 	if l.Name != "" {
 		vals.Add("name", l.Name)
@@ -88,7 +88,7 @@ func (c *LoadBalancerTypeClient) List(ctx context.Context, opts LoadBalancerType
 	const opPath = "/load_balancer_types?%s"
 	ctx = ctxutil.SetOpPath(ctx, opPath)
 
-	reqPath := fmt.Sprintf(opPath, opts.values().Encode())
+	reqPath := fmt.Sprintf(opPath, opts.Values().Encode())
 
 	respBody, resp, err := getRequest[schema.LoadBalancerTypeListResponse](ctx, c.client, reqPath)
 	if err != nil {

--- a/hcloud/location.go
+++ b/hcloud/location.go
@@ -68,7 +68,7 @@ type LocationListOpts struct {
 	Sort []string
 }
 
-func (l LocationListOpts) values() url.Values {
+func (l LocationListOpts) Values() url.Values {
 	vals := l.ListOpts.Values()
 	if l.Name != "" {
 		vals.Add("name", l.Name)
@@ -87,7 +87,7 @@ func (c *LocationClient) List(ctx context.Context, opts LocationListOpts) ([]*Lo
 	const opPath = "/locations?%s"
 	ctx = ctxutil.SetOpPath(ctx, opPath)
 
-	reqPath := fmt.Sprintf(opPath, opts.values().Encode())
+	reqPath := fmt.Sprintf(opPath, opts.Values().Encode())
 
 	respBody, resp, err := getRequest[schema.LocationListResponse](ctx, c.client, reqPath)
 	if err != nil {

--- a/hcloud/network.go
+++ b/hcloud/network.go
@@ -128,7 +128,7 @@ type NetworkListOpts struct {
 	Sort []string
 }
 
-func (l NetworkListOpts) values() url.Values {
+func (l NetworkListOpts) Values() url.Values {
 	vals := l.ListOpts.Values()
 	if l.Name != "" {
 		vals.Add("name", l.Name)
@@ -147,7 +147,7 @@ func (c *NetworkClient) List(ctx context.Context, opts NetworkListOpts) ([]*Netw
 	const opPath = "/networks?%s"
 	ctx = ctxutil.SetOpPath(ctx, opPath)
 
-	reqPath := fmt.Sprintf(opPath, opts.values().Encode())
+	reqPath := fmt.Sprintf(opPath, opts.Values().Encode())
 
 	respBody, resp, err := getRequest[schema.NetworkListResponse](ctx, c.client, reqPath)
 	if err != nil {

--- a/hcloud/placement_group.go
+++ b/hcloud/placement_group.go
@@ -72,7 +72,7 @@ type PlacementGroupListOpts struct {
 	Sort []string
 }
 
-func (l PlacementGroupListOpts) values() url.Values {
+func (l PlacementGroupListOpts) Values() url.Values {
 	vals := l.ListOpts.Values()
 	if l.Name != "" {
 		vals.Add("name", l.Name)
@@ -94,7 +94,7 @@ func (c *PlacementGroupClient) List(ctx context.Context, opts PlacementGroupList
 	const opPath = "/placement_groups?%s"
 	ctx = ctxutil.SetOpPath(ctx, opPath)
 
-	reqPath := fmt.Sprintf(opPath, opts.values().Encode())
+	reqPath := fmt.Sprintf(opPath, opts.Values().Encode())
 
 	respBody, resp, err := getRequest[schema.PlacementGroupListResponse](ctx, c.client, reqPath)
 	if err != nil {

--- a/hcloud/primary_ip.go
+++ b/hcloud/primary_ip.go
@@ -220,7 +220,7 @@ type PrimaryIPListOpts struct {
 	Sort []string
 }
 
-func (l PrimaryIPListOpts) values() url.Values {
+func (l PrimaryIPListOpts) Values() url.Values {
 	vals := l.ListOpts.Values()
 	if l.Name != "" {
 		vals.Add("name", l.Name)
@@ -242,7 +242,7 @@ func (c *PrimaryIPClient) List(ctx context.Context, opts PrimaryIPListOpts) ([]*
 	const opPath = "/primary_ips?%s"
 	ctx = ctxutil.SetOpPath(ctx, opPath)
 
-	reqPath := fmt.Sprintf(opPath, opts.values().Encode())
+	reqPath := fmt.Sprintf(opPath, opts.Values().Encode())
 
 	respBody, resp, err := getRequest[schema.PrimaryIPListResponse](ctx, c.client, reqPath)
 	if err != nil {

--- a/hcloud/server.go
+++ b/hcloud/server.go
@@ -252,7 +252,7 @@ type ServerListOpts struct {
 	Sort   []string
 }
 
-func (l ServerListOpts) values() url.Values {
+func (l ServerListOpts) Values() url.Values {
 	vals := l.ListOpts.Values()
 	if l.Name != "" {
 		vals.Add("name", l.Name)
@@ -274,7 +274,7 @@ func (c *ServerClient) List(ctx context.Context, opts ServerListOpts) ([]*Server
 	const opPath = "/servers?%s"
 	ctx = ctxutil.SetOpPath(ctx, opPath)
 
-	reqPath := fmt.Sprintf(opPath, opts.values().Encode())
+	reqPath := fmt.Sprintf(opPath, opts.Values().Encode())
 
 	respBody, resp, err := getRequest[schema.ServerListResponse](ctx, c.client, reqPath)
 	if err != nil {
@@ -1055,7 +1055,7 @@ func (o ServerGetMetricsOpts) Validate() error {
 	return nil
 }
 
-func (o ServerGetMetricsOpts) values() url.Values {
+func (o ServerGetMetricsOpts) Values() url.Values {
 	query := url.Values{}
 
 	for _, typ := range o.Types {
@@ -1099,7 +1099,7 @@ func (c *ServerClient) GetMetrics(ctx context.Context, server *Server, opts Serv
 		return nil, nil, err
 	}
 
-	reqPath := fmt.Sprintf(opPath, server.ID, opts.values().Encode())
+	reqPath := fmt.Sprintf(opPath, server.ID, opts.Values().Encode())
 
 	respBody, resp, err := getRequest[schema.ServerGetMetricsResponse](ctx, c.client, reqPath)
 	if err != nil {

--- a/hcloud/server_type.go
+++ b/hcloud/server_type.go
@@ -110,7 +110,7 @@ type ServerTypeListOpts struct {
 	Sort []string
 }
 
-func (l ServerTypeListOpts) values() url.Values {
+func (l ServerTypeListOpts) Values() url.Values {
 	vals := l.ListOpts.Values()
 	if l.Name != "" {
 		vals.Add("name", l.Name)
@@ -129,7 +129,7 @@ func (c *ServerTypeClient) List(ctx context.Context, opts ServerTypeListOpts) ([
 	const opPath = "/server_types?%s"
 	ctx = ctxutil.SetOpPath(ctx, opPath)
 
-	reqPath := fmt.Sprintf(opPath, opts.values().Encode())
+	reqPath := fmt.Sprintf(opPath, opts.Values().Encode())
 
 	respBody, resp, err := getRequest[schema.ServerTypeListResponse](ctx, c.client, reqPath)
 	if err != nil {

--- a/hcloud/ssh_key.go
+++ b/hcloud/ssh_key.go
@@ -71,7 +71,7 @@ type SSHKeyListOpts struct {
 	Sort        []string
 }
 
-func (l SSHKeyListOpts) values() url.Values {
+func (l SSHKeyListOpts) Values() url.Values {
 	vals := l.ListOpts.Values()
 	if l.Name != "" {
 		vals.Add("name", l.Name)
@@ -93,7 +93,7 @@ func (c *SSHKeyClient) List(ctx context.Context, opts SSHKeyListOpts) ([]*SSHKey
 	const opPath = "/ssh_keys?%s"
 	ctx = ctxutil.SetOpPath(ctx, opPath)
 
-	reqPath := fmt.Sprintf(opPath, opts.values().Encode())
+	reqPath := fmt.Sprintf(opPath, opts.Values().Encode())
 
 	respBody, resp, err := getRequest[schema.SSHKeyListResponse](ctx, c.client, reqPath)
 	if err != nil {

--- a/hcloud/storage_box.go
+++ b/hcloud/storage_box.go
@@ -141,7 +141,7 @@ type StorageBoxListOpts struct {
 	Sort []string
 }
 
-func (l StorageBoxListOpts) values() url.Values {
+func (l StorageBoxListOpts) Values() url.Values {
 	vals := l.ListOpts.Values()
 	if l.Name != "" {
 		vals.Add("name", l.Name)
@@ -162,7 +162,7 @@ func (c *StorageBoxClient) List(ctx context.Context, opts StorageBoxListOpts) ([
 	const opPath = "/storage_boxes?%s"
 	ctx = ctxutil.SetOpPath(ctx, opPath)
 
-	reqPath := fmt.Sprintf(opPath, opts.values().Encode())
+	reqPath := fmt.Sprintf(opPath, opts.Values().Encode())
 
 	respBody, resp, err := getRequest[schema.StorageBoxListResponse](ctx, c.client, reqPath)
 	if err != nil {
@@ -317,7 +317,7 @@ type StorageBoxFoldersOpts struct {
 	Path string
 }
 
-func (o StorageBoxFoldersOpts) values() url.Values {
+func (o StorageBoxFoldersOpts) Values() url.Values {
 	vals := url.Values{}
 	if o.Path != "" {
 		vals.Add("path", o.Path)
@@ -332,7 +332,7 @@ func (c *StorageBoxClient) Folders(ctx context.Context, storageBox *StorageBox, 
 	const opPath = "/storage_boxes/%d/folders?%s"
 	ctx = ctxutil.SetOpPath(ctx, opPath)
 
-	reqPath := fmt.Sprintf(opPath, storageBox.ID, opts.values().Encode())
+	reqPath := fmt.Sprintf(opPath, storageBox.ID, opts.Values().Encode())
 
 	result := StorageBoxFoldersResult{}
 

--- a/hcloud/storage_box_snapshot.go
+++ b/hcloud/storage_box_snapshot.go
@@ -93,7 +93,7 @@ type StorageBoxSnapshotListOpts struct {
 	Sort          []string
 }
 
-func (o StorageBoxSnapshotListOpts) values() url.Values {
+func (o StorageBoxSnapshotListOpts) Values() url.Values {
 	vals := url.Values{}
 	if o.LabelSelector != "" {
 		vals.Set("label_selector", o.LabelSelector)
@@ -123,7 +123,7 @@ func (c *StorageBoxClient) ListSnapshots(
 	const optPath = "/storage_boxes/%d/snapshots?%s"
 	ctx = ctxutil.SetOpPath(ctx, optPath)
 
-	reqPath := fmt.Sprintf(optPath, storageBox.ID, opts.values().Encode())
+	reqPath := fmt.Sprintf(optPath, storageBox.ID, opts.Values().Encode())
 
 	respBody, resp, err := getRequest[schema.StorageBoxSnapshotListResponse](ctx, c.client, reqPath)
 	if err != nil {

--- a/hcloud/storage_box_subaccount.go
+++ b/hcloud/storage_box_subaccount.go
@@ -119,7 +119,7 @@ type StorageBoxSubaccountListOpts struct {
 	Sort          []string
 }
 
-func (o StorageBoxSubaccountListOpts) values() url.Values {
+func (o StorageBoxSubaccountListOpts) Values() url.Values {
 	vals := url.Values{}
 	if o.Name != "" {
 		vals.Add("name", o.Name)
@@ -147,7 +147,7 @@ func (c *StorageBoxClient) ListSubaccounts(
 	const opPath = "/storage_boxes/%d/subaccounts?%s"
 	ctx = ctxutil.SetOpPath(ctx, opPath)
 
-	reqPath := fmt.Sprintf(opPath, storageBox.ID, opts.values().Encode())
+	reqPath := fmt.Sprintf(opPath, storageBox.ID, opts.Values().Encode())
 
 	respBody, resp, err := getRequest[schema.StorageBoxSubaccountListResponse](ctx, c.client, reqPath)
 	if err != nil {

--- a/hcloud/storage_box_type.go
+++ b/hcloud/storage_box_type.go
@@ -44,7 +44,7 @@ type StorageBoxTypeListOpts struct {
 	Name string
 }
 
-func (l StorageBoxTypeListOpts) values() url.Values {
+func (l StorageBoxTypeListOpts) Values() url.Values {
 	vals := l.ListOpts.Values()
 	if l.Name != "" {
 		vals.Add("name", l.Name)
@@ -59,7 +59,7 @@ func (c *StorageBoxTypeClient) List(ctx context.Context, opts StorageBoxTypeList
 	const opPath = "/storage_box_types?%s"
 	ctx = ctxutil.SetOpPath(ctx, opPath)
 
-	reqPath := fmt.Sprintf(opPath, opts.values().Encode())
+	reqPath := fmt.Sprintf(opPath, opts.Values().Encode())
 
 	respBody, resp, err := getRequest[schema.StorageBoxTypeListResponse](ctx, c.client, reqPath)
 	if err != nil {

--- a/hcloud/volume.go
+++ b/hcloud/volume.go
@@ -99,7 +99,7 @@ type VolumeListOpts struct {
 	Sort   []string
 }
 
-func (l VolumeListOpts) values() url.Values {
+func (l VolumeListOpts) Values() url.Values {
 	vals := l.ListOpts.Values()
 	if l.Name != "" {
 		vals.Add("name", l.Name)
@@ -121,7 +121,7 @@ func (c *VolumeClient) List(ctx context.Context, opts VolumeListOpts) ([]*Volume
 	const opPath = "/volumes?%s"
 	ctx = ctxutil.SetOpPath(ctx, opPath)
 
-	reqPath := fmt.Sprintf(opPath, opts.values().Encode())
+	reqPath := fmt.Sprintf(opPath, opts.Values().Encode())
 
 	respBody, resp, err := getRequest[schema.VolumeListResponse](ctx, c.client, reqPath)
 	if err != nil {

--- a/hcloud/zone.go
+++ b/hcloud/zone.go
@@ -166,7 +166,7 @@ type ZoneListOpts struct {
 	Sort []string
 }
 
-func (l ZoneListOpts) values() url.Values {
+func (l ZoneListOpts) Values() url.Values {
 	result := l.ListOpts.Values()
 	if l.Name != "" {
 		result.Add("name", l.Name)
@@ -187,7 +187,7 @@ func (c *ZoneClient) List(ctx context.Context, opts ZoneListOpts) ([]*Zone, *Res
 	const opPath = "/zones?%s"
 	ctx = ctxutil.SetOpPath(ctx, opPath)
 
-	reqPath := fmt.Sprintf(opPath, opts.values().Encode())
+	reqPath := fmt.Sprintf(opPath, opts.Values().Encode())
 
 	respBody, resp, err := getRequest[schema.ZoneListResponse](ctx, c.client, reqPath)
 	if err != nil {

--- a/hcloud/zone_rrset.go
+++ b/hcloud/zone_rrset.go
@@ -123,7 +123,7 @@ type ZoneRRSetListOpts struct {
 	Sort []string
 }
 
-func (l ZoneRRSetListOpts) values() url.Values {
+func (l ZoneRRSetListOpts) Values() url.Values {
 	result := l.ListOpts.Values()
 	if l.Name != "" {
 		result.Add("name", l.Name)
@@ -149,7 +149,7 @@ func (c *ZoneClient) ListRRSets(ctx context.Context, zone *Zone, opts ZoneRRSetL
 		return nil, nil, invalidArgument("zone", zone, err)
 	}
 
-	reqPath := fmt.Sprintf(opPath, zoneIDOrName, opts.values().Encode())
+	reqPath := fmt.Sprintf(opPath, zoneIDOrName, opts.Values().Encode())
 
 	respBody, resp, err := getRequest[schema.ZoneRRSetListResponse](ctx, c.client, reqPath)
 	if err != nil {


### PR DESCRIPTION
When reporting errors to the users, being able to present the values being send to the API to the users would simplify troubleshooting their setup.

For example in terraform, when returning a diagnostic because a list of resource is empty or must only have a single item, having the query parameters in the diagnostic would help them troubleshoot the problem.

Having access to the url.Values makes it easier to present those query parameters to the users.

An alternative is to read from the structs properties directly, but this would duplicate some of the code already in this `Values()` method, while working on `url.Values` directly is easier.

The base ListOpts struct already has an exported `Values()` method.