### PR TITLE
chore: fix shell path in generate.sh shebang

### DIFF
--- a/hcloud/generate.sh
+++ b/hcloud/generate.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/sh
+#!/usr/bin/env sh
 
 set -eu
 


### PR DESCRIPTION
Some environment do not have `sh` at `/usr/bin/sh`.