### PR TITLE
ci: add govulncheck job

### DIFF
--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -1,0 +1,27 @@
+---
+name: govulncheck
+
+on:
+  pull_request:
+    paths:
+      - .github/workflows/govulncheck.yml
+      - hcloud/internal/version/version.go
+  push:
+    branches:
+      - main
+  schedule:
+    - cron: "33 11 * * *"
+
+permissions:
+  contents: read
+
+jobs:
+  govulncheck:
+    runs-on: ubuntu-latest
+
+    name: Run govulncheck
+
+    steps:
+      - uses: golang/govulncheck-action@032d45514ae346b1db93c04b0c90b841c370344f # v1.1.0
+        with:
+          go-version-file: go.mod


### PR DESCRIPTION
Run govulncheck against hcloud-go on schedule, before releasing a new version, or when updating the job definition.