### PR TITLE
feat: deprecate datacenters resource

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -69,6 +69,9 @@ linters:
         text: "unused-parameter: parameter '(w|r)' seems to be unused, consider removing or renaming it as _"
       - linters:
           - staticcheck
+        text: "\\[Datacenter\\] is deprecated"
+      - linters:
+          - staticcheck
         text: schema\.DatacenterServerTypes is deprecated
       - # TODO: can be removed once https://github.com/leighmcculloch/gocheckcompilerdirectives/pull/6 is merged
         linters:

--- a/hcloud/client.go
+++ b/hcloud/client.go
@@ -103,7 +103,6 @@ type Client struct {
 
 	Action           ActionClient
 	Certificate      CertificateClient
-	Datacenter       DatacenterClient
 	Firewall         FirewallClient
 	FloatingIP       FloatingIPClient
 	Image            ImageClient
@@ -123,6 +122,10 @@ type Client struct {
 	PrimaryIP        PrimaryIPClient
 	StorageBoxType   StorageBoxTypeClient
 	Zone             ZoneClient
+
+	// Deprecated: [DatacenterClient] is deprecated and will be removed after the 2026-10-01. See
+	// https://docs.hetzner.cloud/changelog#2026-06-02-datacenters-deprecated.
+	Datacenter DatacenterClient
 }
 
 // A ClientOption is used to configure a Client.

--- a/hcloud/datacenter.go
+++ b/hcloud/datacenter.go
@@ -11,6 +11,9 @@ import (
 )
 
 // Datacenter represents a datacenter in the Hetzner Cloud.
+//
+// Deprecated: [Datacenter] is deprecated and will be removed after the 2026-10-01. See
+// https://docs.hetzner.cloud/changelog#2026-06-02-datacenters-deprecated.
 type Datacenter struct {
 	ID          int64
 	Name        string
@@ -33,11 +36,17 @@ type DatacenterServerTypes struct {
 }
 
 // DatacenterClient is a client for the datacenter API.
+//
+// Deprecated: [DatacenterClient] is deprecated and will be removed after the 2026-10-01. See
+// https://docs.hetzner.cloud/changelog#2026-06-02-datacenters-deprecated.
 type DatacenterClient struct {
 	client *Client
 }
 
 // GetByID retrieves a datacenter by its ID. If the datacenter does not exist, nil is returned.
+//
+// Deprecated: [DatacenterClient.GetByID] is deprecated and will be removed after the 2026-10-01. See
+// https://docs.hetzner.cloud/changelog#2026-06-02-datacenters-deprecated.
 func (c *DatacenterClient) GetByID(ctx context.Context, id int64) (*Datacenter, *Response, error) {
 	const opPath = "/datacenters/%d"
 	ctx = ctxutil.SetOpPath(ctx, opPath)
@@ -56,6 +65,9 @@ func (c *DatacenterClient) GetByID(ctx context.Context, id int64) (*Datacenter, 
 }
 
 // GetByName retrieves a datacenter by its name. If the datacenter does not exist, nil is returned.
+//
+// Deprecated: [DatacenterClient.GetByName] is deprecated and will be removed after the 2026-10-01. See
+// https://docs.hetzner.cloud/changelog#2026-06-02-datacenters-deprecated.
 func (c *DatacenterClient) GetByName(ctx context.Context, name string) (*Datacenter, *Response, error) {
 	return firstByName(name, func() ([]*Datacenter, *Response, error) {
 		return c.List(ctx, DatacenterListOpts{Name: name})
@@ -64,6 +76,9 @@ func (c *DatacenterClient) GetByName(ctx context.Context, name string) (*Datacen
 
 // Get retrieves a datacenter by its ID if the input can be parsed as an integer, otherwise it
 // retrieves a datacenter by its name. If the datacenter does not exist, nil is returned.
+//
+// Deprecated: [DatacenterClient.Get] is deprecated and will be removed after the 2026-10-01. See
+// https://docs.hetzner.cloud/changelog#2026-06-02-datacenters-deprecated.
 func (c *DatacenterClient) Get(ctx context.Context, idOrName string) (*Datacenter, *Response, error) {
 	if id, err := strconv.ParseInt(idOrName, 10, 64); err == nil {
 		return c.GetByID(ctx, id)
@@ -72,6 +87,9 @@ func (c *DatacenterClient) Get(ctx context.Context, idOrName string) (*Datacente
 }
 
 // DatacenterListOpts specifies options for listing datacenters.
+//
+// Deprecated: [DatacenterListOpts] is deprecated and will be removed after the 2026-10-01. See
+// https://docs.hetzner.cloud/changelog#2026-06-02-datacenters-deprecated.
 type DatacenterListOpts struct {
 	ListOpts
 	Name string
@@ -93,6 +111,9 @@ func (l DatacenterListOpts) Values() url.Values {
 //
 // Please note that filters specified in opts are not taken into account
 // when their value corresponds to their zero value or when they are empty.
+//
+// Deprecated: [DatacenterClient.List] is deprecated and will be removed after the 2026-10-01. See
+// https://docs.hetzner.cloud/changelog#2026-06-02-datacenters-deprecated.
 func (c *DatacenterClient) List(ctx context.Context, opts DatacenterListOpts) ([]*Datacenter, *Response, error) {
 	const opPath = "/datacenters?%s"
 	ctx = ctxutil.SetOpPath(ctx, opPath)
@@ -108,11 +129,17 @@ func (c *DatacenterClient) List(ctx context.Context, opts DatacenterListOpts) ([
 }
 
 // All returns all datacenters.
+//
+// Deprecated: [DatacenterClient.All] is deprecated and will be removed after the 2026-10-01. See
+// https://docs.hetzner.cloud/changelog#2026-06-02-datacenters-deprecated.
 func (c *DatacenterClient) All(ctx context.Context) ([]*Datacenter, error) {
 	return c.AllWithOpts(ctx, DatacenterListOpts{})
 }
 
 // AllWithOpts returns all datacenters for the given options.
+//
+// Deprecated: [DatacenterClient.AllWithOpts] is deprecated and will be removed after the 2026-10-01. See
+// https://docs.hetzner.cloud/changelog#2026-06-02-datacenters-deprecated.
 func (c *DatacenterClient) AllWithOpts(ctx context.Context, opts DatacenterListOpts) ([]*Datacenter, error) {
 	if opts.ListOpts.PerPage == 0 {
 		opts.ListOpts.PerPage = 50

--- a/hcloud/schema/datacenter.go
+++ b/hcloud/schema/datacenter.go
@@ -1,6 +1,9 @@
 package schema
 
 // Datacenter defines the schema of a datacenter.
+//
+// Deprecated: [Datacenter] is deprecated and will be removed after the 2026-10-01. See
+// https://docs.hetzner.cloud/changelog#2026-06-02-datacenters-deprecated.
 type Datacenter struct {
 	ID          int64    `json:"id"`
 	Name        string   `json:"name"`
@@ -23,11 +26,17 @@ type DatacenterServerTypes struct {
 }
 
 // DatacenterGetResponse defines the schema of the response when retrieving a single datacenter.
+//
+// Deprecated: [Datacenter] is deprecated and will be removed after the 2026-10-01. See
+// https://docs.hetzner.cloud/changelog#2026-06-02-datacenters-deprecated.
 type DatacenterGetResponse struct {
 	Datacenter Datacenter `json:"datacenter"`
 }
 
 // DatacenterListResponse defines the schema of the response when listing datacenters.
+//
+// Deprecated: [Datacenter] is deprecated and will be removed after the 2026-10-01. See
+// https://docs.hetzner.cloud/changelog#2026-06-02-datacenters-deprecated.
 type DatacenterListResponse struct {
 	Datacenters []Datacenter `json:"datacenters"`
 }

--- a/hcloud/zz_datacenter_client_iface.go
+++ b/hcloud/zz_datacenter_client_iface.go
@@ -9,19 +9,37 @@ import (
 // IDatacenterClient ...
 type IDatacenterClient interface {
 	// GetByID retrieves a datacenter by its ID. If the datacenter does not exist, nil is returned.
+	//
+	// Deprecated: [DatacenterClient.GetByID] is deprecated and will be removed after the 2026-10-01. See
+	// https://docs.hetzner.cloud/changelog#2026-06-02-datacenters-deprecated.
 	GetByID(ctx context.Context, id int64) (*Datacenter, *Response, error)
 	// GetByName retrieves a datacenter by its name. If the datacenter does not exist, nil is returned.
+	//
+	// Deprecated: [DatacenterClient.GetByName] is deprecated and will be removed after the 2026-10-01. See
+	// https://docs.hetzner.cloud/changelog#2026-06-02-datacenters-deprecated.
 	GetByName(ctx context.Context, name string) (*Datacenter, *Response, error)
 	// Get retrieves a datacenter by its ID if the input can be parsed as an integer, otherwise it
 	// retrieves a datacenter by its name. If the datacenter does not exist, nil is returned.
+	//
+	// Deprecated: [DatacenterClient.Get] is deprecated and will be removed after the 2026-10-01. See
+	// https://docs.hetzner.cloud/changelog#2026-06-02-datacenters-deprecated.
 	Get(ctx context.Context, idOrName string) (*Datacenter, *Response, error)
 	// List returns a list of datacenters for a specific page.
 	//
 	// Please note that filters specified in opts are not taken into account
 	// when their value corresponds to their zero value or when they are empty.
+	//
+	// Deprecated: [DatacenterClient.List] is deprecated and will be removed after the 2026-10-01. See
+	// https://docs.hetzner.cloud/changelog#2026-06-02-datacenters-deprecated.
 	List(ctx context.Context, opts DatacenterListOpts) ([]*Datacenter, *Response, error)
 	// All returns all datacenters.
+	//
+	// Deprecated: [DatacenterClient.All] is deprecated and will be removed after the 2026-10-01. See
+	// https://docs.hetzner.cloud/changelog#2026-06-02-datacenters-deprecated.
 	All(ctx context.Context) ([]*Datacenter, error)
 	// AllWithOpts returns all datacenters for the given options.
+	//
+	// Deprecated: [DatacenterClient.AllWithOpts] is deprecated and will be removed after the 2026-10-01. See
+	// https://docs.hetzner.cloud/changelog#2026-06-02-datacenters-deprecated.
 	AllWithOpts(ctx context.Context, opts DatacenterListOpts) ([]*Datacenter, error)
 }


### PR DESCRIPTION
The API endpoints `GET /v1/datacenters` and `GET /v1/datacenters/{id}` are now deprecated and will be removed after 1 Oct. 2026. After this date, requests to these endpoints will return `HTTP 410 Gone`.

See https://docs.hetzner.cloud/changelog#2026-06-02-datacenters-deprecated.