### PR TITLE
feat: retry requests on api `bad_gateway` error

### DIFF
--- a/hcloud/client_handler_retry.go
+++ b/hcloud/client_handler_retry.go
@@ -66,6 +66,8 @@ func retryPolicy(resp *Response, err error) bool {
 				return true
 			case ErrorCodeRateLimitExceeded:
 				return true
+			case ErrorCodeBadGateway:
+				return true
 			case ErrorCodeTimeout:
 				return true
 			}

--- a/hcloud/client_handler_retry_test.go
+++ b/hcloud/client_handler_retry_test.go
@@ -121,6 +121,11 @@ func TestRetryPolicy(t *testing.T) {
 			want: true,
 		},
 		{
+			name: "api returns bad_gateway error",
+			resp: fakeResponse(t, 502, `{"error":{"code":"bad_gateway"}}`, true),
+			want: true,
+		},
+		{
 			name: "api returns unavailable error",
 			resp: fakeResponse(t, 503, `{"error":{"code":"unavailable"}}`, true),
 			want: false,

--- a/hcloud/error.go
+++ b/hcloud/error.go
@@ -33,6 +33,7 @@ const (
 	ErrorCodeResourceLocked        ErrorCode = "resource_locked"         // The resource is locked. The caller should contact support
 	ErrorCodeServerError           ErrorCode = "server_error"            // Error within the API backend
 	ErrorCodeTokenReadonly         ErrorCode = "token_readonly"          // The token is only allowed to perform GET requests
+	ErrorCodeBadGateway            ErrorCode = "bad_gateway"             // The request could not be answered by the API backend, please retry
 	ErrorCodeTimeout               ErrorCode = "timeout"                 // The request could not be answered in time, please retry
 	ErrorUnsupportedError          ErrorCode = "unsupported_error"       // The given resource does not support this
 	ErrorDeprecatedAPIEndpoint     ErrorCode = "deprecated_api_endpoint" // The request can not be answered because the API functionality was removed

--- a/hcloud/hcloud.go
+++ b/hcloud/hcloud.go
@@ -72,6 +72,7 @@ When the API returned an HTTP error, with the status code:
 When the API returned an application error, with the code:
   - [ErrorCodeConflict]
   - [ErrorCodeRateLimitExceeded]
+  - [ErrorCodeBadGateway]
   - [ErrorCodeTimeout]
 
 Changes to the retry policy might occur between releases, and will not be considered


### PR DESCRIPTION
If the API returns an error code `bad_gateway`, retry the failed request.