### PR TITLE
feat(metadata): add user agent header

### DIFF
--- a/.github/workflows/releaser-pleaser.yml
+++ b/.github/workflows/releaser-pleaser.yml
@@ -24,4 +24,4 @@ jobs:
         uses: apricote/releaser-pleaser@93a3e2c401320206dcd9a9b7a5bbc0850072b3c6 # v0.9.0
         with:
           extra-files: |
-            hcloud/hcloud.go
+            hcloud/internal/version/version.go

--- a/hcloud/client.go
+++ b/hcloud/client.go
@@ -18,6 +18,8 @@ import (
 	"golang.org/x/net/http/httpguts"
 
 	"github.com/hetznercloud/hcloud-go/v2/hcloud/internal/instrumentation"
+	"github.com/hetznercloud/hcloud-go/v2/hcloud/internal/util"
+	"github.com/hetznercloud/hcloud-go/v2/hcloud/internal/version"
 )
 
 // Endpoint is the base URL of the Cloud API.
@@ -28,7 +30,7 @@ const HetznerEndpoint = "https://api.hetzner.com/v1"
 
 // UserAgent is the value for the library part of the User-Agent header
 // that is sent with each request.
-const UserAgent = "hcloud-go/" + Version
+const UserAgent = "hcloud-go/" + version.Version
 
 // A BackoffFunc returns the duration to wait before performing the
 // next retry. The retries argument specifies how many retries have
@@ -94,8 +96,6 @@ type Client struct {
 	retryMaxRetries         int
 	pollBackoffFunc         BackoffFunc
 	httpClient              *http.Client
-	applicationName         string
-	applicationVersion      string
 	userAgent               string
 	debugWriter             io.Writer
 	instrumentationRegistry prometheus.Registerer
@@ -241,8 +241,7 @@ func WithRetryOpts(opts RetryOpts) ClientOption {
 // to at least set an application name.
 func WithApplication(name, version string) ClientOption {
 	return func(client *Client) {
-		client.applicationName = name
-		client.applicationVersion = version
+		client.userAgent = util.BuildUserAgent(name, version, UserAgent)
 	}
 }
 
@@ -271,6 +270,7 @@ func WithInstrumentation(registry prometheus.Registerer) ClientOption {
 // NewClient creates a new client.
 func NewClient(options ...ClientOption) *Client {
 	client := &Client{
+		userAgent:       UserAgent,
 		endpoint:        Endpoint,
 		hetznerEndpoint: HetznerEndpoint,
 		tokenValid:      true,
@@ -291,7 +291,6 @@ func NewClient(options ...ClientOption) *Client {
 		option(client)
 	}
 
-	client.buildUserAgent()
 	if client.instrumentationRegistry != nil {
 		i := instrumentation.New("api", client.instrumentationRegistry)
 		client.httpClient.Transport = i.InstrumentedRoundTripper(client.httpClient.Transport)
@@ -364,17 +363,6 @@ func (c *Client) NewRequest(ctx context.Context, method, path string, body io.Re
 // a struct to json.Unmarshal the response to.
 func (c *Client) Do(req *http.Request, v any) (*Response, error) {
 	return c.handler.Do(req, v)
-}
-
-func (c *Client) buildUserAgent() {
-	switch {
-	case c.applicationName != "" && c.applicationVersion != "":
-		c.userAgent = c.applicationName + "/" + c.applicationVersion + " " + UserAgent
-	case c.applicationName != "" && c.applicationVersion == "":
-		c.userAgent = c.applicationName + " " + UserAgent
-	default:
-		c.userAgent = UserAgent
-	}
 }
 
 const (

--- a/hcloud/client_test.go
+++ b/hcloud/client_test.go
@@ -301,28 +301,6 @@ func TestClientDoPost(t *testing.T) {
 	}
 }
 
-func TestBuildUserAgent(t *testing.T) {
-	testCases := []struct {
-		name               string
-		applicationName    string
-		applicationVersion string
-		userAgent          string
-	}{
-		{"with application name and version", "test", "1.0", "test/1.0 " + UserAgent},
-		{"with application name but no version", "test", "", "test " + UserAgent},
-		{"without application name and version", "", "", UserAgent},
-	}
-
-	for _, testCase := range testCases {
-		t.Run(testCase.name, func(t *testing.T) {
-			client := NewClient(WithApplication(testCase.applicationName, testCase.applicationVersion))
-			if client.userAgent != testCase.userAgent {
-				t.Errorf("unexpected user agent: %v", client.userAgent)
-			}
-		})
-	}
-}
-
 func TestExponentialBackoff(t *testing.T) {
 	t.Run("without jitter", func(t *testing.T) {
 		backoffFunc := ExponentialBackoffWithOpts(ExponentialBackoffOpts{

--- a/hcloud/hcloud.go
+++ b/hcloud/hcloud.go
@@ -80,5 +80,7 @@ breaking changes.
 */
 package hcloud
 
+import "github.com/hetznercloud/hcloud-go/v2/hcloud/internal/version"
+
 // Version is the library's version following Semantic Versioning.
-const Version = "2.46.0" // x-releaser-pleaser-version
+const Version = version.Version

--- a/hcloud/internal/util/user_agent.go
+++ b/hcloud/internal/util/user_agent.go
@@ -1,0 +1,12 @@
+package util
+
+func BuildUserAgent(name, version, userAgent string) string {
+	switch {
+	case name != "" && version != "":
+		return name + "/" + version + " " + userAgent
+	case name != "" && version == "":
+		return name + " " + userAgent
+	default:
+		return userAgent
+	}
+}

--- a/hcloud/internal/util/user_agent_test.go
+++ b/hcloud/internal/util/user_agent_test.go
@@ -1,0 +1,27 @@
+package util
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildUserAgent(t *testing.T) {
+	testCases := []struct {
+		desc    string
+		name    string
+		version string
+		want    string
+	}{
+		{"with application name and version", "test", "1.0", "test/1.0 hcloud-go/1.42.0"},
+		{"with application name but no version", "test", "", "test hcloud-go/1.42.0"},
+		{"without application name and version", "", "", "hcloud-go/1.42.0"},
+	}
+
+	for _, tt := range testCases {
+		t.Run(tt.desc, func(t *testing.T) {
+			got := BuildUserAgent(tt.name, tt.version, "hcloud-go/1.42.0")
+			require.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/hcloud/internal/version/version.go
+++ b/hcloud/internal/version/version.go
@@ -1,0 +1,4 @@
+package version
+
+// Version is the library's version following Semantic Versioning.
+const Version = "2.46.0" // x-releaser-pleaser-version

--- a/hcloud/metadata/client.go
+++ b/hcloud/metadata/client.go
@@ -15,12 +15,18 @@ import (
 
 	"github.com/hetznercloud/hcloud-go/v2/hcloud/exp/ctxutil"
 	"github.com/hetznercloud/hcloud-go/v2/hcloud/internal/instrumentation"
+	"github.com/hetznercloud/hcloud-go/v2/hcloud/internal/util"
+	"github.com/hetznercloud/hcloud-go/v2/hcloud/internal/version"
 )
 
 const Endpoint = "http://169.254.169.254/hetzner/v1/metadata"
 
+const UserAgent = "hcloud-go/" + version.Version
+
 // Client is a client for the Hetzner Cloud Server Metadata Endpoints.
 type Client struct {
+	userAgent string
+
 	endpoint string
 	timeout  time.Duration
 
@@ -59,9 +65,19 @@ func WithTimeout(timeout time.Duration) ClientOption {
 	}
 }
 
+// WithApplication configures a Client with the given application name and
+// application version. The version may be blank. Programs are encouraged
+// to at least set an application name.
+func WithApplication(name, version string) ClientOption {
+	return func(client *Client) {
+		client.userAgent = util.BuildUserAgent(name, version, UserAgent)
+	}
+}
+
 // NewClient creates a new [Client] with the options applied.
 func NewClient(options ...ClientOption) *Client {
 	client := &Client{
+		userAgent:  UserAgent,
 		endpoint:   Endpoint,
 		httpClient: &http.Client{},
 		timeout:    5 * time.Second,
@@ -88,6 +104,8 @@ func (c *Client) get(ctx context.Context, path string) (string, error) {
 	if err != nil {
 		return "", err
 	}
+
+	req.Header.Set("User-Agent", c.userAgent)
 
 	resp, err := c.httpClient.Do(req)
 	if err != nil {


### PR DESCRIPTION
- Move version to dedicated internal package, to break a cyclic import.
- Add a user agent header to the metadata client.
- Extract user agent utility to an internal package.