### PR TITLE
feat: remove datacenter property from server and primary_ip

### DIFF
--- a/hcloud/primary_ip.go
+++ b/hcloud/primary_ip.go
@@ -28,11 +28,6 @@ type PrimaryIP struct {
 	Blocked      bool
 	Created      time.Time
 	Location     *Location
-
-	// Deprecated: [PrimaryIP.Datacenter] is deprecated and will be removed after 1 July 2026.
-	// Use [PrimaryIP.Location] instead.
-	// See https://docs.hetzner.cloud/changelog#2025-12-16-phasing-out-datacenters
-	Datacenter *Datacenter
 }
 
 func (o *PrimaryIP) pathID() (string, error) {
@@ -105,11 +100,6 @@ type PrimaryIPCreateOpts struct {
 	Labels       map[string]string
 	Name         string
 	Type         PrimaryIPType
-
-	// Deprecated: [PrimaryIPCreateOpts.Datacenter] is deprecated and will be removed after 1 July 2026.
-	// Use [PrimaryIPCreateOpts.Location] instead.
-	// See https://docs.hetzner.cloud/changelog#2025-12-16-phasing-out-datacenters
-	Datacenter string
 }
 
 // PrimaryIPCreateResult defines the response

--- a/hcloud/schema/primary_ip.go
+++ b/hcloud/schema/primary_ip.go
@@ -17,11 +17,6 @@ type PrimaryIP struct {
 	Blocked      bool                `json:"blocked"`
 	Created      time.Time           `json:"created"`
 	Location     Location            `json:"location"`
-
-	// Deprecated: [PrimaryIP.Datacenter] is deprecated and will be removed after 1 July 2026.
-	// Use [PrimaryIP.Location] instead.
-	// See https://docs.hetzner.cloud/changelog#2025-12-16-phasing-out-datacenters
-	Datacenter *Datacenter `json:"datacenter"`
 }
 
 // PrimaryIPProtection represents the protection level of a Primary IP.
@@ -45,11 +40,6 @@ type PrimaryIPCreateRequest struct {
 	Labels       *map[string]string `json:"labels,omitempty"`
 	AutoDelete   *bool              `json:"auto_delete,omitempty"`
 	Location     string             `json:"location,omitempty"`
-
-	// Deprecated: [PrimaryIPCreateRequest.Datacenter] is deprecated and will be removed after 1 July 2026.
-	// Use [PrimaryIPCreateRequest.Location] instead.
-	// See https://docs.hetzner.cloud/changelog#2025-12-16-phasing-out-datacenters
-	Datacenter string `json:"datacenter,omitempty"`
 }
 
 // PrimaryIPCreateResponse defines the schema of the response

--- a/hcloud/schema/server.go
+++ b/hcloud/schema/server.go
@@ -26,11 +26,6 @@ type Server struct {
 	PrimaryDiskSize int                `json:"primary_disk_size"`
 	PlacementGroup  *PlacementGroup    `json:"placement_group"`
 	LoadBalancers   []int64            `json:"load_balancers"`
-
-	// Deprecated: [Server.Datacenter] is deprecated and will be removed after 1 July 2026.
-	// Use [Server.Location] instead.
-	// See https://docs.hetzner.cloud/changelog#2025-12-16-phasing-out-datacenters
-	Datacenter *Datacenter `json:"datacenter"`
 }
 
 // ServerProtection defines the schema of a server's resource protection.
@@ -117,11 +112,6 @@ type ServerCreateRequest struct {
 	Firewalls        []ServerCreateFirewalls `json:"firewalls,omitempty"`
 	PlacementGroup   int64                   `json:"placement_group,omitempty"`
 	PublicNet        *ServerCreatePublicNet  `json:"public_net,omitempty"`
-
-	// Deprecated: [ServerCreateRequest.Datacenter] is deprecated and will be removed after 1 July 2026.
-	// Use [ServerCreateRequest.Location] instead.
-	// See https://docs.hetzner.cloud/changelog#2025-12-16-phasing-out-datacenters
-	Datacenter string `json:"datacenter,omitempty"`
 }
 
 // ServerCreatePublicNet defines the public network configuration of a server.

--- a/hcloud/server.go
+++ b/hcloud/server.go
@@ -37,11 +37,6 @@ type Server struct {
 	PrimaryDiskSize int
 	PlacementGroup  *PlacementGroup
 	LoadBalancers   []*LoadBalancer
-
-	// Deprecated: [Server.Datacenter] is deprecated and will be removed after 1 July 2026.
-	// Use [Server.Location] instead.
-	// See https://docs.hetzner.cloud/changelog#2025-12-16-phasing-out-datacenters
-	Datacenter *Datacenter
 }
 
 func (o *Server) pathID() (string, error) {
@@ -316,11 +311,6 @@ type ServerCreateOpts struct {
 	Firewalls        []*ServerCreateFirewall
 	PlacementGroup   *PlacementGroup
 	PublicNet        *ServerCreatePublicNet
-
-	// Deprecated: [ServerCreateOpts.Datacenter] is deprecated and will be removed after 1 July 2026.
-	// Use [ServerCreateOpts.Location] instead.
-	// See https://docs.hetzner.cloud/changelog#2025-12-16-phasing-out-datacenters
-	Datacenter *Datacenter
 }
 
 type ServerCreatePublicNet struct {
@@ -345,9 +335,6 @@ func (o ServerCreateOpts) Validate() error {
 	}
 	if o.Image == nil || (o.Image.ID == 0 && o.Image.Name == "") {
 		return missingField(o, "Image")
-	}
-	if o.Location != nil && o.Datacenter != nil {
-		return mutuallyExclusiveFields(o, "Location", "Datacenter")
 	}
 	return nil
 }
@@ -419,13 +406,6 @@ func (c *ServerClient) Create(ctx context.Context, opts ServerCreateOpts) (Serve
 			reqBody.Location = strconv.FormatInt(opts.Location.ID, 10)
 		} else {
 			reqBody.Location = opts.Location.Name
-		}
-	}
-	if opts.Datacenter != nil {
-		if opts.Datacenter.ID != 0 {
-			reqBody.Datacenter = strconv.FormatInt(opts.Datacenter.ID, 10) // nolint:staticcheck // Deprecated
-		} else {
-			reqBody.Datacenter = opts.Datacenter.Name // nolint:staticcheck // Deprecated
 		}
 	}
 	if opts.PlacementGroup != nil {

--- a/hcloud/server_test.go
+++ b/hcloud/server_test.go
@@ -125,38 +125,6 @@ func TestServerClientGetByID(t *testing.T) {
         }
       ]
     },
-    "datacenter": {
-      "id": 3,
-      "description": "Helsinki 1 virtual DC 2",
-      "location": {
-        "id": 3,
-        "name": "hel1",
-        "description": "Helsinki DC Park 1",
-        "city": "Helsinki",
-        "country": "FI",
-        "latitude": 60.169855,
-        "longitude": 24.938379,
-        "network_zone": "eu-central"
-      },
-      "name": "hel1-dc2",
-      "server_types": {
-        "available": [
-          22, 23, 24, 25, 27, 28, 29, 30, 31, 32, 45, 93, 94, 95, 96, 97, 98,
-          99, 100, 101, 102, 104, 105, 108, 109, 110, 111, 112, 113, 114, 115,
-          116, 117
-        ],
-        "available_for_migration": [
-          22, 23, 24, 25, 27, 28, 29, 30, 31, 32, 45, 93, 94, 95, 96, 97, 98,
-          99, 100, 101, 102, 104, 105, 108, 109, 110, 111, 112, 113, 114, 115,
-          116, 117
-        ],
-        "supported": [
-          1, 3, 5, 7, 9, 11, 12, 13, 14, 15, 22, 23, 24, 25, 26, 27, 28, 29, 30,
-          31, 33, 34, 35, 36, 37, 38, 45, 93, 94, 95, 96, 97, 98, 99, 100, 101,
-          104, 105, 106, 107, 109, 110, 111, 112, 113, 114, 115, 116, 117
-        ]
-      }
-    },
     "location": {
       "id": 3,
       "name": "hel1",
@@ -237,8 +205,6 @@ func TestServerClientGetByID(t *testing.T) {
 	assert.Equal(t, ServerStatusRunning, result.Status)
 	assert.Equal(t, int64(104), result.ServerType.ID)
 	assert.Equal(t, "cx22", result.ServerType.Name)
-	assert.Equal(t, int64(3), result.Datacenter.ID)
-	assert.Equal(t, "hel1-dc2", result.Datacenter.Name)
 	assert.Equal(t, int64(3), result.Location.ID)
 	assert.Equal(t, "hel1", result.Location.Name)
 	assert.Equal(t, int64(310554929), result.Image.ID)
@@ -867,74 +833,6 @@ func TestServersCreateWithDefaultPublicNet(t *testing.T) {
 	}
 	if len(result.NextActions) != 1 || result.NextActions[0].ID != 2 {
 		t.Errorf("unexpected next actions: %v", result.NextActions)
-	}
-}
-
-func TestServersCreateWithDatacenterID(t *testing.T) {
-	env := newTestEnv()
-	defer env.Teardown()
-
-	env.Mux.HandleFunc("/servers", func(w http.ResponseWriter, r *http.Request) {
-		var reqBody schema.ServerCreateRequest
-		if err := json.NewDecoder(r.Body).Decode(&reqBody); err != nil {
-			t.Fatal(err)
-		}
-		if reqBody.Datacenter != "1" { // nolint:staticcheck // Deprecated
-			t.Errorf("unexpected datacenter: %v", reqBody.Datacenter) // nolint:staticcheck // Deprecated
-		}
-		json.NewEncoder(w).Encode(schema.ServerCreateResponse{
-			Server: schema.Server{
-				ID: 1,
-			},
-		})
-	})
-
-	ctx := context.Background()
-	result, _, err := env.Client.Server.Create(ctx, ServerCreateOpts{
-		Name:       "test",
-		ServerType: &ServerType{ID: 1},
-		Image:      &Image{ID: 2},
-		Datacenter: &Datacenter{ID: 1},
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if result.Server == nil {
-		t.Fatal("no server")
-	}
-}
-
-func TestServersCreateWithDatacenterName(t *testing.T) {
-	env := newTestEnv()
-	defer env.Teardown()
-
-	env.Mux.HandleFunc("/servers", func(w http.ResponseWriter, r *http.Request) {
-		var reqBody schema.ServerCreateRequest
-		if err := json.NewDecoder(r.Body).Decode(&reqBody); err != nil {
-			t.Fatal(err)
-		}
-		if reqBody.Datacenter != "dc1" { // nolint:staticcheck // Deprecated
-			t.Errorf("unexpected datacenter: %v", reqBody.Datacenter) // nolint:staticcheck // Deprecated
-		}
-		json.NewEncoder(w).Encode(schema.ServerCreateResponse{
-			Server: schema.Server{
-				ID: 1,
-			},
-		})
-	})
-
-	ctx := context.Background()
-	result, _, err := env.Client.Server.Create(ctx, ServerCreateOpts{
-		Name:       "test",
-		ServerType: &ServerType{ID: 1},
-		Image:      &Image{ID: 2},
-		Datacenter: &Datacenter{Name: "dc1"},
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if result.Server == nil {
-		t.Fatal("no server")
 	}
 }
 

--- a/hcloud/zz_schema_converter.go
+++ b/hcloud/zz_schema_converter.go
@@ -443,7 +443,6 @@ func (c *converterImpl) PrimaryIPFromSchema(source schema.PrimaryIP) *PrimaryIP 
 	hcloudPrimaryIP.Blocked = source.Blocked
 	hcloudPrimaryIP.Created = c.timeTimeToTimeTime(source.Created)
 	hcloudPrimaryIP.Location = c.LocationFromSchema(source.Location)
-	hcloudPrimaryIP.Datacenter = c.pSchemaDatacenterToPHcloudDatacenter(source.Datacenter)
 	return &hcloudPrimaryIP
 }
 func (c *converterImpl) SSHKeyFromSchema(source schema.SSHKey) *SSHKey {
@@ -958,7 +957,6 @@ func (c *converterImpl) SchemaFromPrimaryIP(source *PrimaryIP) schema.PrimaryIP 
 		schemaPrimaryIP.Blocked = (*source).Blocked
 		schemaPrimaryIP.Created = c.timeTimeToTimeTime((*source).Created)
 		schemaPrimaryIP.Location = c.SchemaFromLocation((*source).Location)
-		schemaPrimaryIP.Datacenter = c.pHcloudDatacenterToPSchemaDatacenter((*source).Datacenter)
 	}
 	return schemaPrimaryIP
 }
@@ -989,7 +987,6 @@ func (c *converterImpl) SchemaFromPrimaryIPCreateOpts(source PrimaryIPCreateOpts
 	schemaPrimaryIPCreateRequest.Labels = stringMapToStringMapPtr(source.Labels)
 	schemaPrimaryIPCreateRequest.AutoDelete = source.AutoDelete
 	schemaPrimaryIPCreateRequest.Location = source.Location
-	schemaPrimaryIPCreateRequest.Datacenter = source.Datacenter
 	return schemaPrimaryIPCreateRequest
 }
 func (c *converterImpl) SchemaFromPrimaryIPUpdateOpts(source PrimaryIPUpdateOpts) schema.PrimaryIPUpdateRequest {
@@ -1051,7 +1048,6 @@ func (c *converterImpl) SchemaFromServer(source *Server) schema.Server {
 				schemaServer.LoadBalancers[k] = c.pHcloudLoadBalancerToInt64((*source).LoadBalancers[k])
 			}
 		}
-		schemaServer.Datacenter = c.pHcloudDatacenterToPSchemaDatacenter((*source).Datacenter)
 	}
 	return schemaServer
 }
@@ -1535,7 +1531,6 @@ func (c *converterImpl) ServerFromSchema(source schema.Server) *Server {
 			hcloudServer.LoadBalancers[k] = &hcloudLoadBalancer
 		}
 	}
-	hcloudServer.Datacenter = c.pSchemaDatacenterToPHcloudDatacenter(source.Datacenter)
 	return &hcloudServer
 }
 func (c *converterImpl) ServerMetricsFromSchema(source *schema.ServerGetMetricsResponse) (*ServerMetrics, error) {
@@ -2114,19 +2109,6 @@ func (c *converterImpl) pHcloudCertificateStatusToPSchemaCertificateStatusRef(so
 	}
 	return pSchemaCertificateStatusRef
 }
-func (c *converterImpl) pHcloudDatacenterToPSchemaDatacenter(source *Datacenter) *schema.Datacenter {
-	var pSchemaDatacenter *schema.Datacenter
-	if source != nil {
-		var schemaDatacenter schema.Datacenter
-		schemaDatacenter.ID = (*source).ID
-		schemaDatacenter.Name = (*source).Name
-		schemaDatacenter.Description = (*source).Description
-		schemaDatacenter.Location = c.SchemaFromLocation((*source).Location)
-		schemaDatacenter.ServerTypes = schemaPtrFromDatacenterServerTypes((*source).ServerTypes)
-		pSchemaDatacenter = &schemaDatacenter
-	}
-	return pSchemaDatacenter
-}
 func (c *converterImpl) pHcloudErrorToPSchemaError(source *Error) *schema.Error {
 	var pSchemaError *schema.Error
 	if source != nil {
@@ -2587,19 +2569,6 @@ func (c *converterImpl) pSchemaDatacenterServerTypesToHcloudDatacenterServerType
 		}
 	}
 	return hcloudDatacenterServerTypes
-}
-func (c *converterImpl) pSchemaDatacenterToPHcloudDatacenter(source *schema.Datacenter) *Datacenter {
-	var pHcloudDatacenter *Datacenter
-	if source != nil {
-		var hcloudDatacenter Datacenter
-		hcloudDatacenter.ID = (*source).ID
-		hcloudDatacenter.Name = (*source).Name
-		hcloudDatacenter.Description = (*source).Description
-		hcloudDatacenter.Location = c.LocationFromSchema((*source).Location)
-		hcloudDatacenter.ServerTypes = c.pSchemaDatacenterServerTypesToHcloudDatacenterServerTypes((*source).ServerTypes)
-		pHcloudDatacenter = &hcloudDatacenter
-	}
-	return pHcloudDatacenter
 }
 func (c *converterImpl) pSchemaErrorToPHcloudError(source *schema.Error) *Error {
 	var pHcloudError *Error


### PR DESCRIPTION
Remove the `datacenter` property from Server and Primary IP resource where possible. The property was deprecated ~6 months ago, and because the property is removed from the API, removing it from our code is not considered a breaking change.

Changelog entry: https://docs.hetzner.cloud/changelog#2026-07-01-removing-datacenters

Assisted-by: Claude Opus 4.8