### PR TITLE
feat: add deprecation info to load balancer type

### DIFF
--- a/hcloud/deprecation.go
+++ b/hcloud/deprecation.go
@@ -57,3 +57,4 @@ func (o DeprecatableResource) DeprecationAnnounced() time.Time {
 
 // Make sure that all expected Resources actually implement the interface.
 var _ Deprecatable = ServerType{}
+var _ Deprecatable = LoadBalancerType{}

--- a/hcloud/load_balancer_type.go
+++ b/hcloud/load_balancer_type.go
@@ -20,7 +20,11 @@ type LoadBalancerType struct {
 	MaxTargets              int
 	MaxAssignedCertificates int
 	Pricings                []LoadBalancerTypeLocationPricing
-	Deprecated              *string
+
+	DeprecatableResource
+
+	// Deprecated: [LoadBalancerType.Deprecated] is deprecated, use [LoadBalancerType.Deprecation] instead.
+	Deprecated *string
 }
 
 // LoadBalancerTypeClient is a client for the Load Balancer types API.

--- a/hcloud/load_balancer_type_test.go
+++ b/hcloud/load_balancer_type_test.go
@@ -5,36 +5,90 @@ import (
 	"encoding/json"
 	"net/http"
 	"testing"
+	"time"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/hetznercloud/hcloud-go/v2/hcloud/exp/mockutil"
 	"github.com/hetznercloud/hcloud-go/v2/hcloud/schema"
 )
 
 func TestLoadBalancerTypeClient(t *testing.T) {
 	t.Run("GetByID", func(t *testing.T) {
-		env := newTestEnv()
-		defer env.Teardown()
+		ctx, server, client := makeTestUtils(t)
 
-		env.Mux.HandleFunc("/load_balancer_types/1", func(w http.ResponseWriter, r *http.Request) {
-			json.NewEncoder(w).Encode(schema.LoadBalancerTypeGetResponse{
-				LoadBalancerType: schema.LoadBalancerType{
-					ID: 1,
-				},
-			})
+		server.Expect([]mockutil.Request{
+			{
+				Method: "GET", Path: "/load_balancer_types/42",
+				Status: 200,
+				JSONRaw: `
+				{
+					"load_balancer_type": {
+						"id": 42,
+						"name": "lb11",
+						"description": "LB11",
+						"max_connections": 20000,
+						"max_services": 5,
+						"max_targets": 25,
+						"max_assigned_certificates": 10,
+						"deprecation": {
+							"unavailable_after": "2023-09-01T00:00:00Z",
+							"announced": "2023-06-01T00:00:00Z"
+						},
+						"prices": [
+							{
+								"location": "fsn1",
+								"price_hourly": {
+									"net": "1.0000",
+									"gross": "1.1900"
+								},
+								"price_monthly": {
+									"net": "1.0000",
+									"gross": "1.1900"
+								},
+								"included_traffic": 654321,
+								"price_per_tb_traffic": {
+									"net": "1.0000",
+									"gross": "1.1900"
+								}
+							}
+						]
+					}
+				}`,
+			},
 		})
 
-		ctx := context.Background()
-		loadBalancerType, _, err := env.Client.LoadBalancerType.GetByID(ctx, 1)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if loadBalancerType == nil {
-			t.Fatal("no load balancer type")
-		}
-		if loadBalancerType.ID != 1 {
-			t.Errorf("unexpected load balancer type ID: %v", loadBalancerType.ID)
-		}
+		result, _, err := client.LoadBalancerType.GetByID(ctx, 42)
+		require.NoError(t, err)
+		require.NotNil(t, result)
+		assert.Equal(t, int64(42), result.ID)
+		assert.Equal(t, "lb11", result.Name)
+		assert.Equal(t, "LB11", result.Description)
+		assert.Equal(t, 20000, result.MaxConnections)
+		assert.Equal(t, 5, result.MaxServices)
+		assert.Equal(t, 25, result.MaxTargets)
+		assert.Equal(t, 10, result.MaxAssignedCertificates)
+		assert.NotNil(t, result.Deprecation)
+		assert.Equal(t, "2023-06-01T00:00:00Z", result.Deprecation.Announced.Format(time.RFC3339))
+		assert.Equal(t, "2023-09-01T00:00:00Z", result.Deprecation.UnavailableAfter.Format(time.RFC3339))
+		assert.NotNil(t, result.Deprecated)
+		assert.Equal(t, "2023-06-01T00:00:00Z", *result.Deprecated)
 
 		t.Run("via Get", func(t *testing.T) {
+			env := newTestEnv()
+			defer env.Teardown()
+
+			env.Mux.HandleFunc("/load_balancer_types/1", func(w http.ResponseWriter, r *http.Request) {
+				json.NewEncoder(w).Encode(schema.LoadBalancerTypeGetResponse{
+					LoadBalancerType: schema.LoadBalancerType{
+						ID: 1,
+					},
+				})
+			})
+
+			ctx := context.Background()
+
 			loadBalancerType, _, err := env.Client.LoadBalancerType.Get(ctx, "1")
 			if err != nil {
 				t.Fatal(err)

--- a/hcloud/schema/load_balancer_type.go
+++ b/hcloud/schema/load_balancer_type.go
@@ -10,7 +10,11 @@ type LoadBalancerType struct {
 	MaxTargets              int                            `json:"max_targets"`
 	MaxAssignedCertificates int                            `json:"max_assigned_certificates"`
 	Prices                  []PricingLoadBalancerTypePrice `json:"prices"`
-	Deprecated              *string                        `json:"deprecated"`
+
+	DeprecatableResource
+
+	// Deprecated: [LoadBalancerType.Deprecated] is deprecated, use [LoadBalancerType.Deprecation] instead.
+	Deprecated *string `json:"deprecated"`
 }
 
 // LoadBalancerTypeListResponse defines the schema of the response when

--- a/hcloud/schema_gen.go
+++ b/hcloud/schema_gen.go
@@ -83,6 +83,7 @@ You can find a documentation of goverter here: https://goverter.jmattheis.de/
 // goverter:extend stringSlicePtrFromStringSlice
 // goverter:extend locationFromServerTypeLocationSchema
 // goverter:extend schemaPtrFromDatacenterServerTypes
+// goverter:extend deprecatedStrFromDeprecationSchema
 type converter interface {
 
 	// goverter:map Error.Code ErrorCode
@@ -218,6 +219,7 @@ type converter interface {
 	SchemaFromLoadBalancer(*LoadBalancer) schema.LoadBalancer
 
 	// goverter:map Prices Pricings
+	// goverter:map DeprecatableResource.Deprecation Deprecated | deprecatedStrFromDeprecationSchema
 	LoadBalancerTypeFromSchema(schema.LoadBalancerType) *LoadBalancerType
 
 	// goverter:map Pricings Prices
@@ -1062,6 +1064,14 @@ func mapZeroFloat32ToNil(f float32) *float32 {
 
 func isDeprecationNotNil(d *DeprecationInfo) bool {
 	return d != nil
+}
+
+func deprecatedStrFromDeprecationSchema(d *schema.DeprecationInfo) *string {
+	if d != nil {
+		value := d.Announced.Format(time.RFC3339)
+		return &value
+	}
+	return nil
 }
 
 // int64SlicePtrFromCertificatePtrSlice is needed so that a nil slice is mapped to nil instead of &nil.

--- a/hcloud/schema_test.go
+++ b/hcloud/schema_test.go
@@ -883,7 +883,11 @@ func TestLoadBalancerTypeSchema(t *testing.T) {
 		"max_services": 3,
 		"max_targets": 25,
 		"max_assigned_certificates": 10,
-		"deprecated": "2016-01-30T23:50:00+00:00",
+		"deprecation": {
+			"unavailable_after": "2016-04-30T23:50:00Z",
+			"announced": "2016-01-30T23:50:00Z"
+		},
+		"deprecated": "2016-01-30T23:50:00Z",
 		"prices": [
 			{
 				"location": "fsn1",

--- a/hcloud/zz_schema_converter.go
+++ b/hcloud/zz_schema_converter.go
@@ -304,7 +304,8 @@ func (c *converterImpl) LoadBalancerTypeFromSchema(source schema.LoadBalancerTyp
 			hcloudLoadBalancerType.Pricings[i] = c.LoadBalancerTypeLocationPricingFromSchema(source.Prices[i])
 		}
 	}
-	hcloudLoadBalancerType.Deprecated = source.Deprecated
+	hcloudLoadBalancerType.DeprecatableResource = c.schemaDeprecatableResourceToHcloudDeprecatableResource(source.DeprecatableResource)
+	hcloudLoadBalancerType.Deprecated = deprecatedStrFromDeprecationSchema(source.DeprecatableResource.Deprecation)
 	return &hcloudLoadBalancerType
 }
 func (c *converterImpl) LoadBalancerTypeLocationPricingFromSchema(source schema.PricingLoadBalancerTypePrice) LoadBalancerTypeLocationPricing {
@@ -789,6 +790,7 @@ func (c *converterImpl) SchemaFromLoadBalancerType(source *LoadBalancerType) sch
 				schemaLoadBalancerType.Prices[i] = c.SchemaFromLoadBalancerTypeLocationPricing((*source).Pricings[i])
 			}
 		}
+		schemaLoadBalancerType.DeprecatableResource = c.hcloudDeprecatableResourceToSchemaDeprecatableResource((*source).DeprecatableResource)
 		schemaLoadBalancerType.Deprecated = (*source).Deprecated
 	}
 	return schemaLoadBalancerType


### PR DESCRIPTION
- https://docs.hetzner.cloud/changelog#2026-06-05-deprecation-info-for-load-balancer-types

Add the `Deprecation` object property to the [hcloud.LoadBalancerType](https://pkg.go.dev/github.com/hetznercloud/hcloud-go/v2/hcloud#LoadBalancerType) struct.

- https://docs.hetzner.cloud/changelog#2026-06-05-field-deprecated-on-load-balancer-types-is-now-deprecated

Deprecate the `Deprecated` property in the  [hcloud.LoadBalancerType](https://pkg.go.dev/github.com/hetznercloud/hcloud-go/v2/hcloud#LoadBalancerType) struct, use the `Deprecation` object property instead.